### PR TITLE
Make lemma cache filenames ASCII-safe

### DIFF
--- a/backend/lemma_cache.py
+++ b/backend/lemma_cache.py
@@ -5,6 +5,7 @@ Pre-computes and caches lemmatized text units for faster searches
 import os
 import json
 import hashlib
+import unicodedata
 from datetime import datetime
 from backend.utils import resolve_text_path
 
@@ -20,15 +21,56 @@ def get_file_hash(filepath):
     with open(filepath, 'rb') as f:
         return hashlib.md5(f.read()).hexdigest()
 
-def get_cache_path(text_id, language):
-    """Get path to cached lemma file"""
+def _is_ascii(text):
+    """Return True when text can be safely used in ASCII-only environments."""
+    try:
+        text.encode('ascii')
+        return True
+    except UnicodeEncodeError:
+        return False
+
+def _legacy_cache_path(text_id, language):
+    """Get the pre-v2 cache path that used the raw text ID in the filename."""
     safe_id = text_id.replace('/', '_').replace('.tess', '')
     return os.path.join(CACHE_DIR, language, f"{safe_id}.json")
+
+def get_cache_path(text_id, language):
+    """Get an ASCII-safe path to a cached lemma file.
+
+    The cache filename must stay ASCII-only because some production WSGI
+    environments expose an ASCII filesystem locale. Hashing the normalized
+    text ID keeps filenames stable across NFC/NFD variants and avoids Unicode
+    encode errors for Greek work IDs.
+    """
+    normalized_id = unicodedata.normalize('NFC', text_id)
+    stem = normalized_id.replace('/', '_').replace('.tess', '')
+    digest = hashlib.md5(normalized_id.encode('utf-8')).hexdigest()
+
+    ascii_hint = ''.join(
+        c if c.isalnum() or c in '._-' else '_'
+        for c in stem
+        if ord(c) < 128
+    ).strip('._-')
+    if not ascii_hint:
+        ascii_hint = 'text'
+
+    filename = f"{ascii_hint[:64]}-{digest}.json"
+    return os.path.join(CACHE_DIR, language, filename)
 
 def get_cached_units(text_id, language):
     """Load pre-computed units from cache if available and valid"""
     cache_path = get_cache_path(text_id, language)
-    if not os.path.exists(cache_path):
+    if os.path.exists(cache_path):
+        candidate_paths = [cache_path]
+    elif _is_ascii(text_id):
+        # Preserve existing cache hits for ASCII-only text IDs created before
+        # the ASCII-safe hashed naming scheme.
+        legacy_path = _legacy_cache_path(text_id, language)
+        candidate_paths = [legacy_path] if os.path.exists(legacy_path) else []
+    else:
+        candidate_paths = []
+
+    if not candidate_paths:
         return None
     
     text_path = resolve_text_path(TEXTS_DIR, language, text_id)
@@ -36,14 +78,13 @@ def get_cached_units(text_id, language):
         return None
     
     try:
-        with open(cache_path, 'r', encoding='utf-8') as f:
-            cached = json.load(f)
-        
         current_hash = get_file_hash(text_path)
-        if cached.get('file_hash') != current_hash:
-            return None
-        
-        return cached
+        for candidate_path in candidate_paths:
+            with open(candidate_path, 'r', encoding='utf-8') as f:
+                cached = json.load(f)
+            if cached.get('file_hash') == current_hash:
+                return cached
+        return None
     except (json.JSONDecodeError, IOError):
         return None
 

--- a/tests/test_lemma_cache.py
+++ b/tests/test_lemma_cache.py
@@ -1,0 +1,104 @@
+import json
+import os
+import sys
+import unicodedata
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from backend import lemma_cache
+
+
+@pytest.fixture
+def isolated_cache_dirs(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache" / "lemmas"
+    texts_dir = tmp_path / "texts"
+    monkeypatch.setattr(lemma_cache, "CACHE_DIR", str(cache_dir))
+    monkeypatch.setattr(lemma_cache, "TEXTS_DIR", str(texts_dir))
+    return cache_dir, texts_dir
+
+
+def _write_text_file(texts_dir, language, filename, content="line one\nline two\n"):
+    lang_dir = texts_dir / language
+    lang_dir.mkdir(parents=True, exist_ok=True)
+    path = lang_dir / filename
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+class TestCachePathNaming:
+    def test_greek_text_id_produces_ascii_only_cache_path(self, isolated_cache_dirs):
+        cache_dir, _ = isolated_cache_dirs
+        text_id = "tryphon_i_grammaticus.περὶ_τρόπων.tess"
+
+        cache_path = lemma_cache.get_cache_path(text_id, "grc")
+
+        assert cache_path.startswith(str(cache_dir))
+        assert cache_path.endswith(".json")
+        assert all(ord(ch) < 128 for ch in cache_path)
+        assert "tryphon_i_grammaticus" in os.path.basename(cache_path)
+
+    def test_unicode_normalization_variants_map_to_same_cache_path(self, isolated_cache_dirs):
+        nfc_text_id = "tryphon_i_grammaticus.περὶ_τρόπων.tess"
+        nfd_text_id = unicodedata.normalize("NFD", nfc_text_id)
+
+        assert nfc_text_id != nfd_text_id
+        assert lemma_cache.get_cache_path(nfc_text_id, "grc") == lemma_cache.get_cache_path(nfd_text_id, "grc")
+
+
+class TestCachedUnitLoading:
+    def test_save_and_load_cached_units_for_greek_text_id(self, isolated_cache_dirs):
+        cache_dir, texts_dir = isolated_cache_dirs
+        text_id = "tryphon_i_grammaticus.περὶ_τρόπων.tess"
+        text_path = _write_text_file(texts_dir, "grc", text_id)
+        file_hash = lemma_cache.get_file_hash(str(text_path))
+
+        units_line = [{"ref": "1", "text": "alpha"}]
+        units_phrase = [{"ref": "1", "text": "alpha beta"}]
+
+        assert lemma_cache.save_cached_units(text_id, "grc", units_line, units_phrase, file_hash) is True
+
+        cache_path = lemma_cache.get_cache_path(text_id, "grc")
+        assert os.path.exists(cache_path)
+        assert all(ord(ch) < 128 for ch in cache_path)
+
+        cached = lemma_cache.get_cached_units(text_id, "grc")
+
+        assert cached is not None
+        assert cached["text_id"] == text_id
+        assert cached["units_line"] == units_line
+        assert cached["units_phrase"] == units_phrase
+        assert cached["file_hash"] == file_hash
+        assert not os.path.exists(lemma_cache._legacy_cache_path(text_id, "grc"))
+
+    def test_ascii_text_id_can_still_load_legacy_cache_file(self, isolated_cache_dirs):
+        _, texts_dir = isolated_cache_dirs
+        text_id = "vergil.aeneid.tess"
+        text_path = _write_text_file(texts_dir, "la", text_id)
+        file_hash = lemma_cache.get_file_hash(str(text_path))
+
+        legacy_path = lemma_cache._legacy_cache_path(text_id, "la")
+        os.makedirs(os.path.dirname(legacy_path), exist_ok=True)
+        with open(legacy_path, "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "text_id": text_id,
+                    "language": "la",
+                    "file_hash": file_hash,
+                    "units_line": [{"ref": "1", "text": "arma"}],
+                    "units_phrase": [{"ref": "1", "text": "arma virumque"}],
+                },
+                f,
+            )
+
+        hashed_path = lemma_cache.get_cache_path(text_id, "la")
+        assert hashed_path != legacy_path
+        assert not os.path.exists(hashed_path)
+
+        cached = lemma_cache.get_cached_units(text_id, "la")
+
+        assert cached is not None
+        assert cached["text_id"] == text_id
+        assert cached["file_hash"] == file_hash
+        assert cached["units_line"] == [{"ref": "1", "text": "arma"}]


### PR DESCRIPTION
# Fix Greek Text Search ASCII Cache Path Failure

## Summary

This change makes lemma cache filenames ASCII-safe by hashing the normalized text ID instead of using the raw text ID directly in the cache filename.

It fixes Greek search failures for texts whose IDs include non-ASCII characters, such as `tryphon_i_grammaticus.περὶ_τρόπων.tess`.

## Root Cause

The backend lemma cache used the raw `text_id` to build on-disk cache filenames.

For Greek works, that produced cache paths containing non-ASCII characters. In ASCII-locale WSGI environments, filesystem operations on those paths could raise:

`UnicodeEncodeError: 'ascii' codec can't encode characters ...`

The request path resolution logic was already Unicode-aware, but the cache layer still depended on raw Unicode filenames.

## What Changed

- Reworked lemma cache filename generation to produce ASCII-only cache filenames.
- Normalized text IDs before hashing so NFC/NFD variants map to the same cache file.
- Preserved compatibility for existing ASCII-only cache files by falling back to the legacy cache naming scheme when appropriate.

## Impact

- Greek text searches no longer fail because of non-ASCII cache filenames.
- Existing ASCII-based cache entries for Latin and other ASCII-only text IDs continue to work.
- Existing non-ASCII cache files are not reused and will be regenerated once under the new naming scheme.

## Validation

- Verified the new cache path for a Greek text ID is ASCII-only.
- Verified the new cache path for an ASCII text ID is ASCII-only.
- Confirmed legacy ASCII cache fallback path is still available.
- Ran:

```bash
python -m py_compile backend/lemma_cache.py
```

## Notes

This is a targeted backend fix in `backend/lemma_cache.py`. No frontend behavior or API contract changed.
