### PR TITLE
feat(auth): add admin session controls and public/private repository for user register and sign in

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -141,12 +141,13 @@ except Exception as e:
 # =============================================================================
 # AUTHENTICATION SETUP
 # =============================================================================
-if os.environ.get('DEPLOYMENT_ENV') == 'marvin':
-    from backend.marvin_auth import init_marvin_auth, get_current_user_info
-    init_marvin_auth(app)
-else:
-    from backend.replit_auth import init_auth, get_current_user_info
-    init_auth(app)
+from backend.marvin_auth import (
+    init_marvin_auth,
+    get_current_user_info,
+    update_user_orcid,
+    unlink_user_orcid,
+)
+init_marvin_auth(app)
 
 # =============================================================================
 # CORE PROCESSING COMPONENTS
@@ -589,7 +590,14 @@ def page_not_found(e):
 def get_auth_user():
     """Get current logged-in user info"""
     user_info = get_current_user_info()
-    return jsonify({'user': user_info})
+    auth_type = 'password'
+    self_registration_enabled = os.environ.get('DISABLE_SELF_REGISTER', 'false').lower() not in ('true', '1', 'yes')
+    return jsonify({
+        'user': user_info,
+        'auth_enabled': True,
+        'auth_type': auth_type,
+        'self_registration_enabled': self_registration_enabled,
+    })
 
 @api_route('/auth/saved-searches')
 def get_saved_searches():
@@ -682,7 +690,6 @@ def link_orcid():
     orcid_pattern = re.compile(r'^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$')
     if not orcid_pattern.match(orcid):
         return jsonify({'error': 'Invalid ORCID format. Expected: 0000-0000-0000-0000'}), 400
-    from backend.replit_auth import update_user_orcid
     if update_user_orcid(current_user.id, orcid, orcid_name):
         return jsonify({'success': True, 'user': get_current_user_info()})
     return jsonify({'error': 'Failed to update ORCID'}), 500
@@ -692,7 +699,6 @@ def unlink_orcid():
     """Remove ORCID from user account"""
     if not current_user.is_authenticated:
         return jsonify({'error': 'Not logged in'}), 401
-    from backend.replit_auth import unlink_user_orcid
     if unlink_user_orcid(current_user.id):
         return jsonify({'success': True, 'user': get_current_user_info()})
     return jsonify({'error': 'Failed to unlink ORCID'}), 500

--- a/backend/blueprints/admin.py
+++ b/backend/blueprints/admin.py
@@ -10,10 +10,11 @@ import json
 import time
 import threading
 from collections import defaultdict
+from sqlalchemy import text
 
 from backend.db_utils import get_db_cursor
 from werkzeug.security import check_password_hash, generate_password_hash
-from backend.models import User, db
+from backend.models import User, OAuth, SavedSearch, SavedIntertext, Intertext, db
 from backend.logging_config import get_logger
 from backend.utils import get_text_metadata, get_override, set_override, safe_listdir
 from backend.lemma_cache import (
@@ -472,31 +473,37 @@ def get_users():
 
 
 @admin_bp.route('/users', methods=['POST'])
-def create_admin_user():
-    """Create an admin user (SUPER_ADMIN only)."""
+def create_user():
+    """Create a user account (admin only; admin-role assignment needs SUPER_ADMIN)."""
     if not check_admin_auth():
+        logger.warning("Create user denied: unauthorized session")
         return jsonify({'error': 'Unauthorized'}), 401
 
     admin_roles = [_normalize_role_name(r) for r in (session.get('admin_roles') or [])]
-    if 'SUPER_ADMIN' not in admin_roles:
-        return jsonify({'error': 'SUPER_ADMIN required'}), 403
 
     data = request.get_json() or {}
     email = (data.get('email') or '').strip().lower()
     password = data.get('password') or ''
     first_name = (data.get('first_name') or '').strip()
     last_name = (data.get('last_name') or '').strip()
-    role_name = (data.get('role') or 'ADMIN').strip().upper()
+    role_name = (data.get('role') or 'USER').strip().upper()
 
-    if role_name not in ('ADMIN', 'SUPER_ADMIN'):
+    if role_name not in ('USER', 'ADMIN', 'SUPER_ADMIN'):
+        logger.warning(f"Create user rejected: invalid role={role_name} by={get_admin_username()}")
         return jsonify({'error': 'Invalid role'}), 400
+    if role_name in ('ADMIN', 'SUPER_ADMIN') and 'SUPER_ADMIN' not in admin_roles:
+        logger.warning(f"Create user denied: insufficient privileges for role={role_name} by={get_admin_username()}")
+        return jsonify({'error': 'SUPER_ADMIN required'}), 403
     if not email or not password or not first_name or not last_name:
+        logger.warning(f"Create user rejected: missing required fields by={get_admin_username()} email={email or 'unknown'}")
         return jsonify({'error': 'Email, password, first name, and last name are required'}), 400
     if len(password) < 8:
+        logger.warning(f"Create user rejected: weak password by={get_admin_username()} email={email}")
         return jsonify({'error': 'Password must be at least 8 characters'}), 400
 
     existing = User.query.filter(User.email.ilike(email)).first()
     if existing:
+        logger.info(f"Create user duplicate blocked by={get_admin_username()} email={email}")
         return jsonify({'error': 'User already exists'}), 400
 
     user = User()
@@ -507,35 +514,90 @@ def create_admin_user():
     user.last_name = last_name
     user.must_reset_password = True
 
-    db.session.add(user)
-    db.session.commit()
-
     role_id = _get_role_id(role_name)
     if not role_id:
+        logger.error(f"Create user failed: role id not found role={role_name} by={get_admin_username()}")
         return jsonify({'error': 'Role not found'}), 404
 
     try:
-        with get_db_cursor() as cur:
-            cur.execute(
+        db.session.add(user)
+        db.session.flush()
+        db.session.execute(
+            text(
                 """
                 INSERT INTO user_roles (user_id, role_id, assigned_at, assigned_by)
-                VALUES (%s, %s, NOW(), %s)
+                VALUES (:user_id, :role_id, NOW(), :assigned_by)
                 ON CONFLICT (user_id, role_id) DO NOTHING
-                """,
-                (user.id, role_id, get_admin_username()),
-            )
+                """
+            ),
+            {
+                'user_id': user.id,
+                'role_id': role_id,
+                'assigned_by': get_admin_username(),
+            },
+        )
+        db.session.commit()
+        logger.info(f"User created by={get_admin_username()} user_id={user.id} email={user.email} role={role_name}")
         log_admin_action('admin_user_created', 'user', user.id, {'role': role_name})
     except Exception as e:
+        db.session.rollback()
         logger.error(f"Failed to assign role: {e}")
         return jsonify({'error': 'Failed to assign role'}), 500
 
     return jsonify({'success': True, 'user_id': user.id, 'role': role_name})
 
 
+@admin_bp.route('/users/<user_id>', methods=['DELETE'])
+def delete_user(user_id):
+    """Delete a user account (admin only)."""
+    if not check_admin_auth():
+        logger.warning(f"Delete user denied: unauthorized session target_user={user_id}")
+        return jsonify({'error': 'Unauthorized'}), 401
+
+    current_admin_user_id = session.get('admin_user_id')
+    if current_admin_user_id and str(current_admin_user_id) == str(user_id):
+        logger.warning(f"Delete user blocked: self-delete attempt by={get_admin_username()} user_id={user_id}")
+        return jsonify({'error': 'Cannot delete the currently logged-in admin account'}), 400
+
+    user = User.query.get(user_id)
+    if not user:
+        logger.info(f"Delete user: target not found by={get_admin_username()} user_id={user_id}")
+        return jsonify({'error': 'User not found'}), 404
+
+    target_roles = _get_user_roles(user_id)
+    if 'SUPER_ADMIN' in target_roles and _count_super_admins() <= 2:
+        logger.warning(f"Delete user blocked: last SUPER_ADMIN protection by={get_admin_username()} user_id={user_id}")
+        return jsonify({'error': 'Cannot delete one of the last two SUPER_ADMIN accounts'}), 400
+
+    try:
+        # Preserve public repository rows by removing user linkage before delete.
+        Intertext.query.filter_by(submitter_id=user_id).update(
+            {'submitter_id': None},
+            synchronize_session=False,
+        )
+        SavedIntertext.query.filter_by(user_id=user_id).delete(synchronize_session=False)
+        SavedSearch.query.filter_by(user_id=user_id).delete(synchronize_session=False)
+        OAuth.query.filter_by(user_id=user_id).delete(synchronize_session=False)
+        db.session.execute(
+            text("DELETE FROM user_roles WHERE user_id = :user_id"),
+            {'user_id': user_id},
+        )
+        db.session.delete(user)
+        db.session.commit()
+        logger.info(f"User deleted by={get_admin_username()} user_id={user_id} email={user.email} roles={target_roles}")
+        log_admin_action('user_deleted', 'user', user_id, {'email': user.email, 'roles': target_roles})
+        return jsonify({'success': True, 'message': 'User deleted'})
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f"Failed to delete user {user_id}: {e}")
+        return jsonify({'error': 'Failed to delete user'}), 500
+
+
 @admin_bp.route('/users/<user_id>/roles', methods=['POST'])
 def update_user_roles(user_id):
     """Assign or remove a role for a user (admin only)."""
     if not check_admin_auth():
+        logger.warning(f"Role update denied: unauthorized session target_user={user_id}")
         return jsonify({'error': 'Unauthorized'}), 401
 
     data = request.get_json() or {}
@@ -543,13 +605,23 @@ def update_user_roles(user_id):
     action = (data.get('action') or '').strip().lower()
 
     if role_name not in ('USER', 'ADMIN', 'SUPER_ADMIN'):
+        logger.warning(f"Role update rejected: invalid role={role_name} by={get_admin_username()} target_user={user_id}")
         return jsonify({'error': 'Invalid role'}), 400
     if action not in ('add', 'remove'):
+        logger.warning(f"Role update rejected: invalid action={action} by={get_admin_username()} target_user={user_id}")
         return jsonify({'error': 'Invalid action'}), 400
 
     admin_roles = [_normalize_role_name(r) for r in (session.get('admin_roles') or [])]
     if role_name in ('ADMIN', 'SUPER_ADMIN') and 'SUPER_ADMIN' not in admin_roles:
+        logger.warning(f"Role update denied: insufficient privileges by={get_admin_username()} role={role_name} target_user={user_id}")
         return jsonify({'error': 'SUPER_ADMIN required'}), 403
+
+    target_roles = _get_user_roles(user_id)
+    effective_target_roles = target_roles if target_roles else ['USER']
+    target_is_user_only = len(effective_target_roles) == 1 and effective_target_roles[0] == 'USER'
+    if target_is_user_only and role_name in ('ADMIN', 'SUPER_ADMIN'):
+        logger.warning(f"Role update blocked: USER-only protection by={get_admin_username()} role={role_name} target_user={user_id}")
+        return jsonify({'error': 'USER accounts cannot be promoted or demoted to admin roles via this page'}), 403
 
     role_id = _get_role_id(role_name)
     if not role_id:

--- a/backend/blueprints/intertext.py
+++ b/backend/blueprints/intertext.py
@@ -17,6 +17,151 @@ logger = get_logger(__name__)
 intertext_bp = Blueprint('intertext', __name__, url_prefix='/intertexts')
 
 
+def _parse_json_list(raw_value):
+    if not raw_value:
+        return []
+    try:
+        return json.loads(raw_value)
+    except (TypeError, ValueError):
+        return []
+
+
+def _serialize_public_intertext(it):
+    return {
+        'id': it.id,
+        'source': {
+            'text_id': it.source_text_id,
+            'author': it.source_author,
+            'work': it.source_work,
+            'reference': it.source_reference,
+            'snippet': it.source_snippet,
+            'language': it.source_language
+        },
+        'target': {
+            'text_id': it.target_text_id,
+            'author': it.target_author,
+            'work': it.target_work,
+            'reference': it.target_reference,
+            'snippet': it.target_snippet,
+            'language': it.target_language
+        },
+        'matched_lemmas': _parse_json_list(it.matched_lemmas),
+        'matched_tokens': _parse_json_list(it.matched_tokens),
+        'tesserae_score': it.tesserae_score,
+        'user_score': it.user_score,
+        'submitter_id': it.submitter_id,
+        'submitter': {
+            'name': it.submitter_name or '',
+            'email': it.submitter_email or '',
+            'institution': it.submitter_institution or '',
+            'orcid': it.submitter_orcid or ''
+        },
+        'notes': it.notes,
+        'tags': _parse_json_list(it.tags),
+        'status': it.status,
+        'created_at': it.created_at.isoformat() if it.created_at else None
+    }
+
+
+def _serialize_saved_intertext(it):
+    return {
+        'id': it.id,
+        'source': {
+            'text_id': it.source_text_id,
+            'author': it.source_author,
+            'work': it.source_work,
+            'reference': it.source_reference,
+            'snippet': it.source_snippet,
+            'language': it.source_language
+        },
+        'target': {
+            'text_id': it.target_text_id,
+            'author': it.target_author,
+            'work': it.target_work,
+            'reference': it.target_reference,
+            'snippet': it.target_snippet,
+            'language': it.target_language
+        },
+        'matched_lemmas': _parse_json_list(it.matched_lemmas),
+        'matched_tokens': _parse_json_list(it.matched_tokens),
+        'tesserae_score': it.tesserae_score,
+        'intertext_score': it.intertext_score,
+        'notes': it.notes,
+        'tags': _parse_json_list(it.tags),
+        'shared_to_public': it.shared_to_public,
+        'public_intertext_id': it.public_intertext_id,
+        'created_at': it.created_at.isoformat() if it.created_at else None
+    }
+
+
+def _build_public_intertext(source, target, data, submitter):
+    user_name = f"{submitter.first_name or ''} {submitter.last_name or ''}".strip() or submitter.email
+    return Intertext(
+        source_text_id=source.get('text_id', ''),
+        source_author=source.get('author', ''),
+        source_work=source.get('work', ''),
+        source_reference=source.get('reference', ''),
+        source_snippet=source.get('snippet', ''),
+        source_language=source.get('language', 'la'),
+        target_text_id=target.get('text_id', ''),
+        target_author=target.get('author', ''),
+        target_work=target.get('work', ''),
+        target_reference=target.get('reference', ''),
+        target_snippet=target.get('snippet', ''),
+        target_language=target.get('language', 'la'),
+        matched_lemmas=json.dumps(data.get('matched_lemmas', [])),
+        matched_tokens=json.dumps(data.get('matched_tokens', [])),
+        tesserae_score=data.get('tesserae_score', 0.0),
+        user_score=data.get('intertext_score', data.get('user_score', 0)),
+        submitter_id=submitter.id,
+        submitter_name=user_name,
+        submitter_email=submitter.email or '',
+        submitter_institution=submitter.institution or '',
+        submitter_orcid=submitter.orcid or '',
+        notes=data.get('notes', ''),
+        tags=json.dumps(data.get('tags', [])),
+        status='pending',
+        created_at=datetime.now()
+    )
+
+
+def _sync_public_intertext(public_it, saved_it, submitter):
+    """Keep an existing public intertext aligned with the saved copy."""
+    user_name = f"{submitter.first_name or ''} {submitter.last_name or ''}".strip() or submitter.email
+    public_it.source_text_id = saved_it.source_text_id
+    public_it.source_author = saved_it.source_author
+    public_it.source_work = saved_it.source_work
+    public_it.source_reference = saved_it.source_reference
+    public_it.source_snippet = saved_it.source_snippet
+    public_it.source_language = saved_it.source_language
+    public_it.target_text_id = saved_it.target_text_id
+    public_it.target_author = saved_it.target_author
+    public_it.target_work = saved_it.target_work
+    public_it.target_reference = saved_it.target_reference
+    public_it.target_snippet = saved_it.target_snippet
+    public_it.target_language = saved_it.target_language
+    public_it.matched_lemmas = saved_it.matched_lemmas
+    public_it.matched_tokens = saved_it.matched_tokens
+    public_it.tesserae_score = saved_it.tesserae_score
+    public_it.user_score = saved_it.intertext_score
+    public_it.submitter_id = submitter.id
+    public_it.submitter_name = user_name
+    public_it.submitter_email = submitter.email or ''
+    public_it.submitter_institution = submitter.institution or ''
+    public_it.submitter_orcid = submitter.orcid or ''
+    public_it.notes = saved_it.notes
+    public_it.tags = saved_it.tags
+
+
+def _delete_public_copy(saved_it):
+    if not saved_it.public_intertext_id:
+        return
+    public_it = Intertext.query.get(saved_it.public_intertext_id)
+    if public_it:
+        db.session.delete(public_it)
+    saved_it.public_intertext_id = None
+
+
 @intertext_bp.route('', methods=['GET'])
 def list_intertexts():
     """List all intertexts with optional filtering"""
@@ -45,42 +190,7 @@ def list_intertexts():
         query = query.order_by(Intertext.created_at.desc())
         pagination = query.paginate(page=page, per_page=per_page, error_out=False)
         
-        intertexts = []
-        for it in pagination.items:
-            intertexts.append({
-                'id': it.id,
-                'source': {
-                    'text_id': it.source_text_id,
-                    'author': it.source_author,
-                    'work': it.source_work,
-                    'reference': it.source_reference,
-                    'snippet': it.source_snippet,
-                    'language': it.source_language
-                },
-                'target': {
-                    'text_id': it.target_text_id,
-                    'author': it.target_author,
-                    'work': it.target_work,
-                    'reference': it.target_reference,
-                    'snippet': it.target_snippet,
-                    'language': it.target_language
-                },
-                'matched_lemmas': json.loads(it.matched_lemmas) if it.matched_lemmas else [],
-                'matched_tokens': json.loads(it.matched_tokens) if it.matched_tokens else [],
-                'tesserae_score': it.tesserae_score,
-                'user_score': it.user_score,
-                'submitter_id': it.submitter_id,
-                'submitter': {
-                    'name': it.submitter_name or '',
-                    'email': it.submitter_email or '',
-                    'institution': it.submitter_institution or '',
-                    'orcid': it.submitter_orcid or ''
-                },
-                'notes': it.notes,
-                'tags': json.loads(it.tags) if it.tags else [],
-                'status': it.status,
-                'created_at': it.created_at.isoformat() if it.created_at else None
-            })
+        intertexts = [_serialize_public_intertext(it) for it in pagination.items]
         
         return jsonify({
             'intertexts': intertexts,
@@ -161,40 +271,7 @@ def get_intertext(intertext_id):
         if not it:
             return jsonify({'error': 'Intertext not found'}), 404
         
-        return jsonify({
-            'id': it.id,
-            'source': {
-                'text_id': it.source_text_id,
-                'author': it.source_author,
-                'work': it.source_work,
-                'reference': it.source_reference,
-                'snippet': it.source_snippet,
-                'language': it.source_language
-            },
-            'target': {
-                'text_id': it.target_text_id,
-                'author': it.target_author,
-                'work': it.target_work,
-                'reference': it.target_reference,
-                'snippet': it.target_snippet,
-                'language': it.target_language
-            },
-            'matched_lemmas': json.loads(it.matched_lemmas) if it.matched_lemmas else [],
-            'matched_tokens': json.loads(it.matched_tokens) if it.matched_tokens else [],
-            'tesserae_score': it.tesserae_score,
-            'user_score': it.user_score,
-            'submitter_id': it.submitter_id,
-            'submitter': {
-                'name': it.submitter_name or '',
-                'email': it.submitter_email or '',
-                'institution': it.submitter_institution or '',
-                'orcid': it.submitter_orcid or ''
-            },
-            'notes': it.notes,
-            'tags': json.loads(it.tags) if it.tags else [],
-            'status': it.status,
-            'created_at': it.created_at.isoformat() if it.created_at else None
-        })
+        return jsonify(_serialize_public_intertext(it))
     except Exception as e:
         logger.error(f"Failed to get intertext: {e}")
         return jsonify({'error': str(e)}), 500
@@ -274,7 +351,11 @@ def delete_intertext(intertext_id):
         
         if it.submitter_id != current_user.id:
             return jsonify({'error': 'Only the submitter can delete this intertext'}), 403
-        
+
+        for saved_copy in list(it.saved_copies):
+            saved_copy.shared_to_public = False
+            saved_copy.public_intertext_id = None
+
         db.session.delete(it)
         db.session.commit()
         return jsonify({'success': True})
@@ -400,36 +481,7 @@ def list_my_intertexts():
         query = query.order_by(SavedIntertext.created_at.desc())
         pagination = query.paginate(page=page, per_page=per_page, error_out=False)
         
-        intertexts = []
-        for it in pagination.items:
-            intertexts.append({
-                'id': it.id,
-                'source': {
-                    'text_id': it.source_text_id,
-                    'author': it.source_author,
-                    'work': it.source_work,
-                    'reference': it.source_reference,
-                    'snippet': it.source_snippet,
-                    'language': it.source_language
-                },
-                'target': {
-                    'text_id': it.target_text_id,
-                    'author': it.target_author,
-                    'work': it.target_work,
-                    'reference': it.target_reference,
-                    'snippet': it.target_snippet,
-                    'language': it.target_language
-                },
-                'matched_lemmas': json.loads(it.matched_lemmas) if it.matched_lemmas else [],
-                'matched_tokens': json.loads(it.matched_tokens) if it.matched_tokens else [],
-                'tesserae_score': it.tesserae_score,
-                'intertext_score': it.intertext_score,
-                'notes': it.notes,
-                'tags': json.loads(it.tags) if it.tags else [],
-                'shared_to_public': it.shared_to_public,
-                'public_intertext_id': it.public_intertext_id,
-                'created_at': it.created_at.isoformat() if it.created_at else None
-            })
+        intertexts = [_serialize_saved_intertext(it) for it in pagination.items]
         
         return jsonify({
             'intertexts': intertexts,
@@ -439,6 +491,85 @@ def list_my_intertexts():
         })
     except Exception as e:
         logger.error(f"Failed to list personal intertexts: {e}")
+        return jsonify({'error': str(e)}), 500
+
+
+@intertext_bp.route('/my/<int:saved_id>', methods=['PATCH'])
+def update_saved_intertext(saved_id):
+    """Update a saved intertext in the user's personal collection."""
+    try:
+        if not current_user.is_authenticated:
+            return jsonify({'error': 'Login required'}), 401
+
+        saved_it = SavedIntertext.query.get(saved_id)
+        if not saved_it:
+            return jsonify({'error': 'Saved intertext not found'}), 404
+        if saved_it.user_id != current_user.id:
+            return jsonify({'error': 'Not authorized'}), 403
+
+        data = request.get_json() or {}
+
+        if 'notes' in data:
+            saved_it.notes = (data.get('notes') or '').strip()[:500]
+        if 'tags' in data:
+            saved_it.tags = json.dumps(data.get('tags') or [])
+        if 'intertext_score' in data:
+            score = data.get('intertext_score')
+            if not isinstance(score, int) or score < 1 or score > 5:
+                return jsonify({'error': 'Valid intertext_score (1-5) required'}), 400
+            saved_it.intertext_score = score
+        if 'shared_to_public' in data:
+            should_share = bool(data.get('shared_to_public'))
+            if should_share and not saved_it.shared_to_public:
+                public_it = _build_public_intertext(
+                    {
+                        'text_id': saved_it.source_text_id,
+                        'author': saved_it.source_author,
+                        'work': saved_it.source_work,
+                        'reference': saved_it.source_reference,
+                        'snippet': saved_it.source_snippet,
+                        'language': saved_it.source_language,
+                    },
+                    {
+                        'text_id': saved_it.target_text_id,
+                        'author': saved_it.target_author,
+                        'work': saved_it.target_work,
+                        'reference': saved_it.target_reference,
+                        'snippet': saved_it.target_snippet,
+                        'language': saved_it.target_language,
+                    },
+                    {
+                        'matched_lemmas': _parse_json_list(saved_it.matched_lemmas),
+                        'matched_tokens': _parse_json_list(saved_it.matched_tokens),
+                        'tesserae_score': saved_it.tesserae_score,
+                        'intertext_score': saved_it.intertext_score,
+                        'notes': saved_it.notes or '',
+                        'tags': _parse_json_list(saved_it.tags),
+                    },
+                    current_user,
+                )
+                db.session.add(public_it)
+                db.session.flush()
+                saved_it.shared_to_public = True
+                saved_it.public_intertext_id = public_it.id
+            elif should_share and saved_it.shared_to_public and saved_it.public_intertext_id:
+                public_it = Intertext.query.get(saved_it.public_intertext_id)
+                if public_it:
+                    _sync_public_intertext(public_it, saved_it, current_user)
+            elif not should_share:
+                _delete_public_copy(saved_it)
+                saved_it.shared_to_public = False
+
+        if saved_it.shared_to_public and saved_it.public_intertext_id:
+            public_it = Intertext.query.get(saved_it.public_intertext_id)
+            if public_it:
+                _sync_public_intertext(public_it, saved_it, current_user)
+
+        db.session.commit()
+        return jsonify({'success': True, 'intertext': _serialize_saved_intertext(saved_it)})
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f"Failed to update saved intertext: {e}")
         return jsonify({'error': str(e)}), 500
 
 
@@ -455,14 +586,14 @@ def save_personal_intertext():
         
         source = data.get('source', {})
         target = data.get('target', {})
-        intertext_score = data.get('intertext_score')
+        intertext_score = data.get('intertext_score', 0)
         
         if not source.get('text_id') or not target.get('text_id'):
             return jsonify({'error': 'Source and target text_id required'}), 400
-        if intertext_score is None or intertext_score not in [1, 2, 3, 4, 5]:
+        if not isinstance(intertext_score, int) or intertext_score < 1 or intertext_score > 5:
             return jsonify({'error': 'Valid intertext_score (1-5) required'}), 400
-        
-        share_to_public = data.get('share_to_public', current_user.share_to_public_default)
+
+        share_to_public = bool(data.get('share_to_public', False))
         
         saved_it = SavedIntertext(
             user_id=current_user.id,
@@ -490,34 +621,7 @@ def save_personal_intertext():
         
         public_intertext_id = None
         if share_to_public:
-            user_name = f"{current_user.first_name or ''} {current_user.last_name or ''}".strip() or current_user.email
-            public_it = Intertext(
-                source_text_id=source.get('text_id', ''),
-                source_author=source.get('author', ''),
-                source_work=source.get('work', ''),
-                source_reference=source.get('reference', ''),
-                source_snippet=source.get('snippet', ''),
-                source_language=source.get('language', 'la'),
-                target_text_id=target.get('text_id', ''),
-                target_author=target.get('author', ''),
-                target_work=target.get('work', ''),
-                target_reference=target.get('reference', ''),
-                target_snippet=target.get('snippet', ''),
-                target_language=target.get('language', 'la'),
-                matched_lemmas=json.dumps(data.get('matched_lemmas', [])),
-                matched_tokens=json.dumps(data.get('matched_tokens', [])),
-                tesserae_score=data.get('tesserae_score', 0.0),
-                user_score=intertext_score,
-                submitter_id=current_user.id,
-                submitter_name=user_name,
-                submitter_email=current_user.email or '',
-                submitter_institution=current_user.institution or '',
-                submitter_orcid=current_user.orcid or '',
-                notes=data.get('notes', ''),
-                tags=json.dumps(data.get('tags', [])),
-                status='pending',
-                created_at=datetime.now()
-            )
+            public_it = _build_public_intertext(source, target, data, current_user)
             db.session.add(public_it)
             db.session.flush()
             public_intertext_id = public_it.id
@@ -555,33 +659,32 @@ def share_saved_intertext(saved_id):
         if saved_it.shared_to_public:
             return jsonify({'error': 'Already shared publicly'}), 400
         
-        user_name = f"{current_user.first_name or ''} {current_user.last_name or ''}".strip() or current_user.email
-        public_it = Intertext(
-            source_text_id=saved_it.source_text_id,
-            source_author=saved_it.source_author,
-            source_work=saved_it.source_work,
-            source_reference=saved_it.source_reference,
-            source_snippet=saved_it.source_snippet,
-            source_language=saved_it.source_language,
-            target_text_id=saved_it.target_text_id,
-            target_author=saved_it.target_author,
-            target_work=saved_it.target_work,
-            target_reference=saved_it.target_reference,
-            target_snippet=saved_it.target_snippet,
-            target_language=saved_it.target_language,
-            matched_lemmas=saved_it.matched_lemmas,
-            matched_tokens=saved_it.matched_tokens,
-            tesserae_score=saved_it.tesserae_score,
-            user_score=saved_it.intertext_score,
-            submitter_id=current_user.id,
-            submitter_name=user_name,
-            submitter_email=current_user.email or '',
-            submitter_institution=current_user.institution or '',
-            submitter_orcid=current_user.orcid or '',
-            notes=saved_it.notes,
-            tags=saved_it.tags,
-            status='pending',
-            created_at=datetime.now()
+        public_it = _build_public_intertext(
+            {
+                'text_id': saved_it.source_text_id,
+                'author': saved_it.source_author,
+                'work': saved_it.source_work,
+                'reference': saved_it.source_reference,
+                'snippet': saved_it.source_snippet,
+                'language': saved_it.source_language,
+            },
+            {
+                'text_id': saved_it.target_text_id,
+                'author': saved_it.target_author,
+                'work': saved_it.target_work,
+                'reference': saved_it.target_reference,
+                'snippet': saved_it.target_snippet,
+                'language': saved_it.target_language,
+            },
+            {
+                'matched_lemmas': _parse_json_list(saved_it.matched_lemmas),
+                'matched_tokens': _parse_json_list(saved_it.matched_tokens),
+                'tesserae_score': saved_it.tesserae_score,
+                'intertext_score': saved_it.intertext_score,
+                'notes': saved_it.notes or '',
+                'tags': _parse_json_list(saved_it.tags),
+            },
+            current_user,
         )
         db.session.add(public_it)
         db.session.flush()
@@ -615,7 +718,8 @@ def delete_saved_intertext(saved_id):
             return jsonify({'error': 'Saved intertext not found'}), 404
         if saved_it.user_id != current_user.id:
             return jsonify({'error': 'Not authorized'}), 403
-        
+
+        _delete_public_copy(saved_it)
         db.session.delete(saved_it)
         db.session.commit()
         

--- a/backend/marvin_auth.py
+++ b/backend/marvin_auth.py
@@ -3,6 +3,7 @@ Simple password-based authentication for Marvin deployment.
 Used when DEPLOYMENT_ENV=marvin (not on Replit).
 """
 import os
+import re
 import uuid
 from functools import wraps
 from werkzeug.security import generate_password_hash, check_password_hash
@@ -12,9 +13,31 @@ from flask_login import LoginManager, login_user, logout_user, current_user
 
 from backend.models import db, User
 from backend.db_utils import get_db_cursor
+from backend.logging_config import get_logger
 
 login_manager = None
 marvin_auth_bp = None
+logger = get_logger('marvin_auth')
+
+
+def _client_ip():
+    forwarded_for = (request.headers.get('X-Forwarded-For') or '').split(',')[0].strip()
+    return forwarded_for or request.remote_addr or 'unknown'
+
+
+def _validate_password_policy(password):
+    """Return an error message if password does not meet policy, else None."""
+    if len(password) < 8:
+        return 'Password must be at least 8 characters long'
+    if not re.search(r'[A-Z]', password):
+        return 'Password must include at least one uppercase letter'
+    if not re.search(r'[a-z]', password):
+        return 'Password must include at least one lowercase letter'
+    if not re.search(r'\d', password):
+        return 'Password must include at least one number'
+    if not re.search(r'[^A-Za-z0-9\s]', password):
+        return 'Password must include at least one special character'
+    return None
 
 
 def _load_user_roles(user_id):
@@ -34,12 +57,76 @@ def _load_user_roles(user_id):
         return []
 
 
+def _load_user_roles_by_email(email):
+    """Load roles by email via users->user_roles join (fallback for legacy id mismatches)."""
+    normalized_email = (email or '').strip().lower()
+    if not normalized_email:
+        return []
+    try:
+        with get_db_cursor(commit=False) as cur:
+            cur.execute(
+                """
+                SELECT r.name
+                FROM users u
+                JOIN user_roles ur ON ur.user_id = u.id
+                JOIN roles r ON r.id = ur.role_id
+                WHERE LOWER(COALESCE(u.email, '')) = %s
+                """,
+                (normalized_email,),
+            )
+            return [row[0] for row in cur.fetchall()]
+    except Exception:
+        return []
+
+
+def _is_admin_account(user_id, email=None):
+    """True if account has ADMIN or SUPER_ADMIN role."""
+    roles = [str(role).upper() for role in _load_user_roles(user_id)]
+    if email:
+        roles.extend(str(role).upper() for role in _load_user_roles_by_email(email))
+    return any(role in ('ADMIN', 'SUPER_ADMIN') for role in roles)
+
+
+def _ensure_user_role(role_name='USER'):
+    """Ensure role exists and return role_id."""
+    with get_db_cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO roles (name, description)
+            VALUES (%s, %s)
+            ON CONFLICT (name) DO NOTHING
+            """,
+            (role_name, 'Standard user' if role_name == 'USER' else role_name),
+        )
+        cur.execute("SELECT id FROM roles WHERE name = %s", (role_name,))
+        row = cur.fetchone()
+        return row[0] if row else None
+
+
+def _assign_role_to_user(user_id, role_name='USER', assigned_by='self_register'):
+    """Assign role to user if not already assigned."""
+    role_id = _ensure_user_role(role_name)
+    if not role_id:
+        raise RuntimeError(f"Role '{role_name}' not found")
+
+    with get_db_cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO user_roles (user_id, role_id, assigned_at, assigned_by)
+            VALUES (%s, %s, NOW(), %s)
+            ON CONFLICT (user_id, role_id) DO NOTHING
+            """,
+            (user_id, role_id, assigned_by),
+        )
+
+
 def init_marvin_auth(app):
     """Initialize password-based authentication for Marvin"""
     global login_manager, marvin_auth_bp
     
     login_manager = LoginManager(app)
-    login_manager.login_view = 'marvin_auth.login_page'
+    # Frontend handles login UI; keep API responses explicit instead of redirecting to a missing endpoint.
+    login_manager.login_view = None
     
     @login_manager.user_loader
     def load_user(user_id):
@@ -70,6 +157,7 @@ def create_marvin_auth_blueprint():
     def register():
         """Register a new user with email and password"""
         if os.environ.get('DISABLE_SELF_REGISTER', 'false').lower() in ('true', '1', 'yes'):
+            logger.warning(f"Registration blocked (disabled) from ip={_client_ip()}")
             return jsonify({'success': False, 'error': 'Self-registration is disabled'}), 403
         data = request.get_json() or {}
         email = data.get('email', '').strip().lower()
@@ -78,13 +166,17 @@ def create_marvin_auth_blueprint():
         last_name = data.get('last_name', '').strip()
         
         if not email or not password:
+            logger.warning(f"Registration rejected (missing credentials) email={email or 'unknown'} ip={_client_ip()}")
             return jsonify({'success': False, 'error': 'Email and password are required'}), 400
-        
-        if len(password) < 8:
-            return jsonify({'success': False, 'error': 'Password must be at least 8 characters'}), 400
+
+        password_error = _validate_password_policy(password)
+        if password_error:
+            logger.warning(f"Registration rejected (password policy) email={email} ip={_client_ip()}")
+            return jsonify({'success': False, 'error': password_error}), 400
         
         existing_user = User.query.filter_by(email=email).first()
         if existing_user:
+            logger.info(f"Registration duplicate email blocked email={email} ip={_client_ip()}")
             return jsonify({'success': False, 'error': 'An account with this email already exists'}), 400
         
         user = User()
@@ -96,8 +188,20 @@ def create_marvin_auth_blueprint():
         
         db.session.add(user)
         db.session.commit()
+
+        try:
+            _assign_role_to_user(user.id, 'USER', assigned_by='self_register')
+        except Exception as e:
+            logger.error(f"Failed to assign USER role during registration for {email}: {e}")
+            try:
+                db.session.delete(user)
+                db.session.commit()
+            except Exception as cleanup_err:
+                logger.error(f"Failed to rollback user creation after role assignment error: {cleanup_err}")
+            return jsonify({'success': False, 'error': 'Failed to finalize registration'}), 500
         
         login_user(user)
+        logger.info(f"User registered and logged in user_id={user.id} email={user.email} ip={_client_ip()}")
         
         return jsonify({
             'success': True,
@@ -121,17 +225,28 @@ def create_marvin_auth_blueprint():
         password = data.get('password', '')
         
         if not email or not password:
+            logger.warning(f"Login rejected (missing credentials) email={email or 'unknown'} ip={_client_ip()}")
             return jsonify({'success': False, 'error': 'Email and password are required'}), 400
         
         user = User.query.filter_by(email=email).first()
         
         if not user or not user.password_hash:
+            logger.warning(f"Login failed (user not found/no password) email={email} ip={_client_ip()}")
             return jsonify({'success': False, 'error': 'Invalid email or password'}), 401
         
         if not check_password_hash(user.password_hash, password):
+            logger.warning(f"Login failed (bad password) email={email} ip={_client_ip()}")
             return jsonify({'success': False, 'error': 'Invalid email or password'}), 401
+
+        if _is_admin_account(user.id, email=user.email):
+            logger.warning(f"Public login blocked for admin account user_id={user.id} email={user.email} ip={_client_ip()}")
+            return jsonify({
+                'success': False,
+                'error': 'Not authorised',
+            }), 403
         
         login_user(user)
+        logger.info(f"User login success user_id={user.id} email={user.email} ip={_client_ip()}")
         
         return jsonify({
             'success': True,
@@ -150,6 +265,8 @@ def create_marvin_auth_blueprint():
     @bp.route('/auth/logout', methods=['GET', 'POST'])
     def logout():
         """Log out the current user"""
+        if current_user.is_authenticated:
+            logger.info(f"User logout user_id={current_user.id} email={current_user.email} ip={_client_ip()}")
         logout_user()
         if request.method == 'POST':
             return jsonify({'success': True})
@@ -159,6 +276,7 @@ def create_marvin_auth_blueprint():
     def reset_password():
         """Reset password for the current user"""
         if not current_user.is_authenticated:
+            logger.warning(f"Password reset rejected (unauthenticated) ip={_client_ip()}")
             return jsonify({'success': False, 'error': 'Authentication required'}), 401
 
         data = request.get_json() or {}
@@ -166,15 +284,21 @@ def create_marvin_auth_blueprint():
         confirm_password = data.get('confirm_password', '')
 
         if not new_password or not confirm_password:
+            logger.warning(f"Password reset rejected (missing password) user_id={current_user.id} ip={_client_ip()}")
             return jsonify({'success': False, 'error': 'Password is required'}), 400
         if new_password != confirm_password:
+            logger.warning(f"Password reset rejected (mismatch) user_id={current_user.id} ip={_client_ip()}")
             return jsonify({'success': False, 'error': 'Passwords do not match'}), 400
-        if len(new_password) < 8:
-            return jsonify({'success': False, 'error': 'Password must be at least 8 characters'}), 400
+
+        password_error = _validate_password_policy(new_password)
+        if password_error:
+            logger.warning(f"Password reset rejected (policy) user_id={current_user.id} ip={_client_ip()}")
+            return jsonify({'success': False, 'error': password_error}), 400
 
         current_user.password_hash = generate_password_hash(new_password)
         current_user.must_reset_password = False
         db.session.commit()
+        logger.info(f"Password reset success user_id={current_user.id} email={current_user.email} ip={_client_ip()}")
 
         return jsonify({'success': True})
     
@@ -203,7 +327,7 @@ def require_login(f):
         if not current_user.is_authenticated:
             if request.is_json:
                 return jsonify({'error': 'Authentication required'}), 401
-            return redirect(url_for('marvin_auth.login_page'))
+            return redirect('/')
         return f(*args, **kwargs)
     return decorated_function
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,7 +6,7 @@ import { Modal, LoadingSpinner } from './components/common';
 import { CorpusBrowser, RareWordsExplorer } from './components/corpus';
 import { Repository } from './components/repository';
 import { AdminPanel } from './components/admin';
-import { AboutPage, HelpPage, DownloadsPage, PrivacyPage, ResearchPage, BlogArchivePage } from './components/pages';
+import { AboutPage, HelpPage, DownloadsPage, PrivacyPage, ResearchPage, BlogArchivePage, RegisterUserTestPage } from './components/pages';
 import TextCredits from './components/about/TextCredits';
 import VisualizationsPage from './components/pages/VisualizationsPage';
 import { useCorpus, useSearch } from './hooks';
@@ -26,7 +26,8 @@ const pathToPageType = {
   '/research': 'research',
   '/blog-archive': 'blog-archive',
   '/text-credits': 'text-credits',
-  '/admin': 'admin'
+  '/admin': 'admin',
+  '/register-test': 'register-test'
 };
 
 const pageTypeToPath = {
@@ -42,7 +43,8 @@ const pageTypeToPath = {
   'privacy': '/privacy',
   'research': '/research',
   'text-credits': '/text-credits',
-  'admin': '/admin'
+  'admin': '/admin',
+  'register-test': '/register-test'
 };
 
 const parseSearchParams = () => {
@@ -73,6 +75,8 @@ const buildShareableUrl = (sourceText, targetText, sourceAuthor, targetAuthor, l
 
 function App() {
   const [user, setUser] = useState(null);
+  const [adminSessionActive, setAdminSessionActive] = useState(false);
+  const [adminSessionChecked, setAdminSessionChecked] = useState(false);
   const [pageType, setPageType] = useState(() => {
     const path = window.location.pathname;
     return pathToPageType[path] || 'search';
@@ -134,6 +138,7 @@ function App() {
   const [registerPending, setRegisterPending] = useState(null);
   const [registerScore, setRegisterScore] = useState(0);
   const [registerNotes, setRegisterNotes] = useState('');
+  const [registerVisibility, setRegisterVisibility] = useState('private');
   
   const [corpusSearchResults, setCorpusSearchResults] = useState(null);
   const [corpusSearchLoading, setCorpusSearchLoading] = useState(false);
@@ -183,6 +188,39 @@ function App() {
   }, []);
 
   useEffect(() => {
+    let mounted = true;
+
+    const checkAdminSession = async () => {
+      try {
+        const res = await fetch('/api/admin/me', { credentials: 'include' });
+        if (mounted) {
+          setAdminSessionActive(res.ok);
+          setAdminSessionChecked(true);
+        }
+      } catch (_err) {
+        if (mounted) {
+          setAdminSessionActive(false);
+          setAdminSessionChecked(true);
+        }
+      }
+    };
+
+    const handleAdminAuthChanged = () => {
+      checkAdminSession();
+    };
+
+    checkAdminSession();
+    window.addEventListener('focus', handleAdminAuthChanged);
+    window.addEventListener('admin-auth-changed', handleAdminAuthChanged);
+
+    return () => {
+      mounted = false;
+      window.removeEventListener('focus', handleAdminAuthChanged);
+      window.removeEventListener('admin-auth-changed', handleAdminAuthChanged);
+    };
+  }, []);
+
+  useEffect(() => {
     const urlParams = parseSearchParams();
     if (urlParams.lang && ['la', 'grc', 'en', 'cross'].includes(urlParams.lang)) {
       setActiveTab(urlParams.lang);
@@ -210,12 +248,44 @@ function App() {
   }, [pageType]);
 
   useEffect(() => {
+    if (adminSessionChecked && adminSessionActive && pageType !== 'admin') {
+      setPageType('admin');
+    }
+  }, [adminSessionChecked, adminSessionActive, pageType]);
+
+  useEffect(() => {
     const handlePopState = () => {
       const path = window.location.pathname;
-      setPageType(pathToPageType[path] || 'search');
+      if (adminSessionChecked && adminSessionActive) {
+        setPageType('admin');
+      } else {
+        setPageType(pathToPageType[path] || 'search');
+      }
     };
     window.addEventListener('popstate', handlePopState);
     return () => window.removeEventListener('popstate', handlePopState);
+  }, [adminSessionChecked, adminSessionActive]);
+
+  const setPageTypeWithGuard = useCallback((nextPageType) => {
+    if (adminSessionChecked && adminSessionActive && nextPageType !== 'admin') {
+      setPageType('admin');
+      return;
+    }
+    setPageType(nextPageType);
+  }, [adminSessionChecked, adminSessionActive]);
+
+  const appLockedToAdmin = adminSessionChecked && adminSessionActive;
+
+  const handleAdminSessionLogout = useCallback(async () => {
+    try {
+      await fetch('/api/admin/logout', {
+        method: 'POST',
+        credentials: 'include',
+      });
+    } catch (_err) {}
+    window.dispatchEvent(new Event('admin-auth-changed'));
+    setPageType('search');
+    window.history.pushState({}, '', '/');
   }, []);
 
   // Track previous activeTab and corpus loading state to detect when to apply defaults
@@ -358,10 +428,20 @@ function App() {
   }, [sourceText, targetText, activeTab, settings, searchMode, search]);
 
   const handleRegister = useCallback((result) => {
+    if (!user) {
+      window.dispatchEvent(new CustomEvent('open-public-auth-modal', {
+        detail: {
+          mode: 'login',
+          message: 'Need to sign in to add to repository',
+        }
+      }));
+      return;
+    }
     setRegisterPending(result);
     setRegisterScore(0);
+    setRegisterVisibility('private');
     setShowRegisterModal(true);
-  }, []);
+  }, [user]);
 
   const handleCorpusSearch = useCallback(async (result) => {
     let lemmas;
@@ -428,6 +508,10 @@ function App() {
 
   const handleSubmitRegister = useCallback(async () => {
     if (!registerPending) return;
+    if (!Number.isInteger(registerScore) || registerScore < 1 || registerScore > 5) {
+      alert('Please select a star rating before saving.');
+      return;
+    }
     try {
       const sourceLocus = registerPending.source_locus || registerPending.source?.ref || '';
       const sourceText = registerPending.source_text || registerPending.source_snippet || registerPending.source?.text || '';
@@ -440,26 +524,31 @@ function App() {
         typeof w === 'object' ? (w.lemma || w.word || '') : w
       ).filter(Boolean);
 
-      const res = await fetch('/api/intertexts', {
+      const res = await fetch('/api/intertexts/my', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           source: {
             text_id: sourceTextId,
+            author: registerPending.source_author || registerPending.source?.author || '',
+            work: registerPending.source_work || registerPending.source?.work || '',
             reference: sourceLocus,
             snippet: sourceText,
             language: activeTab
           },
           target: {
             text_id: targetTextId,
+            author: registerPending.target_author || registerPending.target?.author || '',
+            work: registerPending.target_work || registerPending.target?.work || '',
             reference: targetLocus,
             snippet: targetText,
             language: activeTab
           },
           matched_lemmas: matchedLemmas,
           tesserae_score: registerPending.score || registerPending.overall_score || 0,
-          user_score: registerScore,
-          notes: registerNotes.trim().slice(0, 500)
+          intertext_score: registerScore,
+          notes: registerNotes.trim().slice(0, 500),
+          share_to_public: registerVisibility === 'public',
         })
       });
       
@@ -473,19 +562,25 @@ function App() {
       setRegisterPending(null);
       setRegisterScore(0);
       setRegisterNotes('');
-      setPageType('repository');
+      setRegisterVisibility('private');
+      setPageTypeWithGuard('repository');
       window.history.pushState({}, '', '/repository');
     } catch (err) {
       console.error('Failed to register intertext:', err);
       alert('Failed to register intertext: ' + err.message);
     }
-  }, [registerPending, activeTab, registerScore, registerNotes]);
+  }, [registerPending, activeTab, registerScore, registerNotes, registerVisibility, setPageTypeWithGuard]);
 
 
   return (
     <div className="min-h-screen bg-gray-100">
       <Header user={user} setUser={setUser} onLogoClick={() => {
-        setPageType('search');
+        if (appLockedToAdmin) {
+          setPageType('admin');
+          window.history.pushState({}, '', '/admin');
+          return;
+        }
+        setPageTypeWithGuard('search');
         setActiveTab('la');
         setSourceAuthor('');
         setSourceText('');
@@ -497,10 +592,12 @@ function App() {
         window.history.pushState({}, '', '/');
       }} />
       <Navigation 
-        pageType={pageType} 
-        setPageType={setPageType}
+        pageType={appLockedToAdmin ? 'admin' : pageType}
+        setPageType={setPageTypeWithGuard}
         activeTab={activeTab}
         setActiveTab={setActiveTab}
+        lockedToAdmin={appLockedToAdmin}
+        onAdminLogout={handleAdminSessionLogout}
         onLanguageReset={() => {
           setSourceAuthor('');
           setSourceText('');
@@ -513,6 +610,10 @@ function App() {
       />
       
       <main className="max-w-7xl mx-auto px-3 sm:px-6 py-4 sm:py-6">
+        {appLockedToAdmin ? (
+          <AdminPanel />
+        ) : (
+          <>
         {pageType === 'search' && activeTab !== 'cross' && (
           <div className="space-y-6">
             <div className="bg-white rounded-lg shadow p-4 sm:p-6">
@@ -749,7 +850,7 @@ function App() {
         )}
 
         {pageType === 'about' && (
-          <AboutPage onNavigate={setPageType} />
+          <AboutPage onNavigate={setPageTypeWithGuard} />
         )}
 
         {pageType === 'text-credits' && (
@@ -757,7 +858,7 @@ function App() {
         )}
 
         {pageType === 'help' && (
-          <HelpPage />
+          <HelpPage user={user} />
         )}
 
         {pageType === 'downloads' && (
@@ -769,11 +870,11 @@ function App() {
         )}
 
         {pageType === 'research' && (
-          <ResearchPage setPageType={setPageType} />
+          <ResearchPage setPageType={setPageTypeWithGuard} />
         )}
 
         {pageType === 'blog-archive' && (
-          <BlogArchivePage setPageType={setPageType} />
+          <BlogArchivePage setPageType={setPageTypeWithGuard} />
         )}
 
         {pageType === 'admin' && (
@@ -783,12 +884,24 @@ function App() {
         {pageType === 'visualizations' && (
           <VisualizationsPage />
         )}
+
+        {pageType === 'register-test' && (
+          <RegisterUserTestPage setUser={setUser} />
+        )}
+          </>
+        )}
       </main>
 
       <Modal
         isOpen={showRegisterModal}
-        onClose={() => { setShowRegisterModal(false); setRegisterPending(null); setRegisterNotes(''); }}
-        title="Register Intertext"
+        onClose={() => {
+          setShowRegisterModal(false);
+          setRegisterPending(null);
+          setRegisterScore(0);
+          setRegisterNotes('');
+          setRegisterVisibility('private');
+        }}
+        title="Save Parallel"
       >
         {registerPending && (() => {
           const sourceLocus = registerPending.source_locus || registerPending.source?.ref || '';
@@ -798,7 +911,7 @@ function App() {
           return (
           <div className="space-y-4">
             <p className="text-gray-600">
-              Register this parallel to the Intertext Repository for future reference and sharing.
+              Save this parallel to your repository, with the option to keep it private or make it public.
             </p>
             <div className="bg-gray-50 p-4 rounded">
               <div className="text-sm text-gray-500 mb-1">Source</div>
@@ -809,21 +922,53 @@ function App() {
               <div className="text-sm text-gray-700 mt-1">{targetText?.substring(0, 100)}{targetText?.length > 100 ? '...' : ''}</div>
             </div>
             <div className="mt-4">
-              <div className="text-sm text-gray-600 mb-2">Rate this parallel (optional):</div>
+              <div className="text-sm text-gray-600 mb-2">Visibility:</div>
+              <div className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
+                <button
+                  type="button"
+                  onClick={() => setRegisterVisibility('private')}
+                  className={`px-3 py-1.5 text-sm rounded ${
+                    registerVisibility === 'private'
+                      ? 'bg-white text-gray-900 shadow-sm'
+                      : 'text-gray-600 hover:text-gray-800'
+                  }`}
+                >
+                  Private
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setRegisterVisibility('public')}
+                  className={`px-3 py-1.5 text-sm rounded ${
+                    registerVisibility === 'public'
+                      ? 'bg-white text-red-700 shadow-sm'
+                      : 'text-gray-600 hover:text-gray-800'
+                  }`}
+                >
+                  Make Public
+                </button>
+              </div>
+              <p className="text-xs text-gray-500 mt-2">
+                {registerVisibility === 'public'
+                  ? 'This parallel will appear in the public repository and stay in your personal repository.'
+                  : 'This parallel will only appear in your personal repository.'}
+              </p>
+            </div>
+            <div className="mt-4">
+              <div className="text-sm text-gray-600 mb-2">Rate this parallel:</div>
               <div className="flex gap-1">
                 {[1,2,3,4,5].map(star => (
                   <button
                     key={star}
                     type="button"
-                    onClick={() => setRegisterScore(star === registerScore ? 0 : star)}
+                    onClick={() => setRegisterScore(star)}
                     className={`text-2xl ${star <= registerScore ? 'text-yellow-500' : 'text-gray-300'} hover:text-yellow-400 transition-colors`}
                   >
                     ★
                   </button>
                 ))}
-                {registerScore > 0 && (
-                  <span className="ml-2 text-sm text-gray-500 self-center">{registerScore}/5</span>
-                )}
+                <span className="ml-2 text-sm text-gray-500 self-center">
+                  {registerScore > 0 ? `${registerScore}/5` : 'Required'}
+                </span>
               </div>
             </div>
             <div className="mt-4">
@@ -844,16 +989,23 @@ function App() {
             </div>
             <div className="flex gap-3 justify-end">
               <button
-                onClick={() => { setShowRegisterModal(false); setRegisterPending(null); setRegisterScore(0); setRegisterNotes(''); }}
+                onClick={() => {
+                  setShowRegisterModal(false);
+                  setRegisterPending(null);
+                  setRegisterScore(0);
+                  setRegisterNotes('');
+                  setRegisterVisibility('private');
+                }}
                 className="px-4 py-2 bg-gray-100 text-gray-700 border border-gray-300 rounded hover:bg-gray-200"
               >
                 Cancel
               </button>
               <button
                 onClick={handleSubmitRegister}
-                className="px-4 py-2 bg-red-700 text-white rounded hover:bg-red-800"
+                disabled={registerScore < 1}
+                className="px-4 py-2 bg-red-700 text-white rounded hover:bg-red-800 disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                Register
+                Save Parallel
               </button>
             </div>
           </div>

--- a/client/src/components/admin/AdminPanel.jsx
+++ b/client/src/components/admin/AdminPanel.jsx
@@ -23,6 +23,7 @@ export default function AdminPanel() {
   const [activeTab, setActiveTab] = useState('requests');
   const [loading, setLoading] = useState(false);
   const [adminRoles, setAdminRoles] = useState([]);
+  const [adminUserId, setAdminUserId] = useState(null);
   const [mustResetPassword, setMustResetPassword] = useState(false);
   const [resetCurrent, setResetCurrent] = useState('');
   const [resetNext, setResetNext] = useState('');
@@ -63,10 +64,12 @@ export default function AdminPanel() {
         setMustResetPassword(Boolean(data.must_reset_password));
         setResetError('');
         setResetSuccess('');
+        window.dispatchEvent(new Event('admin-auth-changed'));
         try {
           const meRes = await fetch('/api/admin/me', { credentials: 'include' });
           if (meRes.ok) {
             const meData = await meRes.json();
+            setAdminUserId(meData.user_id || null);
             const meRoles = Array.isArray(meData.roles)
               ? meData.roles.map(normalizeRole).filter(Boolean)
               : [];
@@ -140,6 +143,7 @@ export default function AdminPanel() {
     } catch (_ignored) {}
     setIsAuthenticated(false);
     setAdminRoles([]);
+    setAdminUserId(null);
     setMustResetPassword(false);
     setResetCurrent('');
     setResetNext('');
@@ -147,6 +151,7 @@ export default function AdminPanel() {
     setResetError('');
     setResetSuccess('');
     setShowChangePassword(false);
+    window.dispatchEvent(new Event('admin-auth-changed'));
   };
 
   const loadAdminData = async () => {
@@ -367,7 +372,12 @@ export default function AdminPanel() {
             )}
 
             {activeTab === 'users' && (
-              <UsersTab authHeaders={{}} isSuperAdmin={adminRoles.map(normalizeRole).includes('SUPER_ADMIN')} />
+              <UsersTab
+                authHeaders={{}}
+                isAdmin={adminRoles.map(normalizeRole).some((r) => r === 'ADMIN' || r === 'SUPER_ADMIN')}
+                isSuperAdmin={adminRoles.map(normalizeRole).includes('SUPER_ADMIN')}
+                currentAdminUserId={adminUserId}
+              />
             )}
 
             {activeTab === 'sources' && (

--- a/client/src/components/admin/tabs/UsersTab.jsx
+++ b/client/src/components/admin/tabs/UsersTab.jsx
@@ -7,7 +7,7 @@ const roleLabel = (role) => {
   return value.replace(/_/g, ' ');
 };
 
-export default function UsersTab({ authHeaders, isSuperAdmin = false }) {
+export default function UsersTab({ authHeaders, isAdmin = false, isSuperAdmin = false, currentAdminUserId = null }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [users, setUsers] = useState([]);
@@ -19,7 +19,7 @@ export default function UsersTab({ authHeaders, isSuperAdmin = false }) {
   const [createFirstName, setCreateFirstName] = useState('');
   const [createLastName, setCreateLastName] = useState('');
   const [createPassword, setCreatePassword] = useState('');
-  const [createRole, setCreateRole] = useState('ADMIN');
+  const [createRole, setCreateRole] = useState('USER');
   const [createError, setCreateError] = useState(null);
   const [createSuccess, setCreateSuccess] = useState(null);
 
@@ -51,7 +51,7 @@ export default function UsersTab({ authHeaders, isSuperAdmin = false }) {
     }
   };
 
-  const handleCreateAdmin = async (e) => {
+  const handleCreateUser = async (e) => {
     e.preventDefault();
     setCreateError(null);
     setCreateSuccess(null);
@@ -75,18 +75,18 @@ export default function UsersTab({ authHeaders, isSuperAdmin = false }) {
 
       const payload = await res.json();
       if (!res.ok || payload.error) {
-        throw new Error(payload.error || 'Failed to create admin user.');
+        throw new Error(payload.error || 'Failed to create user.');
       }
 
-      setCreateSuccess('Admin user created. They must reset their password on first login.');
+      setCreateSuccess(`User created with role ${payload.role}. They must reset their password on first login.`);
       setCreateEmail('');
       setCreateFirstName('');
       setCreateLastName('');
       setCreatePassword('');
-      setCreateRole('ADMIN');
+      setCreateRole('USER');
       await loadUsers();
     } catch (err) {
-      setCreateError(err.message || 'Failed to create admin user.');
+      setCreateError(err.message || 'Failed to create user.');
     }
   };
 
@@ -144,6 +144,34 @@ export default function UsersTab({ authHeaders, isSuperAdmin = false }) {
     }
   };
 
+  const deleteUser = async (userId, email) => {
+    setActionError(null);
+    setActionSuccess(null);
+    if (!window.confirm(`Delete user ${email || userId}? This cannot be undone.`)) {
+      return;
+    }
+    setBusyUserId(userId);
+    try {
+      const res = await fetch(`/api/admin/users/${userId}`, {
+        method: 'DELETE',
+        headers: {
+          ...authHeaders
+        },
+        credentials: 'include'
+      });
+      const payload = await res.json();
+      if (!res.ok || payload.error) {
+        throw new Error(payload.error || 'Failed to delete user.');
+      }
+      setUsers((prev) => prev.filter((u) => u.id !== userId));
+      setActionSuccess(payload.message || 'User deleted.');
+    } catch (err) {
+      setActionError(err.message || 'Failed to delete user.');
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
   if (loading) {
     return (
       <div className="text-sm text-gray-500">Loading users...</div>
@@ -154,9 +182,9 @@ export default function UsersTab({ authHeaders, isSuperAdmin = false }) {
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <div>
-          <h3 className="text-lg font-semibold text-gray-900">User Roles</h3>
+          <h3 className="text-lg font-semibold text-gray-900">Users & Roles</h3>
           <p className="text-sm text-gray-500">
-            Promote or demote users. SUPER_ADMIN changes should be performed sparingly.
+            Manage user accounts. Admin role changes remain restricted.
           </p>
         </div>
         <button
@@ -185,13 +213,13 @@ export default function UsersTab({ authHeaders, isSuperAdmin = false }) {
         </div>
       )}
 
-      {isSuperAdmin && (
+      {isAdmin && (
         <div className="bg-gray-50 border border-gray-200 rounded p-4">
-          <h4 className="text-sm font-semibold text-gray-900 mb-2">Create Admin User</h4>
+          <h4 className="text-sm font-semibold text-gray-900 mb-2">Create User</h4>
           <p className="text-xs text-gray-500 mb-3">
             Required fields: first name, last name, email, and password.
           </p>
-          <form onSubmit={handleCreateAdmin} className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <form onSubmit={handleCreateUser} className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <input
               type="text"
               className="border rounded px-3 py-2 text-sm"
@@ -230,14 +258,15 @@ export default function UsersTab({ authHeaders, isSuperAdmin = false }) {
               value={createRole}
               onChange={(e) => setCreateRole(e.target.value)}
             >
-              <option value="ADMIN">ADMIN</option>
-              <option value="SUPER_ADMIN">SUPER_ADMIN</option>
+              <option value="USER">USER</option>
+              {isSuperAdmin && <option value="ADMIN">ADMIN</option>}
+              {isSuperAdmin && <option value="SUPER_ADMIN">SUPER_ADMIN</option>}
             </select>
             <button
               type="submit"
               className="bg-red-700 text-white rounded px-3 py-2 text-sm hover:bg-red-800"
             >
-              Create Admin
+              Create User
             </button>
           </form>
           {createError && (
@@ -270,7 +299,9 @@ export default function UsersTab({ authHeaders, isSuperAdmin = false }) {
             {users.map(user => {
               const userRoles = Array.isArray(user.roles) ? user.roles : [];
               const normalizedRoles = userRoles.map(r => (typeof r === 'string' ? r : r.name)).filter(Boolean);
-              const hasRole = (roleName) => normalizedRoles.includes(roleName);
+              const effectiveRoles = normalizedRoles.length > 0 ? normalizedRoles : ['USER'];
+              const hasRole = (roleName) => effectiveRoles.includes(roleName);
+              const isUserOnly = effectiveRoles.length === 1 && effectiveRoles[0] === 'USER';
 
               return (
                 <tr key={user.id} className="border-b">
@@ -279,39 +310,58 @@ export default function UsersTab({ authHeaders, isSuperAdmin = false }) {
                   </td>
                   <td className="py-3 pr-4 text-gray-700">{user.email}</td>
                   <td className="py-3 pr-4 text-gray-700">
-                    {normalizedRoles.length
-                      ? normalizedRoles.map(roleLabel).join(', ')
-                      : 'USER'}
+                    {effectiveRoles.map(roleLabel).join(', ')}
                   </td>
                   <td className="py-3 pr-4">
-                    <div className="flex flex-wrap gap-2">
+                    <div className="flex flex-wrap gap-2 items-center">
+                      {isSuperAdmin ? (
+                        isUserOnly ? (
+                          <span className="text-xs text-gray-500">
+                            Role changes restricted for USER accounts
+                          </span>
+                        ) : (
+                          <>
+                            <button
+                              disabled={busyUserId === user.id || hasRole('ADMIN')}
+                              onClick={() => submitRoleChange(user.id, 'ADMIN', 'add')}
+                              className="text-xs px-2 py-1 rounded bg-blue-50 text-blue-700 border border-blue-200 disabled:opacity-50"
+                            >
+                              Promote to ADMIN
+                            </button>
+                            <button
+                              disabled={busyUserId === user.id || hasRole('SUPER_ADMIN')}
+                              onClick={() => submitRoleChange(user.id, 'SUPER_ADMIN', 'add')}
+                              className="text-xs px-2 py-1 rounded bg-purple-50 text-purple-700 border border-purple-200 disabled:opacity-50"
+                            >
+                              Promote to SUPER_ADMIN
+                            </button>
+                            <button
+                              disabled={busyUserId === user.id || !hasRole('ADMIN')}
+                              onClick={() => submitRoleChange(user.id, 'ADMIN', 'remove')}
+                              className="text-xs px-2 py-1 rounded bg-amber-50 text-amber-700 border border-amber-200 disabled:opacity-50"
+                            >
+                              Demote ADMIN
+                            </button>
+                            <button
+                              disabled={busyUserId === user.id || !hasRole('SUPER_ADMIN')}
+                              onClick={() => submitRoleChange(user.id, 'SUPER_ADMIN', 'remove')}
+                              className="text-xs px-2 py-1 rounded bg-red-50 text-red-700 border border-red-200 disabled:opacity-50"
+                            >
+                              Demote SUPER_ADMIN
+                            </button>
+                          </>
+                        )
+                      ) : (
+                        <span className="text-xs text-gray-500">
+                          Role updates require SUPER_ADMIN
+                        </span>
+                      )}
                       <button
-                        disabled={busyUserId === user.id || hasRole('ADMIN')}
-                        onClick={() => submitRoleChange(user.id, 'ADMIN', 'add')}
-                        className="text-xs px-2 py-1 rounded bg-blue-50 text-blue-700 border border-blue-200 disabled:opacity-50"
-                      >
-                        Promote to ADMIN
-                      </button>
-                      <button
-                        disabled={busyUserId === user.id || hasRole('SUPER_ADMIN')}
-                        onClick={() => submitRoleChange(user.id, 'SUPER_ADMIN', 'add')}
-                        className="text-xs px-2 py-1 rounded bg-purple-50 text-purple-700 border border-purple-200 disabled:opacity-50"
-                      >
-                        Promote to SUPER_ADMIN
-                      </button>
-                      <button
-                        disabled={busyUserId === user.id || !hasRole('ADMIN')}
-                        onClick={() => submitRoleChange(user.id, 'ADMIN', 'remove')}
-                        className="text-xs px-2 py-1 rounded bg-amber-50 text-amber-700 border border-amber-200 disabled:opacity-50"
-                      >
-                        Demote ADMIN
-                      </button>
-                      <button
-                        disabled={busyUserId === user.id || !hasRole('SUPER_ADMIN')}
-                        onClick={() => submitRoleChange(user.id, 'SUPER_ADMIN', 'remove')}
+                        disabled={busyUserId === user.id || String(currentAdminUserId || '') === String(user.id)}
+                        onClick={() => deleteUser(user.id, user.email)}
                         className="text-xs px-2 py-1 rounded bg-red-50 text-red-700 border border-red-200 disabled:opacity-50"
                       >
-                        Demote SUPER_ADMIN
+                        {String(currentAdminUserId || '') === String(user.id) ? 'Current account' : 'Delete User'}
                       </button>
                     </div>
                   </td>

--- a/client/src/components/layout/Header.jsx
+++ b/client/src/components/layout/Header.jsx
@@ -12,7 +12,9 @@ const Header = ({ user, setUser, onLogoClick }) => {
   const [orcidLinking, setOrcidLinking] = useState(false);
   const [orcidError, setOrcidError] = useState(null);
   const [authEnabled, setAuthEnabled] = useState(true);
-  const [authType, setAuthType] = useState('replit');
+  const [adminSessionActive, setAdminSessionActive] = useState(false);
+  const [adminSessionChecked, setAdminSessionChecked] = useState(false);
+  const [selfRegistrationEnabled, setSelfRegistrationEnabled] = useState(true);
   const [isRegister, setIsRegister] = useState(false);
   const [loginEmail, setLoginEmail] = useState('');
   const [loginPassword, setLoginPassword] = useState('');
@@ -26,6 +28,7 @@ const Header = ({ user, setUser, onLogoClick }) => {
   const [resetConfirmPassword, setResetConfirmPassword] = useState('');
   const [resetError, setResetError] = useState('');
   const [resetLoading, setResetLoading] = useState(false);
+  const [authPromptMessage, setAuthPromptMessage] = useState('');
   const dropdownRef = useRef(null);
 
   useEffect(() => {
@@ -34,8 +37,8 @@ const Header = ({ user, setUser, onLogoClick }) => {
         if (data.auth_enabled !== undefined) {
           setAuthEnabled(data.auth_enabled);
         }
-        if (data.auth_type) {
-          setAuthType(data.auth_type);
+        if (data.self_registration_enabled !== undefined) {
+          setSelfRegistrationEnabled(Boolean(data.self_registration_enabled));
         }
         if (data.authenticated) {
           setUser(data.user);
@@ -47,6 +50,39 @@ const Header = ({ user, setUser, onLogoClick }) => {
   }, [setUser]);
 
   useEffect(() => {
+    let mounted = true;
+
+    const checkAdminSession = async () => {
+      try {
+        const res = await fetch('/api/admin/me', { credentials: 'include' });
+        if (mounted) {
+          setAdminSessionActive(res.ok);
+          setAdminSessionChecked(true);
+        }
+      } catch (_err) {
+        if (mounted) {
+          setAdminSessionActive(false);
+          setAdminSessionChecked(true);
+        }
+      }
+    };
+
+    const handleAdminAuthChanged = () => {
+      checkAdminSession();
+    };
+
+    checkAdminSession();
+    window.addEventListener('focus', handleAdminAuthChanged);
+    window.addEventListener('admin-auth-changed', handleAdminAuthChanged);
+
+    return () => {
+      mounted = false;
+      window.removeEventListener('focus', handleAdminAuthChanged);
+      window.removeEventListener('admin-auth-changed', handleAdminAuthChanged);
+    };
+  }, []);
+
+  useEffect(() => {
     const handleClickOutside = (e) => {
       if (dropdownRef.current && !dropdownRef.current.contains(e.target)) {
         setShowDropdown(false);
@@ -54,6 +90,18 @@ const Header = ({ user, setUser, onLogoClick }) => {
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  useEffect(() => {
+    const handleOpenAuthModal = (event) => {
+      setShowLoginModal(true);
+      setIsRegister(event?.detail?.mode === 'register');
+      setAuthPromptMessage(event?.detail?.message || '');
+      setLoginError('');
+    };
+
+    window.addEventListener('open-public-auth-modal', handleOpenAuthModal);
+    return () => window.removeEventListener('open-public-auth-modal', handleOpenAuthModal);
   }, []);
 
   const linkOrcid = async () => {
@@ -152,14 +200,12 @@ const Header = ({ user, setUser, onLogoClick }) => {
     setLoginLastName('');
     setLoginError('');
     setIsRegister(false);
+    setAuthPromptMessage('');
   };
 
   const handleSignInClick = () => {
-    if (authType === 'password') {
-      setShowLoginModal(true);
-    } else {
-      window.location.href = '/api/auth/login';
-    }
+    setAuthPromptMessage('');
+    setShowLoginModal(true);
   };
 
   const handlePasswordReset = async (e) => {
@@ -262,7 +308,7 @@ const Header = ({ user, setUser, onLogoClick }) => {
                   <div className="absolute right-0 mt-2 w-56 sm:w-64 bg-white rounded-lg shadow-lg border z-50">
                     <div className="p-3 border-b">
                       <p className="font-medium text-gray-900">{user.name || user.orcid_name || `${user.first_name || ''} ${user.last_name || ''}`.trim() || 'Account'}</p>
-                      <p className="text-xs text-gray-500">{user.email || 'Signed in with Replit'}</p>
+                      <p className="text-xs text-gray-500">{user.email || 'Signed in'}</p>
                       {(isSuperAdmin || isAdmin) && (
                         <div className="mt-2 flex flex-wrap gap-1">
                           {isSuperAdmin && (
@@ -326,6 +372,13 @@ const Header = ({ user, setUser, onLogoClick }) => {
                   </div>
                 )}
               </div>
+            ) : authEnabled && adminSessionChecked && !adminSessionActive ? (
+              <button
+                onClick={handleSignInClick}
+                className="px-4 py-2 bg-white text-red-700 rounded font-medium hover:bg-orange-50 text-sm"
+              >
+                Sign In
+              </button>
             ) : null}
           </div>
         </div>
@@ -400,7 +453,9 @@ const Header = ({ user, setUser, onLogoClick }) => {
           <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
             <div className="flex justify-between items-center mb-4">
               <h3 className="text-lg font-bold text-gray-900">
-                {isRegister ? 'Create Account' : 'Sign In'}
+                {isRegister
+                  ? 'Create Account'
+                  : (authPromptMessage || 'Sign In')}
               </h3>
               <button
                 onClick={() => { setShowLoginModal(false); resetLoginForm(); }}
@@ -411,14 +466,12 @@ const Header = ({ user, setUser, onLogoClick }) => {
             </div>
             
             <p className="text-sm text-gray-600 mb-4">
-              {isRegister ? 'Join Tesserae to save and share discoveries' : 'Welcome back to Tesserae'}
+              {isRegister
+                ? 'Join Tesserae to save and share discoveries'
+                : (authPromptMessage
+                  ? 'Use your Tesserae account to save this parallel to your repository.'
+                  : 'Welcome back to Tesserae')}
             </p>
-            {!isRegister && (
-              <div className="bg-amber-50 border border-amber-200 text-amber-700 px-3 py-2 rounded text-xs mb-3">
-                If your account was bootstrapped, you may be required to reset your password after signing in.
-              </div>
-            )}
-            
             <form onSubmit={handlePasswordLogin} className="space-y-3">
               {isRegister && (
                 <div className="grid grid-cols-2 gap-3">
@@ -466,8 +519,13 @@ const Header = ({ user, setUser, onLogoClick }) => {
                   required
                   minLength={8}
                   className="w-full border rounded px-3 py-2 text-sm"
-                  placeholder={isRegister ? 'At least 8 characters' : 'Your password'}
+                  placeholder={isRegister ? 'Min 8, upper/lower/number/special' : 'Your password'}
                 />
+                {isRegister && (
+                  <p className="text-xs text-gray-500 mt-1">
+                    Must include at least one uppercase letter, one lowercase letter, one number, and one special character.
+                  </p>
+                )}
               </div>
 
               {isRegister && (
@@ -496,17 +554,21 @@ const Header = ({ user, setUser, onLogoClick }) => {
                 disabled={loginLoading}
                 className="w-full bg-gradient-to-r from-red-700 to-orange-600 text-white py-2 rounded font-medium hover:from-red-800 hover:to-orange-700 disabled:opacity-50"
               >
-                {loginLoading ? 'Please wait...' : (isRegister ? 'Create Account' : 'Sign In')}
+                {loginLoading ? 'Please wait...' : (isRegister ? 'Create Account' : (authPromptMessage ? 'Continue' : 'Sign In'))}
               </button>
             </form>
 
             <div className="mt-4 text-center">
-              <button
-                onClick={() => { setIsRegister(!isRegister); setLoginError(''); }}
-                className="text-red-700 hover:text-red-800 text-sm"
-              >
-                {isRegister ? 'Already have an account? Sign in' : "Don't have an account? Create one"}
-              </button>
+              {selfRegistrationEnabled ? (
+                <button
+                  onClick={() => { setIsRegister(!isRegister); setLoginError(''); }}
+                  className="text-red-700 hover:text-red-800 text-sm"
+                >
+                  {isRegister ? 'Already have an account? Sign in' : "Don't have an account? Create one"}
+                </button>
+              ) : (
+                <p className="text-xs text-gray-500">Self-registration is currently disabled.</p>
+              )}
             </div>
           </div>
         </div>

--- a/client/src/components/layout/Navigation.jsx
+++ b/client/src/components/layout/Navigation.jsx
@@ -24,6 +24,8 @@ const Navigation = ({
   activeTab, 
   setActiveTab,
   onLanguageReset,
+  lockedToAdmin = false,
+  onAdminLogout,
   showDownloads = false,
   setShowDownloads
 }) => {
@@ -33,6 +35,34 @@ const Navigation = ({
     }
     setActiveTab(tabCode);
   };
+
+  if (lockedToAdmin) {
+    return (
+      <nav className="bg-gray-50 border-b sticky top-0 z-40">
+        <div className="max-w-7xl mx-auto px-3 sm:px-6 py-2">
+          <div className="flex items-center justify-between">
+            <button
+              onClick={() => setPageType('admin')}
+              className="px-3 py-2 font-medium text-sm border-b-2 border-red-700 text-red-700"
+            >
+              Admin Panel
+            </button>
+            <div className="text-xs text-gray-600 flex items-center gap-1">
+              <span>Admin session active. Public tabs are restricted until</span>
+              <button
+                onClick={onAdminLogout}
+                className="text-red-700 hover:text-red-800 underline"
+              >
+                logout
+              </button>
+              <span>.</span>
+            </div>
+          </div>
+        </div>
+      </nav>
+    );
+  }
+
   return (
     <nav className="bg-gray-50 border-b sticky top-0 z-40">
       <div className="max-w-7xl mx-auto px-3 sm:px-6">

--- a/client/src/components/pages/HelpPage.jsx
+++ b/client/src/components/pages/HelpPage.jsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { STOPLIST_INFO } from '../../data/stoplists';
 
-export default function HelpPage() {
+export default function HelpPage({ user }) {
   const [activeSection, setActiveSection] = useState('getting-started');
   const [requestName, setRequestName] = useState('');
   const [requestEmail, setRequestEmail] = useState('');
@@ -31,6 +31,21 @@ export default function HelpPage() {
   const [formatterRawText, setFormatterRawText] = useState('');
   const [formatterOutput, setFormatterOutput] = useState('');
   const [formatterCopied, setFormatterCopied] = useState(false);
+
+  useEffect(() => {
+    if (!user) {
+      return;
+    }
+
+    const derivedName = user.name || `${user.first_name || ''} ${user.last_name || ''}`.trim();
+
+    if (!requestName && derivedName) {
+      setRequestName(derivedName);
+    }
+    if (!requestEmail && user.email) {
+      setRequestEmail(user.email);
+    }
+  }, [user, requestName, requestEmail]);
 
   const formatToTess = () => {
     if (!formatterAuthor.trim() || !formatterWork.trim() || !formatterRawText.trim()) {

--- a/client/src/components/pages/RegisterUserTestPage.jsx
+++ b/client/src/components/pages/RegisterUserTestPage.jsx
@@ -1,0 +1,195 @@
+import { useState } from 'react';
+
+const API_BASE = '/api';
+
+export default function RegisterUserTestPage({ setUser }) {
+  const [mode, setMode] = useState('register');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState(null);
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setResult(null);
+
+    if (mode === 'register' && password !== confirmPassword) {
+      setResult({
+        ok: false,
+        data: { error: 'Passwords do not match' },
+      });
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const endpoint = mode === 'register' ? '/auth/register' : '/auth/login';
+      const payload =
+        mode === 'register'
+          ? {
+              email: email.trim(),
+              password,
+              first_name: firstName.trim(),
+              last_name: lastName.trim(),
+            }
+          : {
+              email: email.trim(),
+              password,
+            };
+
+      const res = await fetch(`${API_BASE}${endpoint}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      if (data?.success && data?.user) {
+        const userData = data.user;
+        userData.name =
+          userData.orcid_name ||
+          `${userData.first_name || ''} ${userData.last_name || ''}`.trim() ||
+          'Account';
+        if (setUser) setUser(userData);
+      }
+      setResult({ ok: res.ok && Boolean(data?.success), data });
+    } catch (err) {
+      setResult({
+        ok: false,
+        data: { error: err?.message || `Failed to reach /api/auth/${mode}` },
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-xl mx-auto bg-white rounded-lg shadow p-6">
+      <h2 className="text-xl font-semibold text-gray-900 mb-2">Auth User Test</h2>
+      <p className="text-sm text-gray-600 mb-5">
+        Hidden test route for Marvin password auth (register + sign in). Not linked in navigation.
+      </p>
+
+      <div className="mb-5 flex gap-2">
+        <button
+          type="button"
+          onClick={() => {
+            setMode('register');
+            setResult(null);
+          }}
+          className={`px-3 py-1.5 rounded text-sm ${
+            mode === 'register' ? 'bg-red-700 text-white' : 'bg-gray-100 text-gray-700'
+          }`}
+        >
+          Register
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setMode('login');
+            setResult(null);
+          }}
+          className={`px-3 py-1.5 rounded text-sm ${
+            mode === 'login' ? 'bg-red-700 text-white' : 'bg-gray-100 text-gray-700'
+          }`}
+        >
+          Sign In
+        </button>
+      </div>
+
+      <form onSubmit={onSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full border rounded px-3 py-2 text-sm"
+            placeholder="user@example.com"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Password</label>
+          <input
+            type="password"
+            minLength={8}
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full border rounded px-3 py-2 text-sm"
+            placeholder={mode === 'register' ? 'Min 8, upper/lower/number/special' : 'Your password'}
+          />
+          {mode === 'register' && (
+            <p className="text-xs text-gray-500 mt-1">
+              Must include at least one uppercase letter, one lowercase letter, one number, and one special character.
+            </p>
+          )}
+        </div>
+
+        {mode === 'register' && (
+          <>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Confirm Password</label>
+              <input
+                type="password"
+                minLength={8}
+                required
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className="w-full border rounded px-3 py-2 text-sm"
+                placeholder="Confirm your password"
+              />
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">First Name</label>
+                <input
+                  type="text"
+                  value={firstName}
+                  onChange={(e) => setFirstName(e.target.value)}
+                  className="w-full border rounded px-3 py-2 text-sm"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Last Name</label>
+                <input
+                  type="text"
+                  value={lastName}
+                  onChange={(e) => setLastName(e.target.value)}
+                  className="w-full border rounded px-3 py-2 text-sm"
+                />
+              </div>
+            </div>
+          </>
+        )}
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="px-4 py-2 bg-red-700 text-white rounded hover:bg-red-800 disabled:opacity-50"
+        >
+          {loading ? (mode === 'register' ? 'Registering...' : 'Signing in...') : (mode === 'register' ? 'Test Register' : 'Test Sign In')}
+        </button>
+      </form>
+
+      {result && (
+        <div
+          className={`mt-5 p-3 rounded text-sm ${
+            result.ok ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700'
+          }`}
+        >
+          <div className="font-medium mb-1">{result.ok ? 'Success' : 'Failed'}</div>
+          <pre className="whitespace-pre-wrap break-words">
+            {JSON.stringify(result.data, null, 2)}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/pages/index.js
+++ b/client/src/components/pages/index.js
@@ -4,3 +4,4 @@ export { default as DownloadsPage } from './DownloadsPage';
 export { default as PrivacyPage } from './PrivacyPage';
 export { default as ResearchPage } from './ResearchPage';
 export { default as BlogArchivePage } from './BlogArchivePage';
+export { default as RegisterUserTestPage } from './RegisterUserTestPage';

--- a/client/src/components/repository/Repository.jsx
+++ b/client/src/components/repository/Repository.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { LoadingSpinner, Modal } from '../common';
 
 /**
@@ -93,18 +93,42 @@ function formatCitation(author, work, reference) {
   return reference || '';
 }
 
+function normalizeRepositoryItem(item, { publicEntry = false } = {}) {
+  const source = item.source || {};
+  const target = item.target || {};
+  const sourceLanguage = source.language || item.source_language || item.language || 'la';
+  const targetLanguage = target.language || item.target_language || sourceLanguage;
+  const derivedLanguage = item.language || sourceLanguage || targetLanguage || 'la';
+  const isPublic = item.is_public ?? item.shared_to_public ?? publicEntry;
+
+  return {
+    ...item,
+    source,
+    target,
+    language: derivedLanguage,
+    source_locus: source.reference || item.source_locus || '',
+    target_locus: target.reference || item.target_locus || '',
+    source_text: source.snippet || item.source_text || '',
+    target_text: target.snippet || item.target_text || '',
+    score: item.score ?? item.tesserae_score ?? 0,
+    scholar_score: item.scholar_score ?? item.intertext_score ?? item.user_score ?? 0,
+    status: item.status || (isPublic ? 'shared' : 'private'),
+    is_public: isPublic,
+  };
+}
+
 export default function Repository({ user }) {
-  const [intertexts, setIntertexts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState({ language: 'all', status: 'all' });
   const [sortBy, setSortBy] = useState('created_at');
   const [sortOrder, setSortOrder] = useState('desc');
   const [displayLimit, setDisplayLimit] = useState(50);
-  const [stats, setStats] = useState(null);
-  const [viewMode, setViewMode] = useState('browse');
+  const [viewMode, setViewMode] = useState(user ? 'my' : 'public');
+  const [publicIntertexts, setPublicIntertexts] = useState([]);
   const [myIntertexts, setMyIntertexts] = useState([]);
   const [showAddModal, setShowAddModal] = useState(false);
   const [editingItem, setEditingItem] = useState(null);
+  const [editingScope, setEditingScope] = useState('saved');
   const [newIntertext, setNewIntertext] = useState({
     source_locus: '',
     source_text: '',
@@ -113,7 +137,7 @@ export default function Repository({ user }) {
     language: 'la',
     notes: '',
     scholar_score: 0,
-    is_public: true,
+    is_public: false,
     matched_words: ''
   });
   const [expandedAuthors, setExpandedAuthors] = useState({});
@@ -158,52 +182,56 @@ export default function Repository({ user }) {
     setExpandedFormsCache(newCache);
   }, [expandedFormsCache]);
 
-  useEffect(() => {
-    loadIntertexts();
-    loadStats();
-  }, []);
-
-  useEffect(() => {
-    if (user && viewMode === 'my') {
-      loadMyIntertexts();
-    } else if (viewMode === 'browse' || viewMode === 'byWork') {
-      loadIntertexts();
-    }
-  }, [user, viewMode]);
-
-  const loadIntertexts = async () => {
+  const loadPublicIntertexts = useCallback(async () => {
     setLoading(true);
     try {
       const res = await fetch('/api/intertexts');
+      if (!res.ok) {
+        throw new Error('Failed to load public repository');
+      }
       const data = await res.json();
-      const items = data.intertexts || [];
-      setIntertexts(items);
+      const items = (data.intertexts || []).map((item) => normalizeRepositoryItem(item, { publicEntry: true }));
+      setPublicIntertexts(items);
       await loadExpandedFormsForItems(items);
     } catch (err) {
-      console.error('Failed to load intertexts:', err);
+      console.error('Failed to load public intertexts:', err);
+    } finally {
+      setLoading(false);
     }
-    setLoading(false);
-  };
+  }, [loadExpandedFormsForItems]);
 
-  const loadMyIntertexts = async () => {
+  const loadMyIntertexts = useCallback(async () => {
+    setLoading(true);
     try {
       const res = await fetch('/api/intertexts/my');
+      if (!res.ok) {
+        throw new Error('Failed to load repository');
+      }
       const data = await res.json();
-      setMyIntertexts(data.intertexts || []);
+      const items = (data.intertexts || []).map((item) => normalizeRepositoryItem(item));
+      setMyIntertexts(items);
+      await loadExpandedFormsForItems(items);
     } catch (err) {
       console.error('Failed to load my intertexts:', err);
+    } finally {
+      setLoading(false);
     }
-  };
+  }, [loadExpandedFormsForItems]);
 
-  const loadStats = async () => {
-    try {
-      const res = await fetch('/api/intertexts/stats');
-      const data = await res.json();
-      setStats(data);
-    } catch (err) {
-      console.error('Failed to load repository stats:', err);
+  useEffect(() => {
+    loadPublicIntertexts();
+  }, [loadPublicIntertexts]);
+
+  useEffect(() => {
+    if (user) {
+      loadMyIntertexts();
+      return;
     }
-  };
+    setMyIntertexts([]);
+    if (viewMode !== 'public') {
+      setViewMode('public');
+    }
+  }, [user, viewMode, loadMyIntertexts]);
 
   const getFormsForItem = (item) => {
     const lemmas = item.matched_lemmas || [];
@@ -213,16 +241,33 @@ export default function Repository({ user }) {
   };
 
   const handleAddIntertext = async () => {
+    if (!Number.isInteger(newIntertext.scholar_score) || newIntertext.scholar_score < 1 || newIntertext.scholar_score > 5) {
+      alert('Please select a star rating before adding an intertext.');
+      return;
+    }
     try {
       const payload = {
-        ...newIntertext,
-        matched_tokens: newIntertext.matched_words 
-          ? newIntertext.matched_words.split(',').map(w => w.trim()).filter(Boolean)
-          : []
+        source: {
+          text_id: newIntertext.source_locus.trim() || `manual-source-${Date.now()}`,
+          reference: newIntertext.source_locus.trim(),
+          snippet: newIntertext.source_text.trim(),
+          language: newIntertext.language,
+        },
+        target: {
+          text_id: newIntertext.target_locus.trim() || `manual-target-${Date.now()}`,
+          reference: newIntertext.target_locus.trim(),
+          snippet: newIntertext.target_text.trim(),
+          language: newIntertext.language,
+        },
+        matched_tokens: newIntertext.matched_words
+          ? newIntertext.matched_words.split(',').map((w) => w.trim()).filter(Boolean)
+          : [],
+        intertext_score: newIntertext.scholar_score,
+        notes: newIntertext.notes.trim(),
+        share_to_public: newIntertext.is_public,
       };
-      delete payload.matched_words;
-      
-      const res = await fetch('/api/intertexts', {
+
+      const res = await fetch('/api/intertexts/my', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
@@ -231,11 +276,10 @@ export default function Repository({ user }) {
       setShowAddModal(false);
       setNewIntertext({
         source_locus: '', source_text: '', target_locus: '', target_text: '',
-        language: 'la', notes: '', scholar_score: 0, is_public: true, matched_words: ''
+        language: 'la', notes: '', scholar_score: 0, is_public: false, matched_words: ''
       });
-      loadIntertexts();
-      if (user) loadMyIntertexts();
-      loadStats();
+      loadMyIntertexts();
+      loadPublicIntertexts();
     } catch (err) {
       alert('Failed to add intertext: ' + err.message);
     }
@@ -243,34 +287,118 @@ export default function Repository({ user }) {
 
   const handleUpdateIntertext = async (id, updates) => {
     try {
-      const res = await fetch(`/api/intertexts/${id}`, {
+      const payload = { ...updates };
+      if ('scholar_score' in payload) {
+        payload.intertext_score = payload.scholar_score;
+        delete payload.scholar_score;
+      }
+      if ('is_public' in payload) {
+        payload.shared_to_public = payload.is_public;
+        delete payload.is_public;
+      }
+
+      const res = await fetch(`/api/intertexts/my/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(updates)
+        body: JSON.stringify(payload)
       });
       if (!res.ok) throw new Error('Failed to update');
-      if (viewMode === 'my') loadMyIntertexts();
-      else loadIntertexts();
+      loadMyIntertexts();
+      loadPublicIntertexts();
     } catch (err) {
       alert('Update failed: ' + err.message);
     }
   };
 
+  const handleUpdatePublicIntertext = async (id, updates) => {
+    try {
+      const payload = {};
+      if ('notes' in updates) {
+        payload.notes = updates.notes;
+      }
+      if ('scholar_score' in updates) {
+        payload.user_score = updates.scholar_score;
+      }
+
+      const res = await fetch(`/api/intertexts/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (!res.ok) throw new Error('Failed to update');
+      loadMyIntertexts();
+      loadPublicIntertexts();
+    } catch (err) {
+      alert('Update failed: ' + err.message);
+    }
+  };
+
+  const openEditModal = (item, scope = 'saved') => {
+    setEditingScope(scope);
+    setEditingItem({
+      ...item,
+      notes: item.notes || '',
+      scholar_score: item.scholar_score || 0,
+      is_public: item.is_public !== false,
+    });
+  };
+
+  const handleSaveEditedIntertext = async () => {
+    if (!editingItem) return;
+    if (!Number.isInteger(editingItem.scholar_score) || editingItem.scholar_score < 1 || editingItem.scholar_score > 5) {
+      alert('Please select a star rating before saving changes.');
+      return;
+    }
+
+    if (editingScope === 'public') {
+      await handleUpdatePublicIntertext(editingItem.id, {
+        notes: editingItem.notes || '',
+        scholar_score: editingItem.scholar_score,
+      });
+    } else {
+      await handleUpdateIntertext(editingItem.id, {
+        notes: editingItem.notes || '',
+        scholar_score: editingItem.scholar_score,
+        is_public: editingItem.is_public !== false,
+      });
+    }
+    setEditingItem(null);
+    setEditingScope('saved');
+  };
+
   const handleDeleteIntertext = async (id) => {
     if (!confirm('Delete this intertext?')) return;
     try {
-      await fetch(`/api/intertexts/${id}`, { method: 'DELETE' });
-      if (viewMode === 'my') loadMyIntertexts();
-      else loadIntertexts();
-      loadStats();
+      const res = await fetch(`/api/intertexts/my/${id}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error('Failed to delete');
+      loadMyIntertexts();
+      loadPublicIntertexts();
     } catch (err) {
       alert('Delete failed');
     }
   };
 
-  const filteredIntertexts = (viewMode === 'my' ? myIntertexts : intertexts).filter(item => {
+  const handleDeletePublicIntertext = async (id) => {
+    if (!confirm('Delete this public intertext?')) return;
+    try {
+      const res = await fetch(`/api/intertexts/${id}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error('Failed to delete');
+      loadMyIntertexts();
+      loadPublicIntertexts();
+    } catch (err) {
+      alert('Delete failed');
+    }
+  };
+
+  const isPublicView = viewMode === 'public';
+  const repositoryItems = isPublicView ? publicIntertexts : myIntertexts;
+
+  const filteredIntertexts = repositoryItems.filter(item => {
     if (filter.language !== 'all' && item.language !== filter.language) return false;
-    if (filter.status !== 'all' && item.status !== filter.status) return false;
+    if (!isPublicView) {
+      if (filter.status === 'shared' && !item.is_public) return false;
+      if (filter.status === 'private' && item.is_public) return false;
+    }
     return true;
   });
 
@@ -285,13 +413,22 @@ export default function Repository({ user }) {
     }
     return sortOrder === 'desc' ? -cmp : cmp;
   });
+  const personalStats = {
+    total: myIntertexts.length,
+    shared: myIntertexts.filter((item) => item.is_public).length,
+  };
+
+  const publicStats = {
+    total: publicIntertexts.length,
+    withNotes: publicIntertexts.filter((item) => item.notes).length,
+  };
 
   const groupedByWork = (() => {
     const groups = {};
     filteredIntertexts.forEach(item => {
       const lang = item.language || 'la';
-      const author = item.source_author || item.source_locus?.split(',')[0]?.trim() || 'Unknown';
-      const work = item.source_work || item.source_locus?.split(',')[1]?.trim() || 'Unknown';
+      const author = item.source?.author || item.source_author || item.source_locus?.split(',')[0]?.trim() || 'Unknown';
+      const work = item.source?.work || item.source_work || item.source_locus?.split(',')[1]?.trim() || 'Unknown';
       
       if (!groups[lang]) groups[lang] = {};
       if (!groups[lang][author]) groups[lang][author] = {};
@@ -314,14 +451,14 @@ export default function Repository({ user }) {
   const langNames = { la: 'Latin', grc: 'Greek', en: 'English', cross: 'Greek-Latin' };
 
   const exportCSV = useCallback(() => {
-    const headers = ['Source', 'Target', 'Language', 'Score', 'Scholar Score', 'Status', 'Notes', 'Created'];
+    const headers = ['Source', 'Target', 'Language', 'Match Score', 'Your Rating', 'Visibility', 'Notes', 'Created'];
     const rows = sortedIntertexts.map(item => [
       item.source_locus || '',
       item.target_locus || '',
       item.language || '',
       item.score || '',
       item.scholar_score || '',
-      item.status || '',
+      item.is_public ? 'shared' : 'private',
       (item.notes || '').replace(/"/g, '""'),
       item.created_at || ''
     ]);
@@ -359,20 +496,35 @@ export default function Repository({ user }) {
     <div className="space-y-6">
       <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between">
         <div>
-          <h2 className="text-xl font-semibold text-gray-900">Intertext Repository</h2>
+          <h2 className="text-xl font-semibold text-gray-900">
+            {isPublicView ? 'Public Repository' : 'My Repository'}
+          </h2>
           <p className="text-sm text-gray-500 mt-1">
-            Browse and manage discovered textual parallels
+            {isPublicView
+              ? 'Browse parallels that users chose to make publicly visible.'
+              : 'Review and manage the parallels you have saved with your own comments and ratings'}
           </p>
         </div>
-        {stats && (
+        {isPublicView ? (
           <div className="flex gap-4 text-sm">
             <div className="text-center">
-              <div className="text-2xl font-bold text-red-700">{stats.total || 0}</div>
-              <div className="text-gray-500">Total</div>
+              <div className="text-2xl font-bold text-red-700">{publicStats.total}</div>
+              <div className="text-gray-500">Visible</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-amber-600">{stats.flagged || 0}</div>
-              <div className="text-gray-500">Flagged</div>
+              <div className="text-2xl font-bold text-amber-600">{publicStats.withNotes}</div>
+              <div className="text-gray-500">With Notes</div>
+            </div>
+          </div>
+        ) : (
+          <div className="flex gap-4 text-sm">
+            <div className="text-center">
+              <div className="text-2xl font-bold text-red-700">{personalStats.total}</div>
+              <div className="text-gray-500">Saved</div>
+            </div>
+            <div className="text-center">
+              <div className="text-2xl font-bold text-amber-600">{personalStats.shared}</div>
+              <div className="text-gray-500">Shared</div>
             </div>
           </div>
         )}
@@ -382,24 +534,26 @@ export default function Repository({ user }) {
         <div className="flex flex-wrap gap-4 items-center justify-between">
           <div className="flex gap-2">
             <button
-              onClick={() => setViewMode('browse')}
-              className={`px-4 py-2 rounded text-sm ${viewMode === 'browse' ? 'bg-red-700 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}
+              onClick={() => setViewMode('public')}
+              className={`px-4 py-2 rounded text-sm ${viewMode === 'public' ? 'bg-red-700 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}
             >
-              List View
-            </button>
-            <button
-              onClick={() => setViewMode('byWork')}
-              className={`px-4 py-2 rounded text-sm ${viewMode === 'byWork' ? 'bg-red-700 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}
-            >
-              By Work
+              Public Repository
             </button>
             {user && (
-              <button
-                onClick={() => setViewMode('my')}
-                className={`px-4 py-2 rounded text-sm ${viewMode === 'my' ? 'bg-red-700 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}
-              >
-                My Intertexts
-              </button>
+              <>
+                <button
+                  onClick={() => setViewMode('my')}
+                  className={`px-4 py-2 rounded text-sm ${viewMode === 'my' ? 'bg-red-700 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}
+                >
+                  My Saved
+                </button>
+                <button
+                  onClick={() => setViewMode('byWork')}
+                  className={`px-4 py-2 rounded text-sm ${viewMode === 'byWork' ? 'bg-red-700 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}
+                >
+                  By Work
+                </button>
+              </>
             )}
           </div>
           <div className="flex gap-3 flex-wrap">
@@ -414,14 +568,17 @@ export default function Repository({ user }) {
               <option value="en">English</option>
               <option value="cross">Greek-Latin</option>
             </select>
-            <select
-              value={filter.status}
-              onChange={e => setFilter({ ...filter, status: e.target.value })}
-              className="border rounded px-3 py-2 text-sm"
-            >
-              <option value="all">All Entries</option>
-              <option value="flagged">Flagged Only</option>
-            </select>
+            {!isPublicView && (
+              <select
+                value={filter.status}
+                onChange={e => setFilter({ ...filter, status: e.target.value })}
+                className="border rounded px-3 py-2 text-sm"
+              >
+                <option value="all">All Entries</option>
+                <option value="private">Private Only</option>
+                <option value="shared">Shared Publicly</option>
+              </select>
+            )}
             <select
               value={sortBy}
               onChange={e => setSortBy(e.target.value)}
@@ -429,7 +586,7 @@ export default function Repository({ user }) {
             >
               <option value="created_at">Date</option>
               <option value="score">Match Score</option>
-              <option value="scholar_score">Scholar Score</option>
+              <option value="scholar_score">Your Rating</option>
             </select>
             <button
               onClick={exportCSV}
@@ -437,7 +594,15 @@ export default function Repository({ user }) {
             >
               Export CSV
             </button>
-            {user && (
+            {!user && (
+              <button
+                onClick={() => window.dispatchEvent(new CustomEvent('open-public-auth-modal', { detail: { mode: 'login' } }))}
+                className="px-3 py-2 bg-red-700 text-white rounded hover:bg-red-800 text-sm"
+              >
+                Sign In To Save
+              </button>
+            )}
+            {user && !isPublicView && (
               <button
                 onClick={() => setShowAddModal(true)}
                 className="px-3 py-2 bg-red-700 text-white rounded hover:bg-red-800 text-sm"
@@ -451,8 +616,10 @@ export default function Repository({ user }) {
 
       {filteredIntertexts.length === 0 ? (
         <div className="bg-white rounded-lg shadow p-8 text-center text-gray-500">
-          {viewMode === 'my' 
-            ? "You haven't saved any intertexts yet. Run a search and click 'Register' to save parallels."
+          {isPublicView
+            ? 'No public intertexts found matching your filters.'
+            : viewMode === 'my'
+            ? "You haven't saved any intertexts yet. Run a search and click 'Register' to save a parallel with your notes and rating."
             : "No intertexts found matching your filters."
           }
         </div>
@@ -504,9 +671,9 @@ export default function Repository({ user }) {
                                   <div key={item.id || i} className="px-4 py-3 bg-white hover:bg-gray-50 border-b border-gray-100">
                                     <div className="flex items-start justify-between gap-2 mb-2">
                                       <div className="flex items-center gap-2 flex-wrap">
-                                        {item.status === 'flagged' && (
-                                          <span className="text-xs px-2 py-0.5 rounded bg-amber-100 text-amber-700">flagged</span>
-                                        )}
+                                        <span className={`text-xs px-2 py-0.5 rounded ${item.is_public ? 'bg-green-100 text-green-700' : 'bg-gray-200 text-gray-600'}`}>
+                                          {item.is_public ? 'shared' : 'private'}
+                                        </span>
                                         <span className="text-xs text-gray-400">
                                           Score: {item.score?.toFixed?.(2) || item.score || '-'}
                                         </span>
@@ -514,16 +681,6 @@ export default function Repository({ user }) {
                                           <span className="text-xs text-amber-600">{'★'.repeat(item.scholar_score)}</span>
                                         )}
                                       </div>
-                                      {user && (
-                                        <button
-                                          onClick={() => handleUpdateIntertext(item.id, { status: item.status === 'flagged' ? 'confirmed' : 'flagged' })}
-                                          className={`text-xs px-2 py-0.5 rounded ${
-                                            item.status === 'flagged' ? 'bg-amber-100 text-amber-700' : 'bg-gray-100 text-gray-500'
-                                          }`}
-                                        >
-                                          {item.status === 'flagged' ? '⚑' : '⚐'}
-                                        </button>
-                                      )}
                                     </div>
                                     <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm">
                                       <div className="bg-gray-50 p-2 rounded">
@@ -562,14 +719,17 @@ export default function Repository({ user }) {
           <div className="divide-y divide-gray-200">
             {sortedIntertexts.slice(0, displayLimit).map((item, i) => (
               <div key={item.id || i} className="p-4 hover:bg-gray-50">
+                {(() => {
+                  const canDeletePublicItem = isPublicView && user && item.submitter_id && String(item.submitter_id) === String(user.id);
+                  const canEditPublicItem = canDeletePublicItem;
+                  const canEditSavedItem = viewMode === 'my' && user;
+                  return (
                 <div className="flex items-start justify-between gap-4 mb-2">
                   <div className="flex-1">
                     <div className="flex items-center gap-2 mb-1 flex-wrap">
-                      {item.status === 'flagged' && (
-                        <span className="text-xs px-2 py-0.5 rounded bg-amber-100 text-amber-700">
-                          flagged
-                        </span>
-                      )}
+                      <span className={`text-xs px-2 py-0.5 rounded ${item.is_public ? 'bg-green-100 text-green-700' : 'bg-gray-200 text-gray-600'}`}>
+                        {item.is_public ? 'shared' : 'private'}
+                      </span>
                       <span className="text-xs text-gray-500">
                         {(() => {
                           const lang = item.language || item.source?.language || 'en';
@@ -587,9 +747,6 @@ export default function Repository({ user }) {
                       {item.scholar_score > 0 && (
                         <StarRating value={item.scholar_score} readOnly />
                       )}
-                      {item.is_public === false && (
-                        <span className="text-xs px-2 py-0.5 rounded bg-gray-200 text-gray-600">Private</span>
-                      )}
                     </div>
                   </div>
                   <div className="flex items-center gap-2">
@@ -598,23 +755,10 @@ export default function Repository({ user }) {
                         {new Date(item.created_at).toLocaleDateString()}
                       </span>
                     )}
-                    {user && (
-                      <button
-                        onClick={() => handleUpdateIntertext(item.id, { status: item.status === 'flagged' ? 'confirmed' : 'flagged' })}
-                        className={`text-xs px-2 py-1 rounded ${
-                          item.status === 'flagged' 
-                            ? 'bg-amber-100 text-amber-700 hover:bg-amber-200' 
-                            : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
-                        }`}
-                        title={item.status === 'flagged' ? 'Remove flag' : 'Flag as problematic'}
-                      >
-                        {item.status === 'flagged' ? '⚑ Unflag' : '⚐ Flag'}
-                      </button>
-                    )}
-                    {viewMode === 'my' && user && (
+                    {canEditSavedItem && (
                       <div className="flex gap-1">
                         <button
-                          onClick={() => setEditingItem(item)}
+                          onClick={() => openEditModal(item, 'saved')}
                           className="text-xs px-2 py-1 bg-gray-100 rounded hover:bg-gray-200"
                         >
                           Edit
@@ -627,8 +771,26 @@ export default function Repository({ user }) {
                         </button>
                       </div>
                     )}
+                    {canEditPublicItem && (
+                      <button
+                        onClick={() => openEditModal(item, 'public')}
+                        className="text-xs px-2 py-1 bg-gray-100 rounded hover:bg-gray-200"
+                      >
+                        Edit
+                      </button>
+                    )}
+                    {canDeletePublicItem && (
+                      <button
+                        onClick={() => handleDeletePublicIntertext(item.id)}
+                        className="text-xs px-2 py-1 bg-red-100 text-red-700 rounded hover:bg-red-200"
+                      >
+                        Delete
+                      </button>
+                    )}
                   </div>
                 </div>
+                  );
+                })()}
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                   <div className="bg-gray-50 p-3 rounded">
                     <div className="text-xs text-red-600 mb-1 font-medium">
@@ -684,7 +846,7 @@ export default function Repository({ user }) {
       )}
 
       {showAddModal && (
-        <Modal onClose={() => setShowAddModal(false)} title="Add Manual Intertext">
+        <Modal isOpen={showAddModal} onClose={() => setShowAddModal(false)} title="Add Manual Intertext">
           <div className="space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
@@ -741,11 +903,14 @@ export default function Repository({ user }) {
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Scholar Score</label>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Your Rating</label>
                 <StarRating 
                   value={newIntertext.scholar_score} 
                   onChange={score => setNewIntertext({...newIntertext, scholar_score: score})}
                 />
+                <p className="text-xs text-gray-400 mt-1">
+                  {newIntertext.scholar_score > 0 ? `${newIntertext.scholar_score}/5 selected` : 'Required'}
+                </p>
               </div>
             </div>
             <div>
@@ -783,7 +948,7 @@ export default function Repository({ user }) {
                 checked={newIntertext.is_public}
                 onChange={e => setNewIntertext({...newIntertext, is_public: e.target.checked})}
               />
-              <label htmlFor="is_public" className="text-sm text-gray-700">Make this intertext public</label>
+              <label htmlFor="is_public" className="text-sm text-gray-700">Share this intertext publicly</label>
             </div>
             <div className="flex justify-end gap-2 pt-4">
               <button
@@ -794,7 +959,7 @@ export default function Repository({ user }) {
               </button>
               <button
                 onClick={handleAddIntertext}
-                disabled={!newIntertext.source_locus || !newIntertext.target_locus}
+                disabled={!newIntertext.source_locus || !newIntertext.target_locus || newIntertext.scholar_score < 1}
                 className="px-4 py-2 bg-red-700 text-white rounded hover:bg-red-800 disabled:opacity-50"
               >
                 Add Intertext
@@ -805,17 +970,65 @@ export default function Repository({ user }) {
       )}
 
       {editingItem && (
-        <Modal onClose={() => setEditingItem(null)} title="Edit Intertext">
+        <Modal isOpen={Boolean(editingItem)} onClose={() => {
+          setEditingItem(null);
+          setEditingScope('saved');
+        }} title="Edit Intertext">
           <div className="space-y-4">
+            <div className="bg-gray-50 p-4 rounded">
+              <div className="text-sm text-gray-500 mb-1">Source</div>
+              <div className="font-medium text-red-700">{editingItem.source?.reference || editingItem.source_locus}</div>
+              <div className="text-sm text-gray-700 mt-1">
+                {(editingItem.source?.snippet || editingItem.source_text || '').substring(0, 140)}
+                {(editingItem.source?.snippet || editingItem.source_text || '').length > 140 ? '...' : ''}
+              </div>
+              <div className="text-sm text-gray-500 mt-3 mb-1">Target</div>
+              <div className="font-medium text-amber-600">{editingItem.target?.reference || editingItem.target_locus}</div>
+              <div className="text-sm text-gray-700 mt-1">
+                {(editingItem.target?.snippet || editingItem.target_text || '').substring(0, 140)}
+                {(editingItem.target?.snippet || editingItem.target_text || '').length > 140 ? '...' : ''}
+              </div>
+            </div>
+            {editingScope === 'saved' && (
+              <div>
+                <div className="text-sm text-gray-600 mb-2">Visibility:</div>
+                <div className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
+                  <button
+                    type="button"
+                    onClick={() => setEditingItem({ ...editingItem, is_public: false })}
+                    className={`px-3 py-1.5 text-sm rounded ${
+                      editingItem.is_public === false
+                        ? 'bg-white text-gray-900 shadow-sm'
+                        : 'text-gray-600 hover:text-gray-800'
+                    }`}
+                  >
+                    Private
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setEditingItem({ ...editingItem, is_public: true })}
+                    className={`px-3 py-1.5 text-sm rounded ${
+                      editingItem.is_public !== false
+                        ? 'bg-white text-red-700 shadow-sm'
+                        : 'text-gray-600 hover:text-gray-800'
+                    }`}
+                  >
+                    Make Public
+                  </button>
+                </div>
+              </div>
+            )}
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Scholar Score</label>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Your Rating</label>
               <StarRating 
                 value={editingItem.scholar_score || 0} 
                 onChange={score => {
-                  handleUpdateIntertext(editingItem.id, { scholar_score: score });
                   setEditingItem({...editingItem, scholar_score: score});
                 }}
               />
+              <p className="text-xs text-gray-400 mt-1">
+                {editingItem.scholar_score > 0 ? `${editingItem.scholar_score}/5 selected` : 'Required'}
+              </p>
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -833,31 +1046,20 @@ export default function Repository({ user }) {
                 className="w-full border rounded px-3 py-2 text-sm"
               />
             </div>
-            <div className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                id="edit_is_public"
-                checked={editingItem.is_public !== false}
-                onChange={e => {
-                  handleUpdateIntertext(editingItem.id, { is_public: e.target.checked });
-                  setEditingItem({...editingItem, is_public: e.target.checked});
-                }}
-              />
-              <label htmlFor="edit_is_public" className="text-sm text-gray-700">Public (visible to others)</label>
-            </div>
             <div className="flex justify-end gap-2 pt-4">
               <button
-                onClick={() => setEditingItem(null)}
+                onClick={() => {
+                  setEditingItem(null);
+                  setEditingScope('saved');
+                }}
                 className="px-4 py-2 text-gray-600 hover:text-gray-800"
               >
                 Cancel
               </button>
               <button
-                onClick={() => {
-                  handleUpdateIntertext(editingItem.id, { notes: editingItem.notes });
-                  setEditingItem(null);
-                }}
-                className="px-4 py-2 bg-red-700 text-white rounded hover:bg-red-800"
+                onClick={handleSaveEditedIntertext}
+                disabled={editingItem.scholar_score < 1}
+                className="px-4 py-2 bg-red-700 text-white rounded hover:bg-red-800 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Save Changes
               </button>


### PR DESCRIPTION
## Summary

This branch adds Marvin password-auth support and admin session handling, expands admin user management, and updates repository behavior so saved parallels can be private or public. It also requires ratings for saved repository entries and exposes public repository content to signed-out users.

## What Changed

### Authentication and Login
- Switched the app auth path to Marvin password auth.
- Added auth metadata in `/api/auth/user` so the frontend can detect:
  - auth availability
  - password auth mode
  - whether self-registration is enabled
- Added stronger password policy checks:
  - minimum length
  - uppercase
  - lowercase
  - number
  - special character
- Added self-registration support for public users.
- Automatically assigns the `USER` role on self-registration.
- Blocks admin-role accounts from logging in through the public user login flow.
- Added clearer auth logging around registration, login, logout, and password reset.

### Admin Session Behavior
- Added admin session detection from the public app shell.
- When an admin session is active, public navigation is locked to the admin panel until logout.
- Added explicit admin-session change events so header/app shell stay in sync.
- Added admin logout handling from the locked admin navigation state.

### Admin User Management
- Expanded admin user creation so admins can create `USER` accounts.
- Restricted creation of `ADMIN` and `SUPER_ADMIN` accounts to `SUPER_ADMIN`.
- Added user deletion from the admin users screen.
- Prevented self-delete for the currently logged-in admin.
- Added protections around deleting protected admin accounts.
- Tightened role-management behavior for `USER` accounts and added better privilege checks and audit/logging.

### Public Auth / Register Testing
- Added a hidden `RegisterUserTestPage` for testing password register/sign-in flows.
- Exported/routed the page so it can be used directly for auth testing.

### Repository and Public Visibility
- Added the ability to save repository entries as either:
  - private
  - public
- Signed-out users can now browse publicly visible repository entries.
- Signed-in users can still manage their own saved repository separately.
- Public repository entries stay synchronized with saved copies.
- Switching a saved item back to private removes the linked public copy.
- Deleting a linked saved/public item now keeps the related visibility state consistent.
- Public repository delete actions are owner-only.

### Ratings
- Star rating is now required when saving repository entries.
- Validation is enforced both:
  - in the frontend
  - in the backend API (`1-5` only)

### Repository Editing UX
- The repository edit modal now works correctly.
- Editing behaves more like the save/register flow:
  - preview text shown
  - rating editable
  - notes editable
  - visibility editable for saved entries
- Public owner edits and deletes are routed to the correct backend endpoints.

### Help / Text Request UX
- Help page request fields are prefilled from the logged-in user’s name and email.

## Backend Files
- `backend/app.py`
- `backend/marvin_auth.py`
- `backend/blueprints/admin.py`
- `backend/blueprints/intertext.py`

## Frontend Files
- `client/src/App.jsx`
- `client/src/components/layout/Header.jsx`
- `client/src/components/layout/Navigation.jsx`
- `client/src/components/admin/AdminPanel.jsx`
- `client/src/components/admin/tabs/UsersTab.jsx`
- `client/src/components/repository/Repository.jsx`
- `client/src/components/pages/HelpPage.jsx`
- `client/src/components/pages/RegisterUserTestPage.jsx`
- `client/src/components/pages/index.js`

## Validation Performed
- `python -m py_compile backend/blueprints/intertext.py`
- `python -m py_compile main.py`
- `npm run build`

## Notes
- `dist/` output and local HTTPS runner changes were intentionally not part of the pushed branch.
- A later local merge from `origin/main` was not pushed, so the remote branch only contains the source changes from this feature work.
