### PR TITLE
Clean up text credits and resolve print sources (Issue #79)

### DIFF
--- a/backend/text_sources.json
+++ b/backend/text_sources.json
@@ -8,6 +8,30 @@
     "added_by": "Emilie Redwood"
   },
   {
+    "author": "Acta Joannis",
+    "work": "Acta Joannis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0317.tlg001/",
+    "print_source": "Acta Joannis. Acta Apostolorum Apocrypha, Part 2, Vol. 1. Bonnet, Maximilian, editor. Leipzig: H. Mendelssohn, 1898.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Adamnan",
+    "work": "De Locis Santis",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0007.stoa002/",
+    "print_source": "Adamnan, Saint. Itinera hierosolymitana saecvli IIII-VIII (Corpus scriptorum ecclesiasticorum Latinorum, Volume 39). Geyer, Paul, editor. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1898.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aedelwulfus, monachus Lindisfarnensis",
+    "work": "Carmen de Abbatibus",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/AEDELW%7Ccarm%7C000",
+    "print_source": "Th. Arnold, 1882",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
     "author": "Aelian",
     "work": "De Natura Animalium",
     "e_source": "Perseus",
@@ -22,6 +46,14 @@
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0592",
     "print_source": "Rudolf Hercher, Claudii Aeliani de natura animalium libri xvii, varia historia, epistolae, fragmenta, Vol 2. Lipsiae: In Aedibus B.G. Teubneri, 1866.",
     "added_by": "Emilie Redwood"
+  },
+  {
+    "author": "Aelian",
+    "work": "Fragments",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0545.tlg004/",
+    "print_source": "Rudolf Hercher, Claudii Aeliani De Animalium Natura Libri XVII, Varia Historia, Epistolae Fragmenta., Leipzig. Teubner. 1866, Vol. 2",
+    "added_by": "V6 Import"
   },
   {
     "author": "Aelian",
@@ -48,12 +80,68 @@
     "added_by": "Rudra Chakraborty"
   },
   {
+    "author": "Aelius Herodianus",
+    "work": "On Enclitics",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0087.tlg002/",
+    "print_source": "August Lentz, Herodiani technici reliquiae, Leipzig. Teubner. 1867, Vol. 1",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aelius Herodianus",
+    "work": "On Universal Prosody",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0087.tlg001/",
+    "print_source": "Augustus Lentz, Grammatici Graeci, Leipzig. Teubner. 1867, Vol. 3.1",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aelius Theon",
+    "work": "Progymnasmata",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0607.tlg001/",
+    "print_source": "Aelius Theon, Ars rhetorica, Rhetores Graeci, Volume 2, Spengel, Teubner, 1855",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aeschines",
+    "work": "Against Ctesiphon",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0026.tlg003/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aeschines",
+    "work": "Against Timarchus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0026.tlg001/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aeschines",
+    "work": "On the Embassy",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0026.tlg002/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Aeschines",
     "work": "Speeches (Greek). Machine readable text",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.01.0001",
     "print_source": "Aeschines with an English translation by Charles Darwin Adams, Ph.D..Cambridge, MA, Harvard University Press; London, William Heinemann Ltd., 1919.",
     "added_by": "Elizabeth Hunter"
+  },
+  {
+    "author": "Aeschines Sp",
+    "work": "Epistles",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0026.tlg004/",
+    "print_source": "Friedrich Blass, Aeschinis. Orationes., Leipzig. Teubner. 1896",
+    "added_by": "V6 Import"
   },
   {
     "author": "Aeschylus",
@@ -81,6 +169,14 @@
   },
   {
     "author": "Aeschylus",
+    "work": "Persae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0085.tlg002/",
+    "print_source": "Arthur Sidgwick, Aeschyli Tragoediae, Oxford. Clarendon Press. 1902",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aeschylus",
     "work": "Persians",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.01.0005",
@@ -94,6 +190,14 @@
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.01.0009",
     "print_source": "Herbert Weir Smyth, Ph.D., Aeschylus, with an English translation by Herbert Weir Smyth, Ph. D. in two volumes.. Cambridge: Cambridge, Mass., Harvard University Press; London, William Heinemann, Ltd., 1926.",
     "added_by": "Anna Glenn"
+  },
+  {
+    "author": "Aeschylus",
+    "work": "Septem Contra Thebas",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0085.tlg004/",
+    "print_source": "Arthur Sidgwick, Aeschyli Tragoediae, Oxford. Clarendon Press. 1902",
+    "added_by": "V6 Import"
   },
   {
     "author": "Aeschylus",
@@ -112,11 +216,139 @@
     "added_by": "Anna Glenn"
   },
   {
+    "author": "Aeschylus",
+    "work": "Supplices",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0085.tlg001/",
+    "print_source": "Arthur Sidgwick, Aeschyli Tragoediae, Oxford. Clarendon Press. 1902",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aesop",
+    "work": "Collection of Fables",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0096.tlg002/",
+    "print_source": "Fabulae Aesopicae Collectae. Halm, Karl, editor. Leipzig: Teubner, 1872",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aesop",
+    "work": "Fabulae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0096.tlg002/",
+    "print_source": "Fabulae Aesopicae Collectae. Halm, Karl, editor. Leipzig: Teubner, 1872",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aethelwulf",
+    "work": "Carmen de Abbatibus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Agatharchides",
+    "work": "Ex Agatharchidis de Maris Erythraeo Libri Excerpta",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0067.tlg001/",
+    "print_source": "Agatharchides, creator; Geographi graeci minores Volumen Primum, ed. Karl Müller; Ambroise Firmin Didot, Paris, 1855",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Agathemerus",
+    "work": "Geographiae Informatio",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0090.tlg001/",
+    "print_source": "Agathemerus, creator; Müller, Karl, editor.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Agius of Corvey",
+    "work": "Epicedium Hathumodae",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Agius of Corvey",
+    "work": "Versus Computistici",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Agius, monachus Corbeiensis",
+    "work": "Carmina de Ludovico II",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/CARM_LU2%7Ccarm%7C001",
+    "print_source": "L. Traube 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Agius, monachus Corbeiensis",
+    "work": "Epicedium Hathumodae",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/AGIUS%7Cepha%7C001",
+    "print_source": "L. Traube, 1886-9",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Agius, monachus Corbeiensis",
+    "work": "Versus Computistici",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "",
+    "print_source": "K. Strecker, 1923",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Agnellus Ravennas",
+    "work": "Liber Pontificalis",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/AGNELL%7Cpont%7C001",
+    "print_source": "O. Holder-Egger, 1878",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Aimoin of Saint Germain",
+    "work": "Carmen de Translatione Vincentii",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aimoinus Sangermanensis",
+    "work": "Carmen de Translatione Vincentii",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/AIMOIN%7Ctrvi%7C001",
+    "print_source": "P. v. Winterfeld, 1899",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Alcidamas",
+    "work": "Odysseus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0610.tlg001/",
+    "print_source": "Friedrich Blass, Orationes et fragmenta, adivnctis Gorgiae, Antisthenis, Alcidamantis, declamationibvs, Lipsiae. Tevbneri. 1892",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Alcidamas",
+    "work": "On the Sophists",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0610.perseus002/",
+    "print_source": "Friedrich Blass, Orationes et fragmenta, adiunctis Gorgiae, Antisthenis, Alcidamantis, declamationibus, Leipzig. Teubner. 1892",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Alcuin",
     "work": "Carmina",
     "e_source": "",
     "e_source_url": "",
-    "print_source": "",
+    "print_source": "E. Dümmler, 1881",
     "added_by": "M. Paccara & F. Stella (University of Siena)"
   },
   {
@@ -124,30 +356,78 @@
     "work": "Carmina Rhytmica",
     "e_source": "",
     "e_source_url": "",
-    "print_source": "",
+    "print_source": "K. Strecker, 1923",
     "added_by": "M. Paccara & F. Stella (University of Siena)"
+  },
+  {
+    "author": "Amalarius",
+    "work": "Versus Marini",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Amalarius Symphosius Fortunatus, archiep. Treverensis et Lugdunensis",
+    "work": "Versus Marini",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/AMALAR%7Cvers%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Ambrose",
+    "work": "Apologia Altera Prophetae David",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0022.stoa014/",
+    "print_source": "Ambrose. Sanctii Ambrosii Opera, Pars Altera, (Corpus scriptorum ecclesiasticorum Latinorum, Volume 32.2). Schenkl, Karl, editor. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1897.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Ambrose",
     "work": "Apologia David Altera",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0022",
     "print_source": "Karl Schenkl. Sanctii Ambrosii Opera, Pars Altera. Vindobonae: Gerold. 1897.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Ambrose",
+    "work": "Apologia Prophetae David ad Theodosium a",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0022.stoa015/",
+    "print_source": "Ambrose. Sanctii Ambrosii Opera, Pars Altera, (Corpus scriptorum ecclesiasticorum Latinorum, Volume 32.2). Schenkl, Karl, editor. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1897.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Ambrose",
     "work": "De Apologia David",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0022",
     "print_source": "Karl Schenkl. Sanctii Ambrosii Opera, Pars Altera. Vindobonae: Gerold. 1897.",
     "added_by": "Caitlin Diddams"
   },
   {
     "author": "Ambrose",
+    "work": "De Benedictionibus Patriarcharum Liber U",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0022.stoa019/",
+    "print_source": "Ambrose. Sanctii Ambrosii Opera, Pars Altera, (Corpus scriptorum ecclesiasticorum Latinorum, Volume 32.2). Schenkl, Karl, editor. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1897.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ambrose",
+    "work": "De Cain",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0022.stoa021/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ambrose",
     "work": "De Cain et Abel",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0022",
     "print_source": "Karl Schenkl. Sanctii Ambrosii Opera, Pars Prima. Vindobonae: Gerold. 1897.",
     "added_by": "Caitlin Diddams"
   },
@@ -155,7 +435,7 @@
     "author": "Ambrose",
     "work": "De Fuga Saeculi",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0022",
     "print_source": "Karl Schenkl. Sanctii Ambrosii Opera, Pars Altera. Vindobonae: Gerold. 1897.",
     "added_by": "Caitlin Diddams"
   },
@@ -163,15 +443,23 @@
     "author": "Ambrose",
     "work": "De Helia et Ieiunio",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0022",
     "print_source": "Karl Schenkl. Sanctii Ambrosii Opera, Pars Altera. Vindobonae: Gerold. 1897.",
     "added_by": "Caitlin Diddams"
   },
   {
     "author": "Ambrose",
+    "work": "De Iacob",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ambrose",
     "work": "De Iacob et Vita Beata",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0022",
     "print_source": "Karl Schenkl. Sanctii Ambrosii Opera, Pars Altera. Vindobonae: Gerold. 1897.",
     "added_by": "Caitlin Diddams"
   },
@@ -179,7 +467,7 @@
     "author": "Ambrose",
     "work": "De Interpellatione Iob et David",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0022",
     "print_source": "Karl Schenkl. Sanctii Ambrosii Opera, Pars Altera. Vindobonae: Gerold. 1897.",
     "added_by": "Caitlin Diddams"
   },
@@ -187,23 +475,31 @@
     "author": "Ambrose",
     "work": "De Ioseph",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0022",
     "print_source": "Karl Schenkl. Sanctii Ambrosii Opera, Pars Altera. Vindobonae: Gerold. 1897.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Ambrose",
+    "work": "De Joseph",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0022.stoa035/",
+    "print_source": "Ambrose. Sanctii Ambrosii Opera, Pars Altera, (Corpus scriptorum ecclesiasticorum Latinorum, Volume 32.2). Schenkl, Karl, editor. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1897.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Ambrose",
     "work": "De Mysteriis",
     "e_source": "The Latin Library",
     "e_source_url": "http://www.thelatinlibrary.com/ambrose.html",
-    "print_source": "Edition Unknown.",
+    "print_source": "",
     "added_by": "Brianna Roberts"
   },
   {
     "author": "Ambrose",
     "work": "De Nabuthae",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0022",
     "print_source": "Karl Schenkl. Sanctii Ambrosii Opera, Pars Altera. Vindobonae: Gerold. 1897.",
     "added_by": "Caitlin Diddams"
   },
@@ -211,7 +507,7 @@
     "author": "Ambrose",
     "work": "De Noe",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0022",
     "print_source": "Karl Schenkl. Sanctii Ambrosii Opera, Pars Prima. Vindobonae: Gerold. 1897.",
     "added_by": "Caitlin Diddams"
   },
@@ -219,7 +515,7 @@
     "author": "Ambrose",
     "work": "De Paradiso",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0022",
     "print_source": "Karl Schenkl. Sanctii Ambrosii Opera, Pars Prima. Vindobonae: Gerold. 1897.",
     "added_by": "Caitlin Diddams"
   },
@@ -227,7 +523,7 @@
     "author": "Ambrose",
     "work": "De Patriarchis",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0022",
     "print_source": "Karl Schenkl. Sanctii Ambrosii Opera, Pars Altera. Vindobonae: Gerold. 1897.",
     "added_by": "Caitlin Diddams"
   },
@@ -235,7 +531,7 @@
     "author": "Ambrose",
     "work": "De Tobia",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0022",
     "print_source": "Karl Schenkl. Sanctii Ambrosii Opera, Pars Altera. Vindobonae: Gerold. 1897.",
     "added_by": "Caitlin Diddams"
   },
@@ -244,7 +540,7 @@
     "work": "Epistula ad Sororem",
     "e_source": "The Latin Library",
     "e_source_url": "http://www.thelatinlibrary.com/ambrose.html",
-    "print_source": "Edition Unknown.",
+    "print_source": "",
     "added_by": "Brianna Roberts"
   },
   {
@@ -257,17 +553,41 @@
   },
   {
     "author": "Ambrose",
+    "work": "Exameron",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0022.stoa054/",
+    "print_source": "Ambrose. Sanctii Ambrosii Opera, Pars Prima (Corpus scriptorum ecclesiasticorum Latinorum, Volume 32.1). Schenkl, Karl, editor. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1896.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ambrose",
+    "work": "Exlanatio Super Psalmos Xii",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ambrose",
     "work": "Explanatio Psalmorum XII",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0022",
     "print_source": "Michael Petschenig. Sanctii Ambrosii Opera, Pars VI. Vindobonae: Gerold. 1919.",
     "added_by": "Caitlin Diddams"
   },
   {
     "author": "Ambrose",
+    "work": "Expositio de Psalmo Cxviii",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ambrose",
     "work": "Expositio Evangelii Secundum Lucan",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0022",
     "print_source": "Henricus Schenkl. Sanctii Ambrosii Opera, Pars Quarta. Vindobonae: Gerold. 1902.",
     "added_by": "Caitlin Diddams"
   },
@@ -275,7 +595,7 @@
     "author": "Ambrose",
     "work": "Expositio Psalmi CXVIII",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0022",
     "print_source": "Michael Petschenig. Sanctii Ambrosii Opera, Pars Quinta. Vindobonae: Gerold. 1913.",
     "added_by": "Caitlin Diddams"
   },
@@ -283,9 +603,25 @@
     "author": "Ambrose",
     "work": "Hexameron",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0022",
     "print_source": "Karl Schenkl. Sanctii Ambrosii Opera, Pars Prima. Vindobonae: Gerold. 1897.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Ambrosiaster",
+    "work": "Pseudo Augustini Quaestiones Veteris Et",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0022a.stoa001/",
+    "print_source": "Ambrosiaster. Pseudo-Augustini Quaestiones Veteris et Novi Testamenti CXXVII (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 50). Souter, Alexander, editor. Vienna, Leipzig: Tempsky, Freytag, 1908",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ammianus",
+    "work": "Rerum Gestarum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Ammianus Marcellinus",
@@ -294,6 +630,14 @@
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3Atext%3A2007.01.0081%3Abook%3D14%3Achapter%3D1%3Asection%3D1",
     "print_source": "Ammianus Marcellinus. With An English Translation. John C. Rolfe, PhD, Litt.D. Cambridge. Cambridge, Mass., Harvard University Press; London, William Heinemann, Ltd. 1935-1940.",
     "added_by": "Katherine Roache"
+  },
+  {
+    "author": "Anacharsis",
+    "work": "Epistulae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0037.tlg001/",
+    "print_source": "Rudolf Hercher, Epistolographi Graeci, Paris. A. F. Didot. 1873",
+    "added_by": "V6 Import"
   },
   {
     "author": "Andocides",
@@ -328,12 +672,316 @@
     "added_by": "V3 Legacy Import"
   },
   {
+    "author": "Angilbertus miles",
+    "work": "Carmen de Aquilegia",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/CARM_AQU%7Ccaaq%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Angilbertus miles",
+    "work": "Carmen de Exordio Francorum",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/CARM_GFR%7Ccarm%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Angilbertus miles",
+    "work": "Versus de Fontaneto",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/ANGIL_MI%7Cfont%7C001",
+    "print_source": "D. Norberg, 1968",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Angilbertus, abbas Centulensis",
+    "work": "Carmina",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/ANGIL_CE%7Ccarm%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Angilbertus, abbas Centulensis",
+    "work": "Versus",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/ANGIL_CE%7Cvers%7C001",
+    "print_source": "K. Strecker, 1923)",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Acts of John",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0317.tlg001/",
+    "print_source": "Acta Joannis. Acta Apostolorum Apocrypha, Part 2, Vol. 1. Bonnet, Maximilian, editor. Leipzig: H. Mendelssohn, 1898.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Breviarius de Hierosolyma",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Carmen ad Agobardum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Carmen ad Ludovicum Pium",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Carmen de Aquilegia",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Carmen de Compoti Ratione",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "K. Strecker, 1951",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Carmen de Conversione Saxonum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Carmen de Exordio Francorum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Carmen de Nynia Episcopo",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "K. Strecker, 1923",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Carmen de Pippino",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Carmen de Temporum Ratione",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "K. Strecker, 1951",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Carmen de Timone Comite",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Carmina Augiensia",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Carmina Bibliothecarum Et Psalteriorum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Carmina Cenomanensia",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Carmina de Ludovico Ii",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Carmina Libris Saec Viii Adiecta",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Corneli Translationes",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Geographiae Expositio Compendiaria",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0092.tlg001/",
+    "print_source": "Anonymous, author; Geographi graeci minores Volumen Secundum, ed. Karl Müller; Ambroise Firmin Didot, Paris, 1861",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Hymnus Nynie Episcopi",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Itinerarium Hierosolymitanum",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0329.stoa001/",
+    "print_source": "Anonymous. Itinera hierosolymitana saecvli IIII-VIII (Corpus scriptorum ecclesiasticorum Latinorum, Volume 39). Geyer, Paul, editor. Prague, Vienna, Leipzig: Tempsky, Freytag, 1898.‏",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Karolus Magnus Et Leo Papa",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Anonymous",
     "work": "Laudes Domini",
     "e_source": "Divus Angelus",
     "e_source_url": "http://www.divusangelus.it/texts/sec4dc/laudesdomini.htm",
     "print_source": "Pieter Van Der Weijden, ed. Laudes domini: Tekst, vertaling en commentaar. Amsterdam: H. J. Paris, 1967.",
     "added_by": "Vincent Hunink"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Laudes Mediolanensis Civitatis",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Laudes Veronensis Civitatis",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Planctus de Obitu Karoli",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "S Silviae Peregrinatio",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0111.stoa001/",
+    "print_source": "Itinera Hierosolymitana / Egragia. Itinera hierosolymitana saecvli IIII-VIII (Corpus scriptorum ecclesiasticorum Latinorum, Volume 39). Geyer, Paul, editor. Prague, Vienna, Leipzig: Tempsky, Freytag, 1898.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Stadiasmus Magni Maris",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0077.tlg001/",
+    "print_source": "Anonymous. Geographi graeci minores, Volume 1. Müller, Karl, editor. Paris: Ambroise Firmin Didot, 1855.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Tituli Metrici Saeculi Viii",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Translatio Sancti Mercurii",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "G. Waitz, 1878",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Translatio Xii Martyrum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Versus ad Ebonem Remensem",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous",
+    "work": "Versus de Eversione Monasterii Glonnensis",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Anonymous Pilgrim of Piacenza",
+    "work": "Itinerarium",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0028e.stoa001/",
+    "print_source": "Anonymous pilgrim of Piacenza. Itinera hierosolymitana saecvli IIII-VIII (Corpus scriptorum ecclesiasticorum Latinorum, Volume 39). Geyer, Paul, editor. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1898.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Antiphon",
@@ -392,6 +1040,22 @@
     "added_by": "Katherine Roache"
   },
   {
+    "author": "Antisthenes",
+    "work": "Ajax",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0051.tlg001/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Antisthenes",
+    "work": "Odysseus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0051.tlg002/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Apollodorus",
     "work": "Epitome",
     "e_source": "Perseus",
@@ -406,6 +1070,30 @@
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.01.0021%3atext%3dLibrary",
     "print_source": "Apollodorus. Apollodorus, The Library, with an English Translation by Sir James George Frazer, F.B.A., F.R.S. in 2 Volumes. Cambridge, MA, Harvard University Press; London, William Heinemann Ltd. 1921.",
     "added_by": "Katherine Roache"
+  },
+  {
+    "author": "Apollonius Dyscolus",
+    "work": "On Pronouns",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0082.tlg001/",
+    "print_source": "Apollonius Dyscolus. Apollonii Dyscoli Quae supersunt. Vol. 1.1. (Grammatici Graeci, Volume 2.1). Schneider, Richard; Uhlig, Gustav, editors. Leipzig: Teubner, 1878.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Apollonius of Perga",
+    "work": "Conica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0550.tlg001/",
+    "print_source": "J. L. Heiberg, Apollonii Pergaei quae graece exstant, Leipzig. Teubner. 1893, Vol. 2",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Apollonius Rhodius",
+    "work": "Argonautica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0001.tlg001/",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Appian",
@@ -464,28 +1152,116 @@
     "added_by": "Katherine Roache"
   },
   {
-    "author": "Apulieus",
-    "work": "Apologia",
-    "e_source": "Perseus",
-    "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0501",
-    "print_source": "Apuleius.Apulei Platonici Madaurensis, Pro se de magia liber (Apologia).Rudolf Helm. Lipsiae: B.G. Teubneri. 1912.",
-    "added_by": "Katherine Roache"
-  },
-  {
-    "author": "Apulieus",
-    "work": "De Deo Socratis",
-    "e_source": "Forum Romanum",
-    "e_source_url": "http://www.forumromanum.org/literature/deo_socratis.html",
-    "print_source": "Jean Beaujeu. Paris 1973.",
-    "added_by": "Caitlin Diddams"
-  },
-  {
     "author": "Aratus Solensis",
     "work": "Phaenomena",
     "e_source": "Perseus",
     "e_source_url": "https://web.archive.org/web/20240812080521/http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.01.0019%3aspeech%3d1",
     "print_source": "Arati Phaenomena. Berolini: Apvd Weidmannos. 1893.",
     "added_by": "V3 Legacy Import"
+  },
+  {
+    "author": "Archimedes",
+    "work": "Ad Eratosthenem Methodus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0552.tlg008/",
+    "print_source": "Archimedes. Archimède, Volume 3. Mugler, Charles, editor. Paris: Les Belles Lettres, 1971.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Archimedes",
+    "work": "Arenarius",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0552.tlg004/",
+    "print_source": "Archimedes. Archimède, Volume 2. Mugler, Charles, editor. Paris: Les Belles Lettres, 1971.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Archimedes",
+    "work": "De Conoidibus Et Sphaeroidibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0552.tlg003/",
+    "print_source": "Archimedes. Archimède, Volume 1. Mugler, Charles, editor. Paris: Les Belles Lettres, 1970.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Archimedes",
+    "work": "De Corporibus Fluitantibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0552.tlg012/",
+    "print_source": "Archimedes. Archimède, Volume 3. Mugler, Charles, editor. Paris: Les Belles Lettres, 1971.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Archimedes",
+    "work": "De Lineis Spiralibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0552.tlg005/",
+    "print_source": "Archimedes. Archimède, Volume 2. Mugler, Charles, editor. Paris: Les Belles Lettres, 1971.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Archimedes",
+    "work": "De Planorum Aequilibriis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0552.tlg006/",
+    "print_source": "Archimedes. Archimède, Volume 2. Mugler, Charles, editor. Paris: Les Belles Lettres, 1971.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Archimedes",
+    "work": "De Sphaera Et Cylindro",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0552.tlg001/",
+    "print_source": "Archimedes. Archimède, Volume 1. Mugler, Charles, editor. Paris: Les Belles Lettres, 1970.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Archimedes",
+    "work": "Dimensio Circuli",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0552.tlg002/",
+    "print_source": "Archimedes. Archimède, Volume 1. Mugler, Charles, editor. Paris: Les Belles Lettres, 1970.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Archimedes",
+    "work": "Fragmenta",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0552.tlg013/",
+    "print_source": "Archimedes. Archimède, Volume 4. Mugler, Charles, editor. Paris: Les Belles Lettres, 1972.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Archimedes",
+    "work": "Liber Assumptorum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0552.tlg009/",
+    "print_source": "Archimedes. Archimède, Volume 3. Mugler, Charles, editor. Paris: Les Belles Lettres, 1971.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Archimedes",
+    "work": "Problema Bovinum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0552.tlg010/",
+    "print_source": "Archimedes. Archimède, Volume 3. Mugler, Charles, editor. Paris: Les Belles Lettres, 1971.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Archimedes",
+    "work": "Quadratura Parabolae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0552.tlg007/",
+    "print_source": "Archimedes. Archimède, Volume 2. Mugler, Charles, editor. Paris: Les Belles Lettres, 1971.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Archytas of Tarentum",
+    "work": "Fragmenta",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0620.tlg002/",
+    "print_source": "Hermann Diels, Die Fragmente der Vorsokratiker, Berlin. Weidmann. 1922, Vol. 1",
+    "added_by": "V6 Import"
   },
   {
     "author": "Aretaeus",
@@ -585,11 +1361,35 @@
   },
   {
     "author": "Aristophanes",
+    "work": "Thesmophoriazusae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0019.tlg009/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristophanes",
     "work": "Wasps",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.01.0043",
     "print_source": "F.W. Hall and W.M. Geldart, Aristophanes Comoediae, ed. F.W. Hall and W.M. Geldart, vol. 1. Oxford: Clarendon Press, Oxford, 1907.",
     "added_by": "Anna Glenn"
+  },
+  {
+    "author": "Aristotle",
+    "work": "Analytica Priora",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg001/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "Categoriae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg006/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
   },
   {
     "author": "Aristotle",
@@ -601,11 +1401,155 @@
   },
   {
     "author": "Aristotle",
+    "work": "De Anima",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg002/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "De Audibilibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg043/",
+    "print_source": "Aristotle. Aristotelis De animalium motione et De animalium incessu. Jaeger, Werner, editor. Leipzig:Teubner, 1913.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "De Caelo",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg005/",
+    "print_source": "Aristotle. Aristoteles de coelo et de generatione et corruptione. Prantl, Carl von, editor. Leipzig: Teubner, 1881.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "De Coloribus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg039/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "De Divinatione Per Somnum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg008/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "De Generatione Animalium",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg012/",
+    "print_source": "Immanuel Bekker, Aristotelis De generatione animalium libri quinque, Berlin. Typis Academicis, G. Reimer. 1829",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "De Insomniis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg016/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "De Interpretatione",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg017/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "De Iuventute Et Senectute de Vita Et Morte",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg018/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "De Longitudine Et Brevitate Vitae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg020/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "De Memoria Et Reminiscentia",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg024/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "De Partibus Animalium",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg030/",
+    "print_source": "Aristotle. Aristotelis De partibus animalium libri quattuor. Langkavel, Bernhard. Leipzig: Teubner, 1868.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "De Respiratione",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg037/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "De Sensu Et Sensibilibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg041/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "De Somno Et Vigilia",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg042/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "De Sophisticis Elenchis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg040/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "Divisiones Aristoteleae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg048/",
+    "print_source": "Hermann Mutschmann, Divisiones quae vulgo dicuntur Aristoteleae, Leipzig. B. G. Teubner. 1906",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
     "work": "Economics",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3Atext%3A1999.01.0047",
     "print_source": "Aristotle. Aristotle in 23 Volumes, Vol. 18. Harvard University Press, Cambridge, Mass., London. 1935.",
     "added_by": "Rudra Chakraborty"
+  },
+  {
+    "author": "Aristotle",
+    "work": "Epistulae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg011/",
+    "print_source": "Rudolf Hercher, Epistolographi Graeci, Paris. A. F. Didot. 1873",
+    "added_by": "V6 Import"
   },
   {
     "author": "Aristotle",
@@ -617,6 +1561,30 @@
   },
   {
     "author": "Aristotle",
+    "work": "Fragmenta Deperditae Partis Primae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg003/",
+    "print_source": "Aristotle. Aristotelis Res Publica Atheniensium. Kenyon, Frederic, editor. Berlin: Reimer, 1903.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "Magna Moralia",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg022/",
+    "print_source": "Aristotle. Aristotelis Quae Feruntur Magna Moralia. Susemihl, Franz, editor. Leipzig: Teubner, 1883",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "Mechanica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg042/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
     "work": "Metaphysics",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3Atext%3A1999.01.0051",
@@ -625,11 +1593,35 @@
   },
   {
     "author": "Aristotle",
+    "work": "Meteorologica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg026/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
     "work": "Nicomachean Ethics",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3Atext%3A1999.01.0053",
     "print_source": "ed. J. Bywater, Aristotle's Ethica Nicomachea. Oxford, Clarendon Press. 1894.",
     "added_by": "Rudra Chakraborty"
+  },
+  {
+    "author": "Aristotle",
+    "work": "Physica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg031/",
+    "print_source": "Aristotle. Aristotelis Physica. Ross, W.D., editor. Oxford: Clarendon, 1960.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "Physiognomonica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg044/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
   },
   {
     "author": "Aristotle",
@@ -649,11 +1641,35 @@
   },
   {
     "author": "Aristotle",
+    "work": "Problemata Physica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg031/",
+    "print_source": "Aristotle. Aristotelis Physica. Ross, W.D., editor. Oxford: Clarendon, 1960.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
+    "work": "Res Publica Atheniensium",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg003/",
+    "print_source": "Aristotle. Aristotelis Res Publica Atheniensium. Kenyon, Frederic, editor. Berlin: Reimer, 1903.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aristotle",
     "work": "Rhetoric",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3Atext%3A1999.01.0059",
     "print_source": "Ars Rhetorica. Aristotle. W. D. Ross. Oxford. Clarendon Press. 1959.",
     "added_by": "Rudra Chakraborty"
+  },
+  {
+    "author": "Aristotle",
+    "work": "Topica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0086.tlg044/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
   },
   {
     "author": "Aristotle",
@@ -664,12 +1680,44 @@
     "added_by": "Rudra Chakraborty"
   },
   {
+    "author": "Aristoxenus",
+    "work": "Elementa Harmonica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0088.tlg001/",
+    "print_source": "Aristoxenus. The Harmonics of Aristoxenus. Macran, Henry S., editor. Oxford: Clarendon Press, 1902.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Arius Didymus",
+    "work": "Liber de Philosophorum Sectis Epitome Ap Stobaeum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0529.tlg002/",
+    "print_source": "Friedrich Wilhelm August Mullach, Fragmenta Philosophorum Graecorum, Paris. Firmin-Didot. 1881, Vol. 2",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Arnobius",
     "work": "Adversus Nationes",
     "e_source": "Open Greek and Latin",
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
     "print_source": "August Reifferscheid. Arnobii Adversus Nationes Libri VII. Vindobonae: Gerold. 1875.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Arnobius Advesus Nationes",
+    "work": "",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Arnobius of Sicca",
+    "work": "Adversus Nationes Libri Vii",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0034.stoa001/",
+    "print_source": "Arnobius of Sicca. Arnobii adversus nationes Libri VII. Reifferscheid, August, editor. Corpus scriptorum ecclesiasticorum Latinorum, Volume 4, 1875.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Arrian",
@@ -688,6 +1736,30 @@
     "added_by": "V3 Legacy Import"
   },
   {
+    "author": "Artaxerxis Epistulae",
+    "work": "Epistulae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0045.tlg001/",
+    "print_source": "Rudolf Hercher, Epistolographi Graeci, Paris. A. F. Didot. 1873",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Artemidorus",
+    "work": "Onirocriticon",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0553.tlg001/",
+    "print_source": "Artemidorus. Artemidori Daldiani Onirocriticon. Pack, Roger E., editor. Leipzig: Teubner, 1963.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Aspasius",
+    "work": "In Ethica Nicomachea Paraphrasis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0615.tlg001/",
+    "print_source": "Aspasius. In Ethica Nichomachea Commentaria. (Commentaria in Aristotelem graeca, Volume 19.1). Heylbut, Gustav, editor. Berlin: Reimer, 1889.",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Athenaeus",
     "work": "The Deipnosophists",
     "e_source": "Perseus",
@@ -696,12 +1768,36 @@
     "added_by": "Emilie Redwood"
   },
   {
-    "author": "Augurelli, Giovanni Aurelio",
-    "work": "Chrysopoeia",
-    "e_source": "Perseus",
-    "e_source_url": "https://web.archive.org/web/20240812080521/http://http//www.perseus.tufts.edu/hopper/searchresults?q=chrysopoeia",
-    "print_source": "Christophe Plantin. Chrysopoeia ad Leonem X Pontificem Maximum Antwerpen. 1582.",
-    "added_by": "V3 Legacy Import"
+    "author": "Audradus Modicus",
+    "work": "Carmina",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Audradus Modicus",
+    "work": "De Sancta Trinitate",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Audradus Modicus, episcopus Senonensis",
+    "work": "Carmina",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/AUDRAD%7Ccarm%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Audradus Modicus, episcopus Senonensis",
+    "work": "De Sancta Trinitate",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/AUDRAD%7Ctrin%7C000",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
   },
   {
     "author": "Augustine",
@@ -737,6 +1833,14 @@
   },
   {
     "author": "Augustine",
+    "work": "Confessions",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Augustine",
     "work": "Contra Academicos",
     "e_source": "Open Greek and Latin",
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
@@ -753,6 +1857,22 @@
   },
   {
     "author": "Augustine",
+    "work": "Contra Cresconium",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0040.stoa019/",
+    "print_source": "Augustine. Sancti Aureli Augustini Opera, Sectio VII, Pars II (Corpus scriptorum ecclesiasticorum Latinorum, Volume 52). Petschenig, Michael, editor. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1909.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Augustine",
+    "work": "Contra Cresconium Grammaticum Et Donatistam",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0040.stoa019/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Augustine",
     "work": "Contra Cresconium Grammaticum Partis Donati",
     "e_source": "Open Greek and Latin",
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
@@ -766,6 +1886,14 @@
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
     "print_source": "Joseph Zycha. Sancti Aurelii Augustini Opera, Sect VIII Pars I. Vindobonae: Gerold. 1913.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Augustine",
+    "work": "Contra Duas Epistulas Pelegianorum",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0040.stoa021/",
+    "print_source": "Augustine. Sancti Aureli Augustini Opera, Sectio VIII, Pars I (Corpus scriptorum ecclesiasticorum Latinorum, Volume 60). Urba, Karl; Zycha, Joseph; editors. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1913.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Augustine",
@@ -841,11 +1969,27 @@
   },
   {
     "author": "Augustine",
+    "work": "Contra Secundinem",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0040.stoa031/",
+    "print_source": "Augustine. Sancti Aureli Augustini Opera, Sectio VI, Pars II (Corpus scriptorum ecclesiasticorum Latinorum, Volume 25, Pars II). Zycha, Joseph editor. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1892.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Augustine",
     "work": "Contra Secundinum",
     "e_source": "Open Greek and Latin",
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
     "print_source": "Joseph Zycha. Sancti Aurelii Augustini Opera, Sect VI Pars II. Vindobonae: Gerold. 1892.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Augustine",
+    "work": "De Adulterinis Coniugiis",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Augustine",
@@ -929,11 +2073,27 @@
   },
   {
     "author": "Augustine",
+    "work": "De Cura Pro Mortuis Gerenda ad Paulinum",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0040.stoa037c/",
+    "print_source": "Augustine. Sancti Aureli Augustini Opera, Sectio V, Pars III (Corpus scriptorum ecclesiasticorum Latinorum, Volume 41). Zycha, Joseph, editor. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1900.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Augustine",
     "work": "De Dialectica",
     "e_source": "The Latin Library",
     "e_source_url": "http://www.thelatinlibrary.com/augustine/dia.shtml",
     "print_source": "W. Crecelius S. Aurelii Augustini de dialecta liber. Jahresbericht ueber das Gymnasium zu Elberfeld, Schuljahr 1856-57 (Elberfeld: Lucas, 1857).",
     "added_by": "Tessa Little"
+  },
+  {
+    "author": "Augustine",
+    "work": "De Diuinatione Daemonum",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0040.stoa038a/",
+    "print_source": "Augustine. Sancti Aureli Augustini Opera, Sectio V, Pars III (Corpus scriptorum ecclesiasticorum Latinorum, Volume 41). Zycha, Joseph, editor. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1900.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Augustine",
@@ -958,6 +2118,14 @@
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
     "print_source": "Joseph Zycha. Sancti Aurelii Augustini Opera, Sect VI, Pars I. Vindobonae: Gerold. 1891.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Augustine",
+    "work": "De Fide Et Operibus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Augustine",
@@ -993,11 +2161,27 @@
   },
   {
     "author": "Augustine",
+    "work": "De Genesi ad Litteram Liber Imperfectus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Augustine",
     "work": "De Gestis Pelagii",
     "e_source": "Open Greek and Latin",
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
     "print_source": "Joseph Zycha. Sancti Aureli Augustini Opera, Sectio VIII, Pars II. Vindobonae: Gerold. 1902.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Augustine",
+    "work": "De Gratia Christ",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0040.stoa046/",
+    "print_source": "Augustine. Sancti Aureli Augustini Opera, Sectio VIII, Pars II (Corpus scriptorum ecclesiasticorum Latinorum, Volume 42). Urba, Karl; Zycha, Joseph; editors. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1902.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Augustine",
@@ -1057,6 +2241,14 @@
   },
   {
     "author": "Augustine",
+    "work": "De Ordine",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Augustine",
     "work": "De Ordine Libri Duo",
     "e_source": "Open Greek and Latin",
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
@@ -1078,6 +2270,14 @@
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
     "print_source": "Joseph Zycha. Sancti Aurelii Augustini Opera, Sectio VIII, Pars II. Vindobonae: Gerold. 1902.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Augustine",
+    "work": "De Peccatorum Meritis Et Remissione Et D",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0040.stoa057/",
+    "print_source": "Augustine. Sancti Aureli Augustini Opera, Sectio VIII, Pars I (Corpus scriptorum ecclesiasticorum Latinorum, Volume 60). Urba, Karl; Zycha, Joseph; editors. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1913.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Augustine",
@@ -1121,11 +2321,43 @@
   },
   {
     "author": "Augustine",
+    "work": "De Utilitae Credendi",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Augustine",
     "work": "De Utilitate Credendi",
     "e_source": "Open Greek and Latin",
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
     "print_source": "Joseph Zycha. Sancti Aurelii Augustini Opera, Sectio VI, Pars I. Vindobonae: Gerold. 1891.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Augustine",
+    "work": "Du Duabus Animabus",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0040.stoa040/",
+    "print_source": "Augustine. Sancti Aureli Augustini Opera, Sectio VI, Pars I (Corpus scriptorum ecclesiasticorum Latinorum, Volume 25.1). Zycha, Joseph editor. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1891.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Augustine",
+    "work": "Epistula ad Catholicos de Secta Donatist",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0040.stoa020/",
+    "print_source": "Augustine. Sancti Aureli Augustini Opera, Sectio VII, Pars II (Corpus scriptorum ecclesiasticorum Latinorum, Volume 52). Petschenig, Michael, editor. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1909.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Augustine",
+    "work": "Epistula ad Catholicos de Secta Donatistarum",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0040.stoa020/",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Augustine",
@@ -1153,11 +2385,43 @@
   },
   {
     "author": "Augustine",
+    "work": "Gesta cum Emerito Donatistarum Episcopo",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Augustine",
+    "work": "Gesta cum Emerito Donatistarum Episcopum",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0040.stoa066c/",
+    "print_source": "Augustine. Sancti Aureli Augustini Opera, Sectio VII, Pars III (Corpus scriptorum ecclesiasticorum Latinorum, Volume 53). Petschenig, Michael, editor. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1910.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Augustine",
     "work": "Libellus Adversus Fulgentium",
     "e_source": "Open Greek and Latin",
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
     "print_source": "Michael Petchenig. Sancti Aurelii Augustini Scripta contra Donatistas. Vindobonae: Gerold. 1910.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Augustine",
+    "work": "Libellus Adversus Fulgentium Donatistam",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Augustine",
+    "work": "Liber de Divinis Scripturis Sive Speculu",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0040.stoa080a/",
+    "print_source": "Augustine. Sancti Aureli Augustini Opera, Sectio III, Pars I (Corpus scriptorum ecclesiasticorum Latinorum, Volume 12). Weihrich, Franz, editor. Vienna: Gerold, 1887.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Augustine",
@@ -1169,11 +2433,27 @@
   },
   {
     "author": "Augustine",
+    "work": "Liber Qui Appellatur Speculum",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0040.stoa080/",
+    "print_source": "Augustine. Sancti Aureli Augustini Opera, Sectio III, Pars I (Corpus scriptorum ecclesiasticorum Latinorum, Volume 12). Weihrich, Franz, editor. Vienna: Gerold, 1887.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Augustine",
     "work": "Liber Qui Appellature Speculum",
     "e_source": "Open Greek and Latin",
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
     "print_source": "Franz Weihrich. Aurelii Augustini Hipponensis Episcopi. Vindobonae: Gerold. 1887.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Augustine",
+    "work": "Locutiones in Heptateuchum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Augustine",
@@ -1201,6 +2481,22 @@
   },
   {
     "author": "Augustine",
+    "work": "Retractationes",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Augustine",
+    "work": "Retractationum",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0040.stoa077/",
+    "print_source": "Augustine. Sancti Aureli Augustini Opera, Sectio I, Pars II (Corpus scriptorum ecclesiasticorum Latinorum, Volume 36). Knöll, Pius, editor. Vienna; Leipzig: F. Tempsky; G. Freytag, 1902.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Augustine",
     "work": "Retractiones",
     "e_source": "Open Greek and Latin",
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
@@ -1222,6 +2518,22 @@
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
     "print_source": "Michael Petschenig. Sancti Aurelii Augustini Scripta contra Donatistas. Vindobonae: Gerold. 1910.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Augustine",
+    "work": "Speculum",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0040.stoa080/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Augustine Pseudo",
+    "work": "Quaestiones Veteris Et Novi Testamenti",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Aurelius Victor",
@@ -1281,6 +2593,14 @@
   },
   {
     "author": "Ausonius",
+    "work": "Cupido Cruciatus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ausonius",
     "work": "De Bissula",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0603",
@@ -1297,11 +2617,67 @@
   },
   {
     "author": "Ausonius",
+    "work": "De Xii Caesaribus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ausonius",
+    "work": "Eclogarum Liber",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ausonius",
+    "work": "Ephemeris Id Est Totius Diei Negotium",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ausonius",
     "work": "Epicedion in Patrem",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0607",
     "print_source": "Hugh G. Evelyn-White, Ausonius. Works.. London; Cambridge, Massachusetts: William Heinemann Ltd.; Harvard University Press, 1919.",
     "added_by": "Katherine Roache"
+  },
+  {
+    "author": "Ausonius",
+    "work": "Epigrammata Ausonii de Diversis Rebus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ausonius",
+    "work": "Epistularum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ausonius",
+    "work": "Epitaphia Heroum Qui Bello Troico Interfuerunt",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ausonius",
+    "work": "Gratiarum Actio",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Ausonius",
@@ -1313,6 +2689,22 @@
   },
   {
     "author": "Ausonius",
+    "work": "Libri de Fastis Conclusio",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ausonius",
+    "work": "Ludus Septem Sapientum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ausonius",
     "work": "Mosella",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0619",
@@ -1321,11 +2713,67 @@
   },
   {
     "author": "Ausonius",
+    "work": "Oratio Consulis Ausonii Versibus Rhopalicis",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ausonius",
     "work": "Oratio Consulis Ausonii Versibus Ropalicis",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0619",
     "print_source": "Hugh G. Evelyn-White, Ausonius. Works.. London; Cambridge, Massachusetts: William Heinemann Ltd.; Harvard University Press, 1919.",
     "added_by": "Katherine Roache"
+  },
+  {
+    "author": "Ausonius",
+    "work": "Ordo Urbium Nobilium",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ausonius",
+    "work": "Parentalia",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ausonius",
+    "work": "Praefatiunculae",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ausonius",
+    "work": "Precationes",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ausonius",
+    "work": "Technopaegnion",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ausonius",
+    "work": "Versus Paschales Pro Augusto Dicti",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Ausonius, Decimus Magnus",
@@ -1432,6 +2880,14 @@
     "added_by": "V3 Legacy Import"
   },
   {
+    "author": "Babrius",
+    "work": "Fabulae Aesopeae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0614.tlg001/",
+    "print_source": "Babrius. Babrii Fabulae Aesopeae. Schneidewin, Friedrich Wilhelm, editor. Leipzig: Teubner, 1865.",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Bacchylides",
     "work": "Dithyrambs",
     "e_source": "Perseus",
@@ -1480,6 +2936,46 @@
     "added_by": "Anna Glenn"
   },
   {
+    "author": "Bede the Venerable",
+    "work": "De Locis Santis",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0054.stoa001a/",
+    "print_source": "Bede the Venerable. Itinera hierosolymitana saecvli IIII-VIII (Corpus scriptorum ecclesiasticorum Latinorum, Volume 39). Geyer, Paul, editor. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1898.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Bernowinus",
+    "work": "Carmina",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Bernowinus episcopus Claromontensis",
+    "work": "Carmina",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/BERNOWIN%7Ccarm%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Bertharius of Monte Cassino",
+    "work": "Carmen de Sancto Benedicto",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Bertharius, abbas Casinensis",
+    "work": "Carmen de Sancto Benedicto",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/BERTHAR%7Cbene%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
     "author": "Bion of Phlossa",
     "work": "Epitaphius Adonis",
     "e_source": "Perseus",
@@ -1505,11 +3001,27 @@
   },
   {
     "author": "Boethius",
+    "work": "Commentaria in Porphyrium a Se Translatu",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0058.stoa007/",
+    "print_source": "Boethius. Anicii Manlii Severini Boethii In Isagogen Porphyrii commenta (Corpus scriptorum ecclesiasticorum Latinorum, Volume 48). Schepps, George; Brandt, Samuel, editors. Vienna, Leipzig: F. Tempsky, G. Freytag, 1906.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Boethius",
     "work": "Consolatio Philosophiae",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.02.0121",
     "print_source": "James J. O'Donnell, Consolatio Philosophiae.",
     "added_by": "Emilie Bétrix"
+  },
+  {
+    "author": "Boethius",
+    "work": "De Consolatione Philosophiae",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0058.stoa001/",
+    "print_source": "Boethius. Anicii Manlii Severini Boethii Philosophiae Consolationis (Corpus scriptorum ecclesiasticorum Latinorum, Volume 67). Weinberger, Wilhelm, editor. Vienna, Leipzig: Hoelder-Pichler Tempsky, Akademische Verlags Gesellschaft, 1934.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Boethius",
@@ -1537,6 +3049,22 @@
   },
   {
     "author": "Boethius",
+    "work": "Quomodo Substantiae in Eo Quod Sint Bonae Sint cum Non Sint Substantialia Bona",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Boethius",
+    "work": "Quomodo Trinitas",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Boethius",
     "work": "Quomodo Trinitas Unus Deus Ac Non Tres Dii (De Trinitate)",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atex%3a2008.01.0680",
@@ -1545,11 +3073,43 @@
   },
   {
     "author": "Boethius",
+    "work": "Utrum Pater",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Boethius",
     "work": "Utrum Pater Et Filius Ac Spiritus Sanctus De Divinitate Substantiali ter Praedicentur Liber",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0679",
     "print_source": "H.F. Stewart, Theological Tractates and the Consolation of Philo sophy. London; Cambridge, Massachusetts: William Heinemann Ltd.; Harvard Un iversity Press, 1918.",
     "added_by": "Anna Glenn"
+  },
+  {
+    "author": "Browning",
+    "work": "Sonnets from the Portuguese",
+    "e_source": "Project Gutenberg",
+    "e_source_url": "https://www.gutenberg.org/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Caesar",
+    "work": "De Bello Civili",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Caesar",
+    "work": "De Bello Gallico",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Caesar Augustus",
@@ -1561,11 +3121,27 @@
   },
   {
     "author": "Callimachus",
+    "work": "Aetia",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0533.tlg006/",
+    "print_source": "A. W. Mair, G. R. Mair, Callimachus and Lycophron, London. William Heinemann. 1921",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Callimachus",
     "work": "Epigrams",
     "e_source": "Perseus",
     "e_source_url": "https://web.archive.org/web/20240812080521/http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0672",
     "print_source": "G.R. Mair,Callimachus and Lycophron.. London; New York: W. Heinemann; G. P. Putnam's Sons, 1921.",
     "added_by": "V3 Legacy Import"
+  },
+  {
+    "author": "Callimachus",
+    "work": "Hecala",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0533.tlg009/",
+    "print_source": "A. W. Mair, G. R. Mair, Callimachus and Lycophron, London. William Heinemann. 1921",
+    "added_by": "V6 Import"
   },
   {
     "author": "Callimachus",
@@ -1576,12 +3152,84 @@
     "added_by": "V3 Legacy Import"
   },
   {
+    "author": "Callimachus",
+    "work": "Iambi",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0533.tlg007/",
+    "print_source": "A. W. Mair, G. R. Mair, Callimachus and Lycophron, London. William Heinemann. 1921",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Callistratus",
     "work": "Statuaram Descriptiones",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3Atext%3A2008.01.0594%3Achapter%3D1",
     "print_source": "Flavii Philostrati Opera, Vol 2. Callistratus. Carl Ludwig Kayser. in aedibus B. G. Teubneri. Lipsiae. 1871.",
     "added_by": "Katherine Roache"
+  },
+  {
+    "author": "Calpurnius Siculus",
+    "work": "Eclogae",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Candidus 'Brun', monachus Fuldensis",
+    "work": "Epitaphia Aegili",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/CAND_FUL%7Ceiep%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Candidus 'Brun', monachus Fuldensis",
+    "work": "Vita Aegili",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/CAND_FUL%7Ceigi%7C00a",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Candidus of Fulda",
+    "work": "Epitaphia Aegili",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Candidus of Fulda",
+    "work": "Vita Aegili",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Carmina Delphis Inventa",
+    "work": "Carmina Delphis Inventa",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0362.tlg001/",
+    "print_source": "Carmina Delphis Inventa. Musici Scriptores Graeci. Jan, Karl von. Leipzig: Teubner, 1895.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Carroll",
+    "work": "Alice in Wonderland",
+    "e_source": "Project Gutenberg",
+    "e_source_url": "https://www.gutenberg.org/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Catholic Church Pope",
+    "work": "Epistulae Imperatorum Pontificum Aliorum",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0045a.stoa001/",
+    "print_source": "Catholic Church. Pope. Epistulae imperatorum pontificum aliorum (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 35, Pars 1-2). Günther, Otto, editor. Vienna: Gerold, 1895-1898.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Cato the Elder",
@@ -1614,6 +3262,14 @@
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0668",
     "print_source": "Chariton.Erotici Scriptores Graeci, Vol 2. Rudolf Hercher. in aedibus B. G. Teubneri. Leipzig. 1859.",
     "added_by": "Katherine Roache"
+  },
+  {
+    "author": "Chionis Epistulae",
+    "work": "Epistulae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0041.tlg001/",
+    "print_source": "Rudolf Hercher, Epistolographi Graeci, Paris. A. F. Didot. 1873",
+    "added_by": "V6 Import"
   },
   {
     "author": "Cicero",
@@ -1721,6 +3377,14 @@
   },
   {
     "author": "Cicero",
+    "work": "De Natura Deorum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
     "work": "De Officiis",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2007.01.0047",
@@ -1750,6 +3414,14 @@
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0542",
     "print_source": "A. S. Wilkins, M. Tulli Ciceronis Rhetorica, Tomus II. 1911.",
     "added_by": "Anna Glenn"
+  },
+  {
+    "author": "Cicero",
+    "work": "De Partitione Oratoria",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Cicero",
@@ -1785,6 +3457,14 @@
   },
   {
     "author": "Cicero",
+    "work": "Divinatio in Q Caecilium",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
     "work": "Divinatio in Q. Caecilius",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.02.0012",
@@ -1798,6 +3478,134 @@
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.02.0009",
     "print_source": "L. C. Purser,Ciceronis Epistulae Oxonii, e typographeo Clarendoniano 1906",
     "added_by": "Anna Glenn"
+  },
+  {
+    "author": "Cicero",
+    "work": "Epistulae ad Familiares ad Cassium Et Ceteros",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
+    "work": "Epistulae ad Familiares ad Claudium Pulchrum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
+    "work": "Epistulae ad Familiares ad Curionem Et Ceteros",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
+    "work": "Epistulae ad Familiares ad Lentulum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
+    "work": "Epistulae ad Familiares ad Marium Et Ceteros",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
+    "work": "Epistulae ad Familiares ad Memmium Et Ceteros",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
+    "work": "Epistulae ad Familiares ad Metellum Et Ceteros",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
+    "work": "Epistulae ad Familiares ad Plancum Et Ceteros",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
+    "work": "Epistulae ad Familiares ad Senatum Et Ceteros",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
+    "work": "Epistulae ad Familiares ad Sulpicium Et Ceteros",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
+    "work": "Epistulae ad Familiares ad Terentiam Uxorem",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
+    "work": "Epistulae ad Familiares ad Tironem",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
+    "work": "Epistulae ad Familiares ad Torquatum Et Ceteros",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
+    "work": "Epistulae ad Familiares ad Varronem Et Ceteros",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
+    "work": "Epistulae ad Familiares at Brutum Et Ceteros",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
+    "work": "Epistulae ad Familiares Caeli Epistulae ad Ciceronem",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Cicero",
@@ -1849,6 +3657,22 @@
   },
   {
     "author": "Cicero",
+    "work": "Letters to Brutus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
+    "work": "Letters to Quintus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
     "work": "Lucullus",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2007.01.0033",
@@ -1889,6 +3713,14 @@
   },
   {
     "author": "Cicero",
+    "work": "Pro a Cluentio",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
     "work": "Pro A. Caecina",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.02.0013",
@@ -1910,6 +3742,22 @@
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.02.0014",
     "print_source": "Albert Clark, M. Tulli Ciceronis Orationes: Recognovit brevique adnotatione critica instruxit Albertus Curtis Clark. Oxonii: e Typographeo Clarendoniano, 1909.",
     "added_by": "Anna Glenn"
+  },
+  {
+    "author": "Cicero",
+    "work": "Pro C Rabirio Perduellionis Reo",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cicero",
+    "work": "Pro C Rabirio Postumo",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Cicero",
@@ -1998,6 +3846,14 @@
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.02.0015",
     "print_source": "Albert Clark, M. Tulli Ciceronis Orationes: Recognovit brevique adnotatione critica instruxit Albertus Curtis Clark. Oxonii: e Typographeo Clarendoniano, 1909.",
     "added_by": "Anna Glenn"
+  },
+  {
+    "author": "Cicero",
+    "work": "Pro Publio Quinctio",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Cicero",
@@ -2096,90 +3952,130 @@
     "added_by": "Anna Glenn"
   },
   {
-    "author": "Claudianus",
-    "work": "de Bello Gildonico",
-    "e_source": "Perseus",
-    "e_source_url": "https://web.archive.org/web/20240812080521/http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0698",
-    "print_source": "Maurice Platnaeur, Claudian, Vol 1. London; New York: William Heinemann; G.P. Putnam's Sons, 1922.",
-    "added_by": "V3 Legacy Import"
+    "author": "Cicero Pseudo",
+    "work": "In Sallustium",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
-    "author": "Claudianus",
-    "work": "de Bello Gothico",
-    "e_source": "Perseus",
-    "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0690",
-    "print_source": "Maurice Platnaeur, Claudian, Vol 2. London; New York: William Heinemann; G.P. Putnam's Sons, 1922.",
-    "added_by": ""
+    "author": "Cicero Pseudo",
+    "work": "Pridie Quam in Exilium Iret Oratio",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
-    "author": "Claudianus",
-    "work": "De consulatu Stilichonis",
-    "e_source": "Perseus",
-    "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0684",
-    "print_source": "Maurice Platnaeur, Claudian, Vol 1-2. London; New York: William Heinemann; G.P. Putnam's Sons, 1922.",
-    "added_by": ""
+    "author": "Claudian",
+    "work": "Carmina Minora",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
-    "author": "Claudianus",
-    "work": "de Raptu Proserpinae",
-    "e_source": "Perseus",
-    "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0685",
-    "print_source": "Maurice Platnaeur, Claudian, Vol 2. London; New York: William Heinemann; G.P. Putnam's Sons, 1922.",
-    "added_by": ""
+    "author": "Claudian",
+    "work": "De Bello Gildonico",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
-    "author": "Claudianus",
-    "work": "Epithalamium de nuptiis Honorii Augusti",
-    "e_source": "Perseus",
-    "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0691",
-    "print_source": "Maurice Platnaeur, Claudian, Vol 1. London; New York: William Heinemann; G.P. Putnam's Sons, 1922.",
-    "added_by": ""
+    "author": "Claudian",
+    "work": "De Bello Gothico",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
-    "author": "Claudianus",
-    "work": "In Consulatum Olybrii et Probini",
-    "e_source": "Perseus",
-    "e_source_url": "https://web.archive.org/web/20240812080521/http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0694",
-    "print_source": "Maurice Platnaeur, Claudian, Vol 1. London; New York: William Heinemann; G.P. Putnam's Sons, 1922.",
-    "added_by": "V3 Legacy Import"
+    "author": "Claudian",
+    "work": "De Consulatu Stilichonis",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
-    "author": "Claudianus",
+    "author": "Claudian",
+    "work": "De Raptu Proserpinae",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Claudian",
+    "work": "Epithalamium de Nuptiis Honorii Augusti",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Claudian",
+    "work": "In Consulatum Olybrii Et Probini",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Claudian",
     "work": "In Eutropium",
-    "e_source": "Perseus",
-    "e_source_url": "https://web.archive.org/web/20240812080521/http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0697",
-    "print_source": "Maurice Platnaeur, Claudian, Vol 1. London; New York: William Heinemann; G.P. Putnam's Sons, 1922.",
-    "added_by": "V3 Legacy Import"
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
-    "author": "Claudianus",
+    "author": "Claudian",
     "work": "In Rufinum",
-    "e_source": "Perseus",
-    "e_source_url": "https://web.archive.org/web/20240812080521/http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0689",
-    "print_source": "Maurice Platnaeur, Claudian, Vol 1. London; New York: William Heinemann; G.P. Putnam's Sons, 1922.",
-    "added_by": "V3 Legacy Import"
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Claudian",
+    "work": "Panegyricus de Quarto Consulatu Honorii Augusti",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Claudian",
+    "work": "Panegyricus de Sexto Consulatu Honorii Augusti",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Claudian",
+    "work": "Panegyricus de Tertio Consulatu Honorii Augusti",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Claudian",
+    "work": "Panegyricus Dictus Manlio Theodoro Consuli",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Claudianus",
     "work": "Panegyricus De Quarto Consolatu Honorii Augusti",
     "e_source": "Perseus",
     "e_source_url": "https://web.archive.org/web/20240812080521/http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0695",
-    "print_source": "Maurice Platnaeur, Claudian, Vol 1. London; New York: William Heinemann; G.P. Putnam's Sons, 1922.",
-    "added_by": "V3 Legacy Import"
-  },
-  {
-    "author": "Claudianus",
-    "work": "Panegyricus De Sexto Consulatu Honorii Augusti",
-    "e_source": "Perseus",
-    "e_source_url": "https://web.archive.org/web/20240812080521/http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0687",
-    "print_source": "Maurice Platnaeur, Claudian, Vol 2. London; New York: William Heinemann; G.P. Putnam's Sons, 1922.",
-    "added_by": "V3 Legacy Import"
-  },
-  {
-    "author": "Claudianus",
-    "work": "Panegyricus De Tertio Consulatu Honorii Augusti",
-    "e_source": "Perseus",
-    "e_source_url": "https://web.archive.org/web/20240812080521/http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0696",
     "print_source": "Maurice Platnaeur, Claudian, Vol 1. London; New York: William Heinemann; G.P. Putnam's Sons, 1922.",
     "added_by": "V3 Legacy Import"
   },
@@ -2192,6 +4088,22 @@
     "added_by": "V3 Legacy Import"
   },
   {
+    "author": "Claudianus Mamertus",
+    "work": "De Statu Animae",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0089a.stoa001/",
+    "print_source": "Claudianus Mamertus. Claudiani Mamerti opera (Corpus scriptorum ecclesiasticorum latinorum, Volume 11). Engelbrecht, August, editor. Vienna: Gerold, 1885.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Claudianus Mamertus",
+    "work": "Epistolae",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0089a.stoa002/",
+    "print_source": "Claudianus Mamertus. Claudiani Mamerti opera (Corpus scriptorum ecclesiasticorum latinorum, Volume 11). Engelbrecht, August, editor. Vienna: Gerold, 1885.",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Claudius Mamertinus",
     "work": "Panegyricus",
     "e_source": "DigilibLT",
@@ -2200,12 +4112,60 @@
     "added_by": "Brianna Roberts"
   },
   {
+    "author": "Claudius Ptolemaeus",
+    "work": "Almagest",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0363.tlg001/",
+    "print_source": "Claudius Ptolemaeus. Claudii Ptolemaei Opera quae exstant omnia, Volume 1, Part 1-2. Heiberg, J.L., editor. Leipzig: Teubner, 1898-1903.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Claudius Ptolemaeus",
+    "work": "Apotelesmatica Tetrabiblos",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0363.tlg007/",
+    "print_source": "Claudius Ptolemaeus. Claudii Ptolemaei opera quae exstant omnia, Volume 3.1. Boll, Franz, and Boer, Emilie, editors. Leipzig: Teubner, 1954.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Claudius Ptolemaeus",
+    "work": "Musica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0363.tlg011/",
+    "print_source": "Claudius Ptolemaeus. Musici Scriptores Graeci. Jan, Karl von, editor. Leipzig: Teubner, 1895.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Clement of Alexandria",
+    "work": "Eclogae Propheticae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0555.tlg005/",
+    "print_source": "Otto Stählin, Stromata, Buch VII-VIII. Excerpta ex Theodoto. Eclogae prophetica., Leipzig. Hinrichs. 1909",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Clement of Alexandria",
+    "work": "Excerpta ex Theodoto",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0555.tlg007/",
+    "print_source": "Otto Stählin, Stromata, Buch VII-VIII. Excerpta ex Theodoto. Eclogae prophetica., Leipzig. Hinrichs. 1909",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Clement of Alexandria",
     "work": "Exhortation to Endurance, or to the Newly Baptized",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0632",
     "print_source": "Clement of Alexandria. G.W. Butterworth. Clement of Alexandria, with an English Translation by G.W. Butterworth. William Heinemann Ltd; G.P. Putnam's Sons. London; New York. 1919.",
     "added_by": "Katherine Roache"
+  },
+  {
+    "author": "Clement of Alexandria",
+    "work": "Paedagogus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0555.tlg002/",
+    "print_source": "Otto Stählin, Protrepticus und Paedagogus, Leipzig. Hinrichs. 1905",
+    "added_by": "V6 Import"
   },
   {
     "author": "Clement of Alexandria",
@@ -2224,12 +4184,36 @@
     "added_by": "Katherine Roache"
   },
   {
+    "author": "Clement of Alexandria",
+    "work": "Quis Dives Salvetur",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0555.tlg006/",
+    "print_source": "Otto Stählin, Stromata, Buch VII-VIII. Excerpta ex Theodoto. Eclogae prophetica., Leipzig. Hinrichs. 1909",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cleonides",
+    "work": "Introduction to Harmonics",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg1272.tlg001/",
+    "print_source": "CLeomedes. De motu circulari corporum caelestium. Ziegler, Konrad, editor. Leipzig: Teubner, 1891.",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Colluthus",
     "work": "Rape of Helen",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0495",
     "print_source": "Colluthus. A. W. Mair. Oppian, Colluthus, Tryphiodorus with an English Translation by A.W. Mair. London, William Heinemann, Ltd.; New York: G.P. Putnam's Sons. 1928.",
     "added_by": "Katherine Roache"
+  },
+  {
+    "author": "Columella",
+    "work": "De Re Rustica",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Columella",
@@ -2248,20 +4232,60 @@
     "added_by": "Anna Glenn"
   },
   {
-    "author": "Commodianus",
+    "author": "Commodian",
     "work": "Carmen Apologeticum",
-    "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
-    "print_source": "Bernhard Dombart. Commodiani Carmina. Vindobonae: Gerold. 1887.",
-    "added_by": "Caitlin Diddams"
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
-    "author": "Commodianus",
+    "author": "Commodian",
     "work": "Instructiones",
-    "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
-    "print_source": "Bernhard Dombart. Commodiani Carmina. Vindobonae: Gerold. 1887.",
-    "added_by": "Caitlin Diddams"
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Corippus",
+    "work": "Johannis",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Couplet Et Alii",
+    "work": "Confucius Sinarum Philosophus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cowper",
+    "work": "Task",
+    "e_source": "Project Gutenberg",
+    "e_source_url": "https://www.gutenberg.org/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cratetis Epistulae",
+    "work": "Epistulae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0623.tlg001/",
+    "print_source": "Rudolf Hercher, Epistolographi Graeci, Paris. A. F. Didot. 1873",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Critias",
+    "work": "Fragmenta",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0319.tlg004/",
+    "print_source": "Hermann Diels, Die Fragmente der Vorsokratiker, Berlin. Weidmann. 1922, Vol. 2",
+    "added_by": "V6 Import"
   },
   {
     "author": "Curtius Rufus",
@@ -2289,11 +4313,27 @@
   },
   {
     "author": "Cyprian",
+    "work": "Ad Quirinum Aut Testimoniorum Libri Tres Adversus Judaeos",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian",
     "work": "De Bono Patientiae",
     "e_source": "Open Greek and Latin",
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
     "print_source": "Wilhelm August Ritter von Hartel. S. Thasci Caecili Cypriani Opera Omnia. Vindobonae: Gerold. 1868.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Cyprian",
+    "work": "De Catholicae Ecclesiae Unitate",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Cyprian",
@@ -2321,11 +4361,27 @@
   },
   {
     "author": "Cyprian",
+    "work": "De Habitu Uirginum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian",
     "work": "De Lapsis",
     "e_source": "Open Greek and Latin",
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
     "print_source": "Wilhelm August Ritter von Hartel. S. Thasci Caecili Cypriani Opera Omnia. Vindobonae: Gerold. 1868.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Cyprian",
+    "work": "De Mortalitate",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Cyprian",
@@ -2338,14 +4394,6 @@
   {
     "author": "Cyprian",
     "work": "De Opere et Eleemosynis",
-    "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
-    "print_source": "Wilhelm August Ritter von Hartel. S. Thasci Caecili Cypriani Opera Omnia. Vindobonae: Gerold. 1868.",
-    "added_by": "Caitlin Diddams"
-  },
-  {
-    "author": "Cyprian",
-    "work": "De Unitate Ecclesiae Catholicae Liber",
     "e_source": "Open Greek and Latin",
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
     "print_source": "Wilhelm August Ritter von Hartel. S. Thasci Caecili Cypriani Opera Omnia. Vindobonae: Gerold. 1868.",
@@ -2369,6 +4417,14 @@
   },
   {
     "author": "Cyprian",
+    "work": "Fortunatum Aut de Exhortatione Martyrii",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian",
     "work": "Quod Idola Dii Non Sint",
     "e_source": "Open Greek and Latin",
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
@@ -2385,11 +4441,323 @@
   },
   {
     "author": "Cyprian",
+    "work": "Sententiae Episcoporum Numero Lxxxvii de Haereticis Baptizandis",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian",
     "work": "Testimoniorum Libri Tres adversus Judaeos",
     "e_source": "Open Greek and Latin",
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
     "print_source": "Wilhelm August Ritter von Hartel. S. Thasci Caecili Cypriani Opera Omnia. Vindobonae: Gerold. 1868.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "Ad Flavium Felicem de Resurrectione Mortuorum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "Ad Novatianum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "Ad Senatorem ex Christiana Religione ad Idolorum Servitutem Conversum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "Ad Vigilium de Iudaica Incredulitate",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "Adversus Iudaeos",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "De Bono Pudicitiae",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "De Duodecim Abusivis Saeculi",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "De Duplici Martyrio",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "De Iona",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "De Laude Martyrii",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "De Montibus Sina Et Sion",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "De Pascha",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "De Pascha Computus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "De Rebaptismate",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "De Singularitate Clericorum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "De Spectaculis",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "Epistulae",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "Genesis",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "Liber de Aleatoribus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "Orationes",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Pseudo",
+    "work": "Sodoma",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Saint",
+    "work": "Ad Demetrianum",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0104a.stoa002/",
+    "print_source": "Cyprian. Saint. S. Thasci Caecili Cypriani Opera omnia, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 3.1). Hartel, Wilhelm von, editor. Vienna: Gerold, 1868.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Saint",
+    "work": "Ad Donatum",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0104a.stoa001/",
+    "print_source": "Cyprian. Saint. S. Thasci Caecili Cypriani Opera omnia, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 3.1). Hartel, Wilhelm von, editor. Vienna: Gerold, 1868.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Saint",
+    "work": "De Bono Patientiae",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0104a.stoa003/",
+    "print_source": "Cyprian. Saint. S. Thasci Caecili Cypriani Opera omnia, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 3.1). Hartel, Wilhelm von, editor. Vienna: Gerold, 1868.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Saint",
+    "work": "De Disciplina Et Habitu Virginum Liber",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0104a.stoa004/",
+    "print_source": "Cyprian. Saint. S. Thasci Caecili Cypriani Opera omnia, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 3.1). Hartel, Wilhelm von, editor. Vienna: Gerold, 1868.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Saint",
+    "work": "De Dominica Oratione",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0104a.stoa015/",
+    "print_source": "Cyprian. Saint. S. Thasci Caecili Cypriani Opera omnia, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 3.1). Hartel, Wilhelm von, editor. Vienna: Gerold, 1868.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Saint",
+    "work": "De Exhortatione Martyrii",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0104a.stoa005/",
+    "print_source": "Cyprian. Saint. S. Thasci Caecili Cypriani Opera omnia, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 3.1). Hartel, Wilhelm von, editor. Vienna: Gerold, 1868.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Saint",
+    "work": "De Lapsis",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0104a.stoa007/",
+    "print_source": "Cyprian. Saint. S. Thasci Caecili Cypriani Opera omnia, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 3.1). Hartel, Wilhelm von, editor. Vienna: Gerold, 1868.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Saint",
+    "work": "De Mortalite",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0104a.stoa008/",
+    "print_source": "Cyprian. Saint. S. Thasci Caecili Cypriani Opera omnia, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 3.1). Hartel, Wilhelm von, editor. Vienna: Gerold, 1868.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Saint",
+    "work": "De Opere Et Eleemosynis",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0104a.stoa009/",
+    "print_source": "Cyprian. Saint. S. Thasci Caecili Cypriani Opera omnia, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 3.1). Hartel, Wilhelm von, editor. Vienna: Gerold, 1868.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Saint",
+    "work": "De Unitate Ecclesiae Catholicae Liber",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0104a.stoa010/",
+    "print_source": "Cyprian. Saint. S. Thasci Caecili Cypriani Opera omnia, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 3.1). Hartel, Wilhelm von, editor. Vienna: Gerold, 1868.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Saint",
+    "work": "De Zelo Et Livore",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0104a.stoa011/",
+    "print_source": "Cyprian. Saint. S. Thasci Caecili Cypriani Opera omnia, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 3.1). Hartel, Wilhelm von, editor. Vienna: Gerold, 1868.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Saint",
+    "work": "Epistulae",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0104a.stoa012/",
+    "print_source": "Cyprian. Saint. S. Thasci Caecili Cypriani Opera omnia, Pars II (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 3.2). Hartel, Wilhelm von, editor. Vienna: Gerold, 1871.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Saint",
+    "work": "Quod Idola Dii Non Sint",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0104a.stoa006/",
+    "print_source": "Cyprian. Saint. S. Thasci Caecili Cypriani Opera omnia, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 3.1). Hartel, Wilhelm von, editor. Vienna: Gerold, 1868.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Saint",
+    "work": "Sententiae Episcoporum",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0104a.stoa013/",
+    "print_source": "Cyprian. Saint. S. Thasci Caecili Cypriani Opera omnia, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 3.1). Hartel, Wilhelm von, editor. Vienna: Gerold, 1868.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprian Saint",
+    "work": "Testimoniorum Libri Tres Adversus Judaeo",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0104a.stoa014/",
+    "print_source": "Cyprian. Saint. S. Thasci Caecili Cypriani Opera omnia, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 3.1). Hartel, Wilhelm von, editor. Vienna: Gerold, 1868.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprianus Cordubensis",
+    "work": "Cypriani Et Samsonis Carmina",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Cyprianus Cordubensis",
+    "work": "Cypriani Et Samsonis Carminum Appendix",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Cyprianus Gallus",
@@ -2398,6 +4766,22 @@
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
     "print_source": "Rudolf Peiper. Cypriani Galli Poetae Heptateuchos. Vindobonae: Gerold. 1891.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Cyprianus, archipresbyter Cordubensis",
+    "work": "Cypriani Et Samsonis Carmina",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/CYPR_COR%7Ccarm%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Dante",
+    "work": "Divina Comedia",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Demades",
@@ -2928,6 +5312,54 @@
     "added_by": "V3 Legacy Import"
   },
   {
+    "author": "Dhuoda",
+    "work": "Rhythmi ex Manuali Dhuodanae",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/DHUODA%7Cdhuo%7C122",
+    "print_source": "K. Strecker, 1914",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Dhuoda",
+    "work": "Rhythmy ex Manuali Dhuodanae",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Dhuoda",
+    "work": "Versus de Eversione Monasterii Glonnensis",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/VERS_GLO%7Cvers%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Dicuil",
+    "work": "Versus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "K. Strecker, 1923",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Dicuil Scotus",
+    "work": "Versus",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/DICUIL%7Cvers%7C001",
+    "print_source": "K. Strecker, 1923",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Didymus Alexandrinus",
+    "work": "Mensurae Marmorum Ac Lignorum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0357.tlg001/",
+    "print_source": "Didymus Alexandrinus, Mensurae marmorum ac lignorum, Hultsch, Weidmann, 1864",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Dinarchus",
     "work": "Against Aristogiton",
     "e_source": "Perseus",
@@ -2950,6 +5382,22 @@
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3Atext%3A1999.01.0081%3Aspeech%3D3",
     "print_source": "Dinarchus. Minor Attic Orators in two volumes, 2, with an English translation by J. O. Burtt, M.A. Cambridge, MA, Harvard University Press; London, William Heinemann Ltd. 1962.",
     "added_by": "Katherine Roache"
+  },
+  {
+    "author": "Diogenianus of Heraclea",
+    "work": "Popular Proverbs",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg1328.tlg001/",
+    "print_source": "Ernst von Leutsch and F. G. Schneidewin, Paroemiographi Graeci, Vol. 1, Göttingen: Vandenhoeck et Ruprecht, 1839.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Dionysius Calliphontis",
+    "work": "Dionysii Calliphontis Filii Descriptio Graeciae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0069.tlg001/",
+    "print_source": "Dionysius, Calliphontis, creator; Geographi graeci minores Volumen Primum, ed. Karl Müller; Ambroise Firmin Didot, Paris, 1855",
+    "added_by": "V6 Import"
   },
   {
     "author": "Dionysius of Halicarnassus",
@@ -2985,11 +5433,27 @@
   },
   {
     "author": "Dionysius of Halicarnassus",
+    "work": "De Compositione Verborum Epitome",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0081.tlg013/",
+    "print_source": "Hermann Usener, Ludwig Radermacher, Dionysii Halicarnasei Opuscula, Leipzig. Teubner. 1904, Vol. 2",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Dionysius of Halicarnassus",
     "work": "De Demosthene",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0580",
     "print_source": "Hermann Usener, Dionysii Halicarnasei Quae Exstant, Volumen Quintum. Leipzig: In Aedibus B.G. Teubneri, 1899.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Dionysius of Halicarnassus",
+    "work": "De Demosthenis Dictione",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0081.tlg006/",
+    "print_source": "Dionysius of Halicarnassus. Dionysii Halicarnasei quae exstant, Volume 5.1: Opuscula, Volume 1. Usener, Hermann; Radermacher, Ludwig; editors. Leipzig: Teubner, 1899.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Dionysius of Halicarnassus",
@@ -3056,6 +5520,22 @@
     "added_by": "Caitlin Diddams"
   },
   {
+    "author": "Dionysius of Halicarnasus",
+    "work": "Ars Rhetorica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0081.tlg016/",
+    "print_source": "Hermann Usener, Ludwig Radermacher, Dionysii Halicarnasei Opuscula, Leipzig. Teubner. 1904, Vol. 2",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Dionysius of Halicarnasus",
+    "work": "De Imitatione Fragmenta",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0081.tlg014/",
+    "print_source": "Hermann Usener, Ludwig Radermacher, Dionysii Halicarnasei Opuscula, Leipzig. Teubner. 1904, Vol. 2",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Dracontius",
     "work": "De Laudibus Dei",
     "e_source": "MQDQ",
@@ -3097,11 +5577,35 @@
   },
   {
     "author": "Einhardus",
+    "work": "Einhardus",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/EINH%7Cpass%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Einhardus",
     "work": "Rythmus de Passione Marcellini et Petri",
     "e_source": "",
     "e_source_url": "",
     "print_source": "",
     "added_by": "M. Paccara & F. Stella (University of Siena)"
+  },
+  {
+    "author": "Engelmodus",
+    "work": "Carmina",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Engelmodus episcopus",
+    "work": "Carmina",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/ENGELM%7Ccarm%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
   },
   {
     "author": "Ennius",
@@ -3121,6 +5625,14 @@
   },
   {
     "author": "Ennodius",
+    "work": "Epigrammata",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ennodius",
     "work": "Epigrammatica",
     "e_source": "Open Greek and Latin",
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/   ",
@@ -3136,12 +5648,28 @@
     "added_by": "Cari Haas"
   },
   {
+    "author": "Eobanus",
+    "work": "Iliad",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Eobanus Hessus",
     "work": "Iliad",
     "e_source": "CAMENA",
     "e_source_url": "https://web.archive.org/web/20240812080521/http://mateo.uni-mannheim.de/camena/hessus3/hessusilias1_6.html",
     "print_source": "Harry Vredeveld, The Poetic Works of Helius Eobanus Hessus. Tempe: ACMRS Press, 2004–2008; Leiden: Brill, 2012–ongoing.",
     "added_by": "V3 Legacy Import"
+  },
+  {
+    "author": "Epicharmus",
+    "work": "Fragmenta",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0521.tlg008/",
+    "print_source": "Hermann Diels, Die Fragmente der Vorsokratiker, Berlin. Weidmann. 1922, Vol. 1",
+    "added_by": "V6 Import"
   },
   {
     "author": "Epictetus",
@@ -3168,6 +5696,118 @@
     "added_by": "V3 Legacy Import"
   },
   {
+    "author": "Epictetus",
+    "work": "Gnomologium Epicteteum E Stobaei Libris 34",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0557.tlg005/",
+    "print_source": "Heinrich Schenkl, Epicteti Dissertationes ab Arriano Digestae, Leipzig. Teubner. 1916",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Epicurus",
+    "work": "Epistula ad Herodotum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0537.tlg010/",
+    "print_source": "Peter von der Mühll, Epicuri epistulae tres et ratae sententiae a Laertio Diogene Servatae, Leipzig. Teubner. 1922",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Epicurus",
+    "work": "Gnomologium Vaticanum Epicureum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0537.tlg014/",
+    "print_source": "Peter von der Mühll, Epicuri epistulae tres et ratae sententiae a Laertio Diogene Servatae, Leipzig. Teubner. 1922",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Epicurus",
+    "work": "Ratae Sententiae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0537.tlg013/",
+    "print_source": "Peter von der Mühll, Epicuri epistulae tres et ratae sententiae a Laertio Diogene Servatae, Leipzig. Teubner. 1922",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Erchembertus, monachus Casinensis",
+    "work": "Martyrologium",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/ERCHEMB%7Cmart%7C001",
+    "print_source": "U. Westerbergh, 1957",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Erchempert",
+    "work": "Martyrologium",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ermenricus, monachus Elwangensis",
+    "work": "Epistola ad Grimaldum",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "",
+    "print_source": "E. Dümmler, K. Hampe, 1899",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Ermoldus Nigellus, Aquitanus",
+    "work": "Carmen in Honorem Ludowici Pii",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/ERMOLD%7Cludo%7C000",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Ermoldus Nigellus, Aquitanus",
+    "work": "Carmen in Laudem Pippini Regis",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/ERMOLD%7Cpipp%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Ermoldus Nigellus, Aquitanus",
+    "work": "Carminum Appendix",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/ERMOLD%7Ccaap%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Eucherius of Lyon",
+    "work": "De Laude Heremi",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0117.stoa001/",
+    "print_source": "Eucherius of Lyon. Sancti Eucherii Lugdunensis. Formulae spiritalis intellegentiae Instructionum libri duo Passio agaunensium martyrum Epistula de laude heremi (Corpus scriptorum ecclesiasticorum Latinorum, Volume 31). Wotke, Karl, editor. Prague; Vienna; Leipzig: Tempsky, Freytag, 1894.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Eucherius of Lyon",
+    "work": "Formulae Spiritalis Intellegentiae",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0117.stoa002/",
+    "print_source": "Eucherius of Lyon. Sancti Eucherii Lugdunensis. Formulae spiritalis intellegentiae Instructionum libri duo Passio agaunensium martyrum Epistula de laude heremi (Corpus scriptorum ecclesiasticorum Latinorum, Volume 31). Wotke, Karl, editor. Prague; Vienna; Leipzig: Tempsky, Freytag, 1894.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Eucherius of Lyon",
+    "work": "Instructiones",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0117.stoa003/",
+    "print_source": "Eucherius of Lyon. Sancti Eucherii Lugdunensis. Formulae spiritalis intellegentiae Instructionum libri duo Passio agaunensium martyrum Epistula de laude heremi (Corpus scriptorum ecclesiasticorum Latinorum, Volume 31). Wotke, Karl, editor. Prague; Vienna; Leipzig: Tempsky, Freytag, 1894.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Eucherius of Lyon",
+    "work": "Unknown",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0117.stoa004/",
+    "print_source": "Eucherius of Lyon. Sancti Eucherii Lugdunensis. Formulae spiritalis intellegentiae Instructionum libri duo Passio agaunensium martyrum Epistula de laude heremi (Corpus scriptorum ecclesiasticorum Latinorum, Volume 31). Wotke, Karl, editor. Prague; Vienna; Leipzig: Tempsky, Freytag, 1894.",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Euclid",
     "work": "Elements",
     "e_source": "Perseus",
@@ -3190,6 +5830,14 @@
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
     "print_source": "Pius Knoll. Eugippi Opera, Pars I. Vindobonae: Gerold. 1885.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Eugippius",
+    "work": "Exerpta ex Operibus Augustini",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Eugippius",
@@ -3238,6 +5886,14 @@
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.01.0095",
     "print_source": "Gilbert Murray, Euripidis Fabulae, vol 2.. Oxford: Clarendon Press, Oxford, 1913.",
     "added_by": "Tony R. Waleszczak &amp; Jessica Micceri"
+  },
+  {
+    "author": "Euripides",
+    "work": "Fragmenta",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0006.tlg020/",
+    "print_source": "August Nauck, Tragicorum Graecorum Fragmenta, Leipzig. Teubner. 1889",
+    "added_by": "V6 Import"
   },
   {
     "author": "Euripides",
@@ -3345,11 +6001,27 @@
   },
   {
     "author": "Euripides",
+    "work": "Supplices",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0006.tlg006/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Euripides",
     "work": "The Trojan Women",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.01.0123",
     "print_source": "Gilbert Murray, Euripidis Fabulae, vol. 2. Oxford: Clarendon Press, Oxford, 1913.",
     "added_by": "Tony R. Waleszczak &amp; Jessica Micceri"
+  },
+  {
+    "author": "Euripides",
+    "work": "Troades",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0006.tlg010/",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Eusebius of Caesarea",
@@ -3368,12 +6040,92 @@
     "added_by": "Caitlin Diddams"
   },
   {
+    "author": "Eutropius",
+    "work": "Breviarium Historiae Romanae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:stoa0121.stoa001/",
+    "print_source": "Hans Droysen, Eutropi Breviarium ab urbe condita cum versionibus graecis et Pauli Landolfique additamentis, Berolini. Weidmann. 1879",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Evagrius Monachus",
+    "work": "Altercatio Legis Inter Simonem Iudaeum E",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0120c.stoa001/",
+    "print_source": "Evagrius Monachus. Scriptores ecclesiastici minores saeculorum IV. V. VI, Volume 1 (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 45). Bratke, Eduard. Vienna; Leipzig: Tempsky, Freytag, 1904.",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Evodius",
     "work": "De Fide Contra Manicheos",
     "e_source": "Open Greek and Latin",
     "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
     "print_source": "Joseph Zycha. Sancti Aurelii Augustini Opera, Sect VI Pars II. Vindobonae: Gerold. 1892.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Evodius Bishop of Uzalis",
+    "work": "De Fide Contra Manicheos",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0120d.stoa001/",
+    "print_source": "Evodius, Bishop of Uzalis. Sancti Aureli Augustini Opera, Sectio VI, Pars II (Corpus scriptorum ecclesiasticorum Latinorum, Volume 25.2). Zycha, Joseph editor. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1892.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Fardulfus",
+    "work": "Carmina",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Fardulfus abbas",
+    "work": "Carmina",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/FARD%7Ccarm%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Faustus of Riez",
+    "work": "De Gratia Libri Duo",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0121g.stoa001/",
+    "print_source": "Faustus of Riez. Fausti Reiensis praeter sermones pseudo-eusebianos opera (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 21). Engelbrecht, August, editor. Prague; Vienna; Leipzig: Tempsky, Freytag, 1891.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Faustus of Riez",
+    "work": "De Ratione Fidei",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0121g.stoa005/",
+    "print_source": "Faustus of Riez. Fausti Reiensis praeter sermones pseudo-eusebianos opera (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 21). Engelbrecht, August, editor. Prague; Vienna; Leipzig: Tempsky, Freytag, 1891.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Faustus of Riez",
+    "work": "De Spiritu Sancto Libri Duo",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0121g.stoa002/",
+    "print_source": "Faustus of Riez. Fausti Reiensis praeter sermones pseudo-eusebianos opera (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 21). Engelbrecht, August, editor. Prague; Vienna; Leipzig: Tempsky, Freytag, 1891.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Faustus of Riez",
+    "work": "Epistulae",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0121g.stoa003/",
+    "print_source": "Faustus of Riez. Fausti Reiensis praeter sermones pseudo-eusebianos opera (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 21). Engelbrecht, August, editor. Prague; Vienna; Leipzig: Tempsky, Freytag, 1891.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Faustus of Riez",
+    "work": "Sermones",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0121g.stoa004/",
+    "print_source": "Faustus of Riez. Fausti Reiensis praeter sermones pseudo-eusebianos opera (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 21). Engelbrecht, August, editor. Prague; Vienna; Leipzig: Tempsky, Freytag, 1891.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Favonius",
@@ -3417,11 +6169,27 @@
   },
   {
     "author": "Flavius Josephus",
+    "work": "De Iudaeorum Vetustate Sive Contra Apion",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0526.tlg003/",
+    "print_source": "Flavius Josephus. Flavii Iosephi Opera, Vol. 5. Niese, Benedikt, editor. Berlin: Weidmann, 1889.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Flavius Josephus",
     "work": "Josephi Vita",
     "e_source": "Perseus",
     "e_source_url": "https://web.archive.org/web/20240812080521/http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.01.0149",
     "print_source": "B. Niese, Flavii Iosephi opera. Berlin: Weidmann, 1890.",
     "added_by": "V3 Legacy Import"
+  },
+  {
+    "author": "Florus",
+    "work": "Epitome Bellorum Omnium Annorum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Florus",
@@ -3440,12 +6208,572 @@
     "added_by": "Caitlin Diddams"
   },
   {
+    "author": "Florus of Lyon",
+    "work": "Carmina",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Florus of Lyon",
+    "work": "Carminum Appendix",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Florus, diaconus Lugdunensis",
+    "work": "Carmina",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/FLOR_LGD%7Ccarm%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Florus, diaconus Lugdunensis",
+    "work": "Carminum Appendix",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/FLOR_LGD%7Ccarx%7C001",
+    "print_source": "K. Strecker, 1923",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
     "author": "Fulcher of Chartres",
     "work": "Historia Hierosolymitana",
     "e_source": "archive.org",
     "e_source_url": "https://web.archive.org/web/20240812080521/https://archive.org/details/historiahierosol00foucuoft/mode/2up",
     "print_source": "Fulcheri Carnotensis Historia Hierosolymitana (1095-1127). Mit Erläuterungen und einem Anhange herausgegeben von Heinrich Hagenmeyer. Heidelberg, Carl Winters Universitätsbuchhandlung, 1913.",
     "added_by": "V3 Legacy Import"
+  },
+  {
+    "author": "Gaius Romanus",
+    "work": "Fragmenta",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0572.tlg001/",
+    "print_source": "Martin Joseph Routh, Reliquiae Sacrae, Oxford. Oxford University Press. 1846, Vol. 2",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "Ad Glauconem de Methodo Medendi",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg067/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1826",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "Adhortatio ad Artes Addiscendas",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg001/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1821",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "An in Arteriis Sanguis Contineatur",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg023/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1822",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Anatomicis Administrationibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg011/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1821",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Antidotis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg078/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1827",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Atra Bile",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg030/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1823",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Bono Habitu",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg025/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1822",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Causis Morborum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg042/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1824",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Comate Secundum Hippocratem",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg052/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1824",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Compositione Medicamentorum Secundum Locos Ivi",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg076/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1826",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Constitutione Artis Medicae ad Patrophilum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg006/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1821",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Consuetudinibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg103/",
+    "print_source": "Iwan von Müller, Galeni libellus De consuetudinibus, Erlangen. Universität Erlangen. 1879",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Crisibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg064/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1825",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Curandi Ratione Per Venae Sectionem",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg070/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1826",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Diebus Decretoriis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg065/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1825",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Difficultate Respirationis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg056/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1824",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Dignoscendis Pulsibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg060/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1824",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Dignotione ex Insomniis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg040/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1823",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Elementis ex Hippocrate",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg008/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1821",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Experientia Medica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg107/",
+    "print_source": "Hermann Schöne, Eine Streitschrift Galen's gegen die empirischen Ärzte, Berlin. Reimer. 1901",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Foetuum Formatione",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg022/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1822",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Hirudinibus Revulsione Cucurbitula Incisione Et",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg071/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1826",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Humero Iis Modis Prolapso Quos Hippocrates Non",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg096/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1829",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Inaequali Intemperie",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg055/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1824",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Instrumento Odoratus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg015/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1821",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Locis Affectis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg057/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1824",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Marcore",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg053/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1824",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Methodo Medendi",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg066/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1825",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Morborum Differentiis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg041/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1823",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Motu Musculorum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg018/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1822",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Naturalibus Facultatibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg010/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1821",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Nervorum Dissectione",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg014/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1821",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Optima Doctrina",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg002/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1821",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Ossibus ad Tirones",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg012/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1821",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Parvae Pilae Exercitio",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg034/",
+    "print_source": "Johannes Marquardt, Claudii Galeni librum De parvae pilae exercitio, Güstrow. Domschule. 1879",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Placitis Hippocratis Et Platonis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg032/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1823",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Plenitudine",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg050/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1824",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Praenotione ad Epigenem",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg083/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1827",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Praesagitione ex Pulsibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg062/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1825",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Propriorum Animi Cuiuslibet Affectuum Dignotion",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg028/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1823",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Ptisana",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg039/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1823",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Pulsibus ad Tirones",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg058/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1824",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Purgantium Medicamentorum Facultate",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg072/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1826",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Rebus Boni Malique Suci",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg038/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1823",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Sanitate Tuenda",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg036/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1823",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Sectis ad Eos Qui Introducuntur",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg004/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1821",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Semine",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg021/",
+    "print_source": "Karl Gottlob Kühn, >Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1822",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Simplicium Medicamentorum Temperamentis Ac Facu",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg075/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1826",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Sophismatis Seu Captionibus Penes Dictionem",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg082/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1827",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Substantia Facultatum Naturalium Fragmentum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg084/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1822",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Symptomatum Differentiis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg043/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1824",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Temperamentis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg009/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1821",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Theriaca ad Pisonem",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg079/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1827",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Totius Morbi Temporibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg047/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1824",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Tremore Palpitatione Convulsione Et Rigore",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg051/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1824",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Tumoribus Praeter Naturam",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg054/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1824",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Typis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg048/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1824",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Usu Partium Corporis Humani Ixi",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg017/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1822",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Uteri Dissectione",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg016/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1821",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Utilitate Respirationis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg020/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1822",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Venae Sectione Adversus Erasistratum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg068/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1826",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Venarum Arteriarumque Dissectione",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg013/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1821",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Venereis Ap Oribasium",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg035/",
+    "print_source": "Galen. Claudii Galeni Opera Omnia, Volume 5. Kühn, Karl Gottlob, editor. Leipzig: Knobloch, 1823.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "De Victu Attenuante",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg019/",
+    "print_source": "Karl Kalbfleisch, Galeni De victu attenuante liber, Leipzig. B. G. Teubner. 1898",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "Institutio Logica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg081/",
+    "print_source": "Karl Kalbfleisch, Galeni Institutio logica, Leipzig. B. G. Teubner. 1896",
+    "added_by": "V6 Import"
   },
   {
     "author": "Galen",
@@ -3456,6 +6784,54 @@
     "added_by": "Jessica Micceri"
   },
   {
+    "author": "Galen",
+    "work": "On the Powers of Foods",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg079/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1827",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "Protrepticus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg001/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1821",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "Quod Optimus Medicus Sit Quoque Philosophus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg003/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1821",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "Quos Quibus Catharticis Medicamentis Et Quando Pur",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg073/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Knobloch. 1826",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "Synopsis Librorum Suorum de Pulsibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg063/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Leipzig. Knobloch. 1825",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Galen",
+    "work": "Thrasybulus Sive Utrum Medicinae Sit an Gymnastica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0057.tlg033/",
+    "print_source": "George Helmreich, Claudii Galeni Pergameni Scripta Minora, Leipzig. Teubner. 1893, Vol. 3",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Gellius",
     "work": "Attic Nights",
     "e_source": "Perseus",
@@ -3464,12 +6840,92 @@
     "added_by": "Anna Glenn"
   },
   {
+    "author": "Gerwardus",
+    "work": "Versus",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/GERWARD%7Cvers%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Giovanni Aurelio Augurelli",
+    "work": "Chrysopoeia",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Giraldus, monachus Floriacensis",
+    "work": "Carmina",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/GIR_FLOR%7Ccarm%7C001",
+    "print_source": "R. B. C. Huygens, 2000",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
     "author": "Glass",
     "work": "Washingtonii Vita",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.02.0129",
     "print_source": "J.N. Reynolds, Washingtonii Vita. New York: Harper &amp; Brothe rs, 1842.",
     "added_by": "Anna Glenn"
+  },
+  {
+    "author": "Godescalcus Saxo",
+    "work": "Carmina I",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/GODESC%7Ccai_%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Godescalcus Saxo",
+    "work": "Carmina II",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/GODESC%7Ccaii%7C001",
+    "print_source": "K. Strecker, 1951",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Godescalcus Saxo",
+    "work": "Versus",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/GODESC%7Cvers%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Godescalcus Saxus",
+    "work": "Carmina",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Godescalcus Saxus",
+    "work": "Carminum Appendix",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Gorgias of Leontini",
+    "work": "Defense of Palamedes",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0593.tlg002/",
+    "print_source": "Gorgias. Antiphontis orationes et fragmenta adiunctis Gorgiae, Antisthenis, Alcidamantis declamationibus. Blass, Friedrich, editor. Leipzig: Teubner, 1908.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Gorgias of Leontini",
+    "work": "Encomium of Helen",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0593.tlg001/",
+    "print_source": "Gorgias. Antiphontis orationes et fragmenta adiunctis Gorgiae, Antisthenis, Alcidamantis declamationibus. Blass, Friedrich, editor. Leipzig: Teubner, 1908.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Gregory of Nazianzus",
@@ -3488,12 +6944,164 @@
     "added_by": "Caitlin Diddams"
   },
   {
+    "author": "Hanno",
+    "work": "Periplus Hannonis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0064.tlg001/",
+    "print_source": "Hanno, Periplus; Geographi graeci minores Volumen Primum, ed. Karl Müller; Ambroise Firmin Didot, Paris, 1855",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hegesippus Pseudo",
+    "work": "De Excidio Hierosolymitano",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Heiricus, monachus Autissiodorensis",
+    "work": "Vita Germani Episcopi Autissiodorensis",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/HEIRIC%7Cvige%7C00a",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Heraclitus of Ephesus",
+    "work": "Fragmenta",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0626.tlg002/",
+    "print_source": "Hermann Diels, Die Fragmente der Vorsokratiker, Berlin. Weidmann. 1922, Vol. 1",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hermogenes",
+    "work": "On Stases",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0592.tlg001/",
+    "print_source": "Hermogenes. Hermogenis Opera. Rabe, Hugo, editor. Leipzig: Teubner, 1913.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hermogenes",
+    "work": "Progymnasmata Dub",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0592.tlg001/",
+    "print_source": "Hermogenes. Hermogenis Opera. Rabe, Hugo, editor. Leipzig: Teubner, 1913.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hero of Alexandria",
+    "work": "Belopoeica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0559.tlg012/",
+    "print_source": "Hero of Alexandria. Greek and Roman Artillery: Technical Treatises. Marsden, Eric William, editor. Oxford: Clarendon Press, 1971.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hero of Alexandria",
+    "work": "Catoptrica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0559.tlg005/",
+    "print_source": "Hero of Alexandria. Herons Von Alexandria Mechanik Und Katoptrik (Heronis Alexandrini Opera Quae Superunt Omnia, Volume 2.1) Schmidt, Wilhelm; Nix, Ludwig, editors. Leipzig: Teubner, 1900.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hero of Alexandria",
+    "work": "De Automatis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0559.tlg002/",
+    "print_source": "Hero of Alexandria. Herons Von Alexandria Druckwerke Und Automatentheater (Heronis Alexandrini Opera Quae Superunt Omnia, Volume 1). Schmidt, Wilhelm, editor. Leipzig: Teubner, 1899.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hero of Alexandria",
+    "work": "De Mensuris",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0559.tlg011/",
+    "print_source": "Hero of Alexandria. Heronis quae feruntur sterometrica et de mensuris (Heronis Alexandrini Opera Quae Superunt Omnia, Volume 5). Heiberg, Johan Ludvig, editor. Leipzig: Teubner, 1914.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hero of Alexandria",
+    "work": "Dioptra",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0559.tlg007/",
+    "print_source": "Hero of Alexandria. Herons Von Alexandria Vermessungslehre und Dioptra (Heronis Alexandrini Opera Quae Superunt Omnia, Volume 3). Schöne, Hermann, editor. Leipzig: Teubner, 1903.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hero of Alexandria",
+    "work": "Geodaesia Sp",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0559.tlg015/",
+    "print_source": "Hero of Alexandria. Heronis quae feruntur sterometrica et de mensuris (Heronis Alexandrini Opera Quae Superunt Omnia, Volume 5). Heiberg, Johan Ludvig, editor. Leipzig: Teubner, 1914.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hero of Alexandria",
+    "work": "Mechanicorum Fragmenta",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0559.tlg004/",
+    "print_source": "Hero of Alexandria. Herons Von Alexandria Mechanik Und Katoptrik (Heronis Alexandrini Opera Quae Superunt Omnia, Volume 2.1) Schmidt, Wilhelm; Nix, Ludwig, editors. Leipzig: Teubner, 1900.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hero of Alexandria",
+    "work": "Metrica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0559.tlg006/",
+    "print_source": "Hero of Alexandria. Herons Von Alexandria Vermessungslehre und Dioptra (Heronis Alexandrini Opera Quae Superunt Omnia, Volume 3). Schöne, Hermann, editor. Leipzig: Teubner, 1903.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hero of Alexandria",
+    "work": "Pneumatica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0559.tlg001/",
+    "print_source": "Hero of Alexandria. Herons Von Alexandria Druckwerke Und Automatentheater (Heronis Alexandrini Opera Quae Superunt Omnia, Volume 1). Schmidt, Wilhelm, editor. Leipzig: Teubner, 1899.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hero of Alexandria",
+    "work": "Stereometrica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0559.tlg010/",
+    "print_source": "Hero of Alexandria. Heronis quae feruntur sterometrica et de mensuris (Heronis Alexandrini Opera Quae Superunt Omnia, Volume 5). Heiberg, Johan Ludvig, editor. Leipzig: Teubner, 1914.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Herodian",
+    "work": "Ab Excessu Divi Marci",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0015.tlg001/",
+    "print_source": "Herodian. Ab excessu divi Marci. Bekker, Immanuel, editor. Leipzig: Teubner, 1855.",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Herodian",
     "work": "History of the Empire",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus:text:2008.01.0596",
     "print_source": "",
     "added_by": "V3 Legacy Import"
+  },
+  {
+    "author": "Herodianus",
+    "work": "Symposium",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0015.tlg002/",
+    "print_source": "Augustus Lentz, Grammatici Graeci, Vol. 3.1, Leipzig: Teubner, 1867.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Herodotus",
+    "work": "Histories",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0016.tlg001/",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Herodotus",
@@ -3504,6 +7112,22 @@
     "added_by": "Jessica Micceri"
   },
   {
+    "author": "Heronis Alexandrini",
+    "work": "Liber Geeponicus Sp",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0559.tlg016/",
+    "print_source": "Hero of Alexandria. Heronis Alexandrini geometricorum et stereometricorum reliquiae. Hultsch, Friedrich, editor. Berlin: Weidmann, 1864.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hesiod",
+    "work": "Theogony",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0020.tlg001/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Hesiod",
     "work": "Works and Days",
     "e_source": "Bibliotheca Augustana",
@@ -3512,10 +7136,26 @@
     "added_by": "Cari Haas"
   },
   {
+    "author": "Hibernicus Exul",
+    "work": "Carmina",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hibernicus Exul, vel Dungalus Scotus",
+    "work": "Carmina",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/HIB_EXUL%7Ccarm%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
     "author": "Hilary of Poitiers",
     "work": "Fragmenta Historica",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0149",
     "print_source": "Alfred Leonhard Feder. S. Hilarii Episcopi Pictaviensis Opera, Pars IV. Vindobonae: Gerold. 1916.",
     "added_by": "Caitlin Diddams"
   },
@@ -3523,7 +7163,7 @@
     "author": "Hilary of Poitiers",
     "work": "Fragmenta Minora",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0149",
     "print_source": "Alfred Leonhard Feder. S. Hilarii Episcopi Pictaviensis Opera, Pars IV. Vindobonae: Gerold. 1916.",
     "added_by": "Caitlin Diddams"
   },
@@ -3531,7 +7171,7 @@
     "author": "Hilary of Poitiers",
     "work": "Hymni",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0149",
     "print_source": "Alfred Leonhard Feder. S. Hilarii Episcopi Pictaviensis Opera, Pars IV. Vindobonae: Gerold. 1916.",
     "added_by": "Caitlin Diddams"
   },
@@ -3539,7 +7179,7 @@
     "author": "Hilary of Poitiers",
     "work": "Liber ad Constantium Imperatorem",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0149",
     "print_source": "Alfred Leonhard Feder. S. Hilarii Episcopi Pictaviensis Opera, Pars IV. Vindobonae: Gerold. 1916.",
     "added_by": "Caitlin Diddams"
   },
@@ -3547,7 +7187,7 @@
     "author": "Hilary of Poitiers",
     "work": "Oratio Synodi Sardicensis ad Constantium Imperatorem",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0149",
     "print_source": "Alfred Leonhard Feder. S. Hilarii Episcopi Pictaviensis Opera, Pars IV. Vindobonae: Gerold. 1916.",
     "added_by": "Caitlin Diddams"
   },
@@ -3555,7 +7195,7 @@
     "author": "Hilary of Poitiers",
     "work": "Tractatus Mysteriorum",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0149",
     "print_source": "Alfred Leonhard Feder. S. Hilarii Episcopi Pictaviensis Opera, Pars IV. Vindobonae: Gerold. 1916.",
     "added_by": "Caitlin Diddams"
   },
@@ -3563,9 +7203,97 @@
     "author": "Hilary of Poitiers",
     "work": "Tractatus Super Psalmos",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0149",
     "print_source": "Anton Zingerle. Tractatus Super Psalmos. Vindobonae: Gerold. 1891.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Hilary Saint Archbishop of Arles",
+    "work": "Epistulae ad Eucherium",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hilary Saint Bishop of Poitiers",
+    "work": "Collectanea Antiariana Parisina",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0149b.stoa002/",
+    "print_source": "Hilary, Saint, Bishop of Poitiers. S. Hilarii episcopi Pictaviensis opera (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 65.4). Feder, Alfred, editor. Vienna, Leipzig: Tempsky, Freytag, 1916.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hilary Saint Bishop of Poitiers",
+    "work": "Fragmenta Minora",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0149b.stoa003/",
+    "print_source": "Hilary, Saint, Bishop of Poitiers. S. Hilarii episcopi Pictaviensis opera (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 65.4). Feder, Alfred, editor. Vienna, Leipzig: Tempsky, Freytag, 1916.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hilary Saint Bishop of Poitiers",
+    "work": "Hymni",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0149b.stoa004/",
+    "print_source": "Hilary, Saint, Bishop of Poitiers. S. Hilarii episcopi Pictaviensis opera (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 65.4). Feder, Alfred, editor. Vienna, Leipzig: Tempsky, Freytag, 1916.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hilary Saint Bishop of Poitiers",
+    "work": "Liber ad Constantium Imperatorem",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0149b.stoa005/",
+    "print_source": "Hilary, Saint, Bishop of Poitiers. S. Hilarii episcopi Pictaviensis opera (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 65.4). Feder, Alfred, editor. Vienna, Leipzig: Tempsky, Freytag, 1916.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hilary Saint Bishop of Poitiers",
+    "work": "Libri Tres Adversum Valentem Et Ursacium",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0149b.stoa006/",
+    "print_source": "Hilary, Saint, Bishop of Poitiers. S. Hilarii episcopi Pictaviensis opera (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 65.4). Feder, Alfred, editor. Vienna, Leipzig: Tempsky, Freytag, 1916.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hilary Saint Bishop of Poitiers",
+    "work": "Oratio Synodi Sardicensis ad Constantium",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0149b.stoa007/",
+    "print_source": "Alfred Feder, S. Hilarii episcopi Pictaviensis opera, Vienna. Tempsky. 1916",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hilary Saint Bishop of Poitiers",
+    "work": "Spuria",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0149b.stoa008/",
+    "print_source": "Hilary, Saint, Bishop of Poitiers. S. Hilarii episcopi Pictaviensis opera (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 65.4). Feder, Alfred, editor. Vienna, Leipzig: Tempsky, Freytag, 1916.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hilary Saint Bishop of Poitiers",
+    "work": "Tractatus Mysteriorum",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0149b.stoa009/",
+    "print_source": "Hilary, Saint, Bishop of Poitiers. S. Hilarii episcopi Pictaviensis opera (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 65.4). Feder, Alfred, editor. Vienna, Leipzig: Tempsky, Freytag, 1916.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hilary Saint Bishop of Poitiers",
+    "work": "Tractatus Super Psalmos",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0149b.stoa001/",
+    "print_source": "Hilary, Saint, Bishop of Poitiers. S. Hilarii Episcopi Pictaviensis Tractatus super psalmos. (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 22). Zingerle, Anton, editor. Prague, Vienna, Leipzig: Tempsky, Freytag, 1891.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hildebert of Lavardin",
+    "work": "Carmen in Libros Regum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Hildebert of Lavardin",
@@ -3574,6 +7302,158 @@
     "e_source_url": "http://www.thelatinlibrary.com/hildebert.html",
     "print_source": "",
     "added_by": "V3 Legacy Import"
+  },
+  {
+    "author": "Hildebert of Lavardin",
+    "work": "Carmina Minora",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hildebert of Lavardin",
+    "work": "Carminum Supplementum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hildebert of Lavardin",
+    "work": "De Machabaeis",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hildebert of Lavardin",
+    "work": "De Mysterio Missae",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hildebert of Lavardin",
+    "work": "De Operibus Sex Dierum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hildebert of Lavardin",
+    "work": "De Ordine Mundi",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hildebert of Lavardin",
+    "work": "De Querimonia Et Conflictu Carnis Et Spiritus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hildebert of Lavardin",
+    "work": "In Primum Caput Ecclesiastes",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hildebert of Lavardin",
+    "work": "Vita Mariae Aegyptiacae",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hildebertus episcopus Cenomanensis",
+    "work": "Carmina Minora",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/HILD_CEN%7Cmyst%7C001",
+    "print_source": "Bourassé 1893 (PL 171)Scott 1969Orth 2000",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Hildebertus episcopus Cenomanensis",
+    "work": "De Machabeis",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/HILD_CEN%7Cmyst%7C001",
+    "print_source": "Bourassé 1893 (PL 171)Scott 1969Orth 2000",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Hildebertus episcopus Cenomanensis",
+    "work": "De Mysterio Missae",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/HILD_CEN%7Cmyst%7C001",
+    "print_source": "Bourassé 1893 (PL 171)Scott 1969Orth 2000",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Hildebertus episcopus Cenomanensis",
+    "work": "In Libros Regum",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/HILD_CEN%7Cmyst%7C001",
+    "print_source": "Bourassé 1893 (PL 171)Scott 1969Orth 2000",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Hildebertus episcopus Cenomanensis",
+    "work": "Querimonia Carnis Et Spiritus",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/HILD_CEN%7Cmyst%7C001",
+    "print_source": "Bourassé 1893 (PL 171)Scott 1969Orth 2000",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Hildebertus episcopus Cenomanensis",
+    "work": "Vita Mariae Aegyptiacae",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/HILD_CEN%7Cmyst%7C001",
+    "print_source": "Bourassé 1893 (PL 171)Scott 1969Orth 2000",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Hincmar",
+    "work": "Carmina",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hincmarus, archiepiscopus Remensis",
+    "work": "Carmina",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/HINCM%7Ccarm%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Hippocrates",
+    "work": "Aphorismi",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg012/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1844",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hippocrates",
+    "work": "Coa Praesagia",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg017/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1846",
+    "added_by": "V6 Import"
   },
   {
     "author": "Hippocrates",
@@ -3585,11 +7465,91 @@
   },
   {
     "author": "Hippocrates",
+    "work": "De Aere Aquis Locis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg002/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1840",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hippocrates",
     "work": "De Alimento",
     "e_source": "Perseus",
     "e_source_url": "https://web.archive.org/web/20240812080521/http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.01.0249%3atext%3dAlim",
     "print_source": "W. H. S. Jones, Hippocrates Collected Works I. Cambridge: Harvard University Press, 1868",
     "added_by": "V3 Legacy Import"
+  },
+  {
+    "author": "Hippocrates",
+    "work": "De Arte",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg018/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1849",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hippocrates",
+    "work": "De Articulis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg010/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1844",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hippocrates",
+    "work": "De Capitis Vulneribus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg007/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1841",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hippocrates",
+    "work": "De Diaeta in Morbis Acutis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg004/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1840",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hippocrates",
+    "work": "De Flatibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg021/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1849",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hippocrates",
+    "work": "De Fracturis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg009/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1841",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hippocrates",
+    "work": "De Genitura",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg024a/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1851",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hippocrates",
+    "work": "De Humoribus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg015/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1846",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hippocrates",
+    "work": "De Liquidorum Usu",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg022/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1849",
+    "added_by": "V6 Import"
   },
   {
     "author": "Hippocrates",
@@ -3601,11 +7561,43 @@
   },
   {
     "author": "Hippocrates",
+    "work": "De Natura Hominis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg019/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1849",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hippocrates",
+    "work": "De Officina Medici",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg008/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1841",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hippocrates",
     "work": "De Prisca Medicina",
     "e_source": "Perseus",
     "e_source_url": "https://web.archive.org/web/20240812080521/http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.01.0249%3atext%3dVM",
     "print_source": "W. H. S. Jones, Hippocrates Collected Works I. Cambridge: Harvard University Press, 1868",
     "added_by": "V3 Legacy Import"
+  },
+  {
+    "author": "Hippocrates",
+    "work": "De Salubri Diaeta",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg020/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1849",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hippocrates",
+    "work": "Epidemiarum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg006/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1840",
+    "added_by": "V6 Import"
   },
   {
     "author": "Hippocrates",
@@ -3630,6 +7622,30 @@
     "e_source_url": "https://web.archive.org/web/20240812080521/http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.01.0249%3atext%3dPraec.",
     "print_source": "W. H. S. Jones, Hippocrates Collected Works I. Cambridge: Harvard University Press, 1868",
     "added_by": "V3 Legacy Import"
+  },
+  {
+    "author": "Hippocrates",
+    "work": "Prognosticon",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg003/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1840",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hippocrates",
+    "work": "Prorrheticon I",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg016/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1846",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hippocrates",
+    "work": "Vectiarius",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0627.tlg011/",
+    "print_source": "Émile Littré, Oeuvres complètes d'Hippocrate, Paris. Baillière. 1844",
+    "added_by": "V6 Import"
   },
   {
     "author": "Homer",
@@ -3696,6 +7712,86 @@
     "added_by": "Chris Forstall"
   },
   {
+    "author": "Hrabanus",
+    "work": "Carmen Evangeliorum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hrabanus",
+    "work": "Carmina",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hrabanus",
+    "work": "Carminum Appendix",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hrabanus",
+    "work": "De Imagine Caesaris",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hrabanus",
+    "work": "Laudes Crucis",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Hrabanus Maurus, abbas Fuldensis, archiep. Moguntinus",
+    "work": "Carmen Euangeliorum",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/HRABAN%7Ceuan%7C001",
+    "print_source": "K. Strecker, 1923",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Hrabanus Maurus, abbas Fuldensis, archiep. Moguntinus",
+    "work": "Carmina",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/HRABAN%7Ccarm%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Hrabanus Maurus, abbas Fuldensis, archiep. Moguntinus",
+    "work": "Carminum Appendix",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/HRABAN%7Ccaap%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Hrabanus Maurus, abbas Fuldensis, archiep. Moguntinus",
+    "work": "De Imagine Caesaris",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/HRABAN%7Cimag%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Hrabanus Maurus, abbas Fuldensis, archiep. Moguntinus",
+    "work": "Laudes Crucis",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/HRABAN%7Claud%7C000",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
     "author": "Hyperides",
     "work": "Speeches (Greek). Machine readable text",
     "e_source": "Perseus",
@@ -3704,12 +7800,44 @@
     "added_by": "Jessica Micceri"
   },
   {
+    "author": "Iohannes Hymmonides, diaconus Romanus",
+    "work": "Iohannes Hymmonides, Diaconus Romanus",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/IOH_HYMM%7Ccena%7C001",
+    "print_source": "K. Strecker, 1914",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Iohannes Scotus 'Eriugena'",
+    "work": "Carmina",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/IOH_SCOT%7Ccarm%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Iohannes Scotus 'Eriugena'",
+    "work": "Carminum Appendix",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/IOH_SCOT%7Ccarm%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
     "author": "Isaeus",
     "work": "Speeches (Greek). Machine readable text",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.01.0141",
     "print_source": "Isaeus with an English translation by Edward Seymour Forster, M.A..Cambridge, MA, Harvard University Press; London, William Heinemann Ltd., 1962.",
     "added_by": "Jessica Micceri"
+  },
+  {
+    "author": "Isidore of Charax",
+    "work": "Mansiones Parthicae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0070.tlg001/",
+    "print_source": "Isidore, of Charax. Geographi graeci minores, Volume 1. Müller, Karl, editor. Paris: Ambroise Firmin Didot, 1855.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Isocrates",
@@ -3728,18 +7856,50 @@
     "added_by": "V3 Legacy Import"
   },
   {
+    "author": "Italicus",
+    "work": "Ilias Latina",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Iulius Firmicus Maternus",
+    "work": "Liber de Errore Profanorum Religionum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Iuuencus",
+    "work": "Euangeliorum Libri",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Jerome",
-    "work": "Epistulae. Selections.",
-    "e_source": "Perseus",
-    "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0566",
-    "print_source": "F.A. Wright, Select Letters of St. Jerome. London; Cambridg e, Massachusetts: William Heinemann Ltd.; Harvard University Press, 1933.",
-    "added_by": "Anna Glenn"
+    "work": "Epistulae",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "In Hieremiam Prophetam",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Jerome",
     "work": "In Hieremiam Prophetam Libri Sex",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0162",
     "print_source": "Siegfried Reiter. In Hieremiam Prophetam Libri Sex. Vindobonae: Gerold. 1913.",
     "added_by": "Caitlin Diddams"
   },
@@ -3752,18 +7912,714 @@
     "added_by": "Tony R Waleszczak"
   },
   {
+    "author": "Jerome",
+    "work": "Vulgate 1 Chronicles",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 1 Corinthians",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 1 Esdras",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 1 John",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 1 Kings",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 1 Maccabees",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 1 Peter",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 1 Samuel",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 1 Thessalonians",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 1 Timothy",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 2 Chronicles",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 2 Corinthians",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 2 Esdras",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 2 John",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 2 Kings",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 2 Maccabees",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 2 Peter",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 2 Samuel",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 2 Thessalonians",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 2 Timothy",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate 3 John",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate a Epistle of Paul to the Laodicians",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate a Old Latin Psalms",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Acts",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Amos",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Apocalypse",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate B Psalm",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Baruch",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Colossians",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Daniel",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Deuteronomy",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Ecclesiastes",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Ephesians",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Esther",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Exodus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Ezekiel",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Ezra",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Galatians",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Genesis",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Habbakuk",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Haggaiah",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Hebrews",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Hosea",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Isaiah",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate James",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Jeremiah",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Job",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Joel",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate John",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Jonah",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Joshua",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Jude",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Judges",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Judith",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Lamentations",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Leviticus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Luke",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Malachi",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Mark",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Matthew",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Micah",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Nahum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Nehemiah",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Numbers",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Obadiah",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Part 21a Old Latin Psalms",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Part 21b Psalm",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Part 73a Epistle of Paul to the Laodicians",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Philemon",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Philippians",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Prayer of Manasseh",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Proverbs",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Psalms",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Romans",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Ruth",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Sirach",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Song of Songs",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Titus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Tobias",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Wisdom",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Zechariah",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome",
+    "work": "Vulgate Zephoniah",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome Saint",
+    "work": "Epistulae",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0162.stoa004/",
+    "print_source": "Jerome, Saint. S. Euesebii Hieronymi Opera, Section 1 (Pars I-III): Sancti Eusebii Hieronymi Epistulae (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 52-54). Hilberg, Isidor, editor. Vienna, Leipzig: Tempsky, Freytag, 1910-1918.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Jerome Saint",
+    "work": "In Hieremiam Prophetam Libri Sex",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0162.stoa024/",
+    "print_source": "Jerome, Saint. S. Euesebii Hieronymi Opera, Section 2, Pars 1: In Hieremiam Prophetam (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 59). Vienna, Leipzig: Tempsky, Freytag, 1913.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Johannes Hymonides",
+    "work": "Versiculi de Cena Cypriani",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "John Cassian",
+    "work": "Conlationes",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0076c.stoa001/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "John Cassian",
     "work": "Conlationes Patrum (Collationibus)",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0076c",
     "print_source": "Michael Petschenig. Johannis Cassiani Opera, Pars 2. Vindobonae: Gerold. 1886.",
     "added_by": "Caitlin Diddams"
   },
   {
     "author": "John Cassian",
+    "work": "De Incarnatione",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0076c.stoa003/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "John Cassian",
     "work": "De Incarnatione Domini Contra Nestorum",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0076c",
     "print_source": "Michael Petschenig. Johannis Cassiani Opera, Pars 1. Vindobonae: Gerold. 1888.",
     "added_by": "Caitlin Diddams"
   },
@@ -3771,9 +8627,129 @@
     "author": "John Cassian",
     "work": "Institutiones",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0076c",
     "print_source": "Michael Petschenig. Johannis Cassiani Opera, Pars 1. Vindobonae: Gerold. 1888.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Joseph Scottus",
+    "work": "Carmen de Compoti Ratione",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/CARM_RAT%7Ccomp%7C001",
+    "print_source": "K. Strecker, 1951",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Joseph Scottus",
+    "work": "Carmen de Conversione Saxonum",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/CARM_CSX%7Csaxo%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Joseph Scottus",
+    "work": "Carmen de Nynia Episcopo",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/CARM_NYN%7Ccarm%7C001",
+    "print_source": "K. Strecker, 1923",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Joseph Scottus",
+    "work": "Carmen de Pippino",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/CARM_PIP%7Cpivi%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Joseph Scottus",
+    "work": "Carmen de Temporum Ratione",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/CARM_TRT%7Ccarm%7C001",
+    "print_source": "K. Strecker, 1951",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Joseph Scottus",
+    "work": "Carmina",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/IOS_SCOT%7Ccarm%7C001",
+    "print_source": "E. Dümmler 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Joseph Scottus",
+    "work": "Carmina Libris Saec. VIII Adiecta",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/CARM_L1%7Ccarm%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Joseph Scottus",
+    "work": "Hymnus Nynie Episcopi",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/HYMN_NYN%7Chymn%7C001",
+    "print_source": "K. Strecker, 1923",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Joseph Scottus",
+    "work": "Karolus Magnus Et Leo Papa",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/CARM_KAR%7Ckaro%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Joseph Scottus",
+    "work": "Laudes Mediolanensis Civitatis",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/LAUD_MED|laud|001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Joseph Scottus",
+    "work": "Laudes Veronensis Civitatis",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/LAUD_VER%7Claud%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Joseph Scottus",
+    "work": "Planctus de Obitu Karoli",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/PLANCT_K%7Cplan%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Joseph Scottus",
+    "work": "Tituli Metrici I, II",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/TIT_ME1%7Ctitu%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Joseph Scottus",
+    "work": "Translatio Duodecim Martyrum",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/TRANSL_B|duod|001",
+    "print_source": "G. Waitz, 1878",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Joseph Scottus",
+    "work": "Translatio Sancti Mercurii",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/TRANSL_B%7Cmerc%7C001",
+    "print_source": "G. Waitz, 1878",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
   },
   {
     "author": "Julius Caesar",
@@ -3795,7 +8771,7 @@
     "author": "Julius Firmicus Maternus",
     "work": "De Errore Profanarum Religionum",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0123a",
     "print_source": "Karl Halm. M. Minucii Felicis Octavius, Iulii Firmici Materni Liber de Errore Profanarum Religionum. Vindobonae: Gerold. 1867.",
     "added_by": "Caitlin Diddams"
   },
@@ -3808,10 +8784,34 @@
     "added_by": "Chris Forstall"
   },
   {
+    "author": "Juvencus",
+    "work": "Historia Evangelica",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Juvencus Caius Vettius Aquilinus",
+    "work": "Evangeliorum Libri Quattuor",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0169a.stoa002/",
+    "print_source": "Juvencus. Evangeliorum libri quattuor. Corpus scriptorum ecclesiasticorum Latinorum, Volume 24. Huemer, Johann, editor. Vienna: Gerold, 1891.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Lactantius",
+    "work": "Carmen de Passione Domini",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Lactantius",
     "work": "Carmen de Passioni Domini",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0171",
     "print_source": "Samuel BrandtL. Caeli Firmiani Lactanti Opera omnia, Pars II, Fasc I. Vindobonae: Gerold, 1897.",
     "added_by": "Caitlin Diddams"
   },
@@ -3819,7 +8819,7 @@
     "author": "Lactantius",
     "work": "De Ave Phoenice",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0171",
     "print_source": "Samuel BrandtL. Caeli Firmiani Lactanti Opera omnia, Pars II, Fasc I. Vindobonae: Gerold, 1897.",
     "added_by": "Caitlin Diddams"
   },
@@ -3827,7 +8827,7 @@
     "author": "Lactantius",
     "work": "De Ira Dei",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0171",
     "print_source": "Samuel BrandtL. Caeli Firmiani Lactanti Opera omnia, Pars II, Fasc I. Vindobonae: Gerold, 1897.",
     "added_by": "Caitlin Diddams"
   },
@@ -3835,7 +8835,7 @@
     "author": "Lactantius",
     "work": "De Mortibus Persecutorum",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0171",
     "print_source": "Samuel BrandtL. Caeli Firmiani Lactanti Opera omnia, Pars II, Fasc II. Vindobonae: Gerold, 1897.",
     "added_by": "Caitlin Diddams"
   },
@@ -3843,7 +8843,7 @@
     "author": "Lactantius",
     "work": "De Opificio Dei",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0171",
     "print_source": "Samuel BrandtL. Caeli Firmiani Lactanti Opera omnia, Pars II, Fasc I. Vindobonae: Gerold, 1897.",
     "added_by": "Caitlin Diddams"
   },
@@ -3851,9 +8851,25 @@
     "author": "Lactantius",
     "work": "Divinarum Institutionum",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0171",
     "print_source": "Samuel BrandtL. Caeli Firmiani Lactanti Opera omnia, Pars I. Vindobonae: Gerold, 1890.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Lactantius",
+    "work": "Epitome Divinarum Institutionum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Lactantius",
+    "work": "Fragmenta",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0171.stoa010/",
+    "print_source": "Lactantius. L. Caeli Firmiani Lactanti Opera omnia, Part II, Fasc 1. Brandt, Samuel, editor; Laubmann, Georg, editor. Vienna: Gerold, 1897.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Lactantius Placidus",
@@ -3880,12 +8896,36 @@
     "added_by": "Caitlin Diddams"
   },
   {
+    "author": "Lios Monocus",
+    "work": "Libellulus Sacerdotalis",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/LIOS_MON%7Clibe%7C001",
+    "print_source": "P. v. Winterfeld, 1899",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Lios Monocus",
+    "work": "Libellus Sacerdotalis",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Livy",
-    "work": "Ab urbe condita, books 1-10, 21-45",
-    "e_source": "Perseus",
-    "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.02.0169",
-    "print_source": "W. Weissenborn, Titi Livi ab urbe condita libri Leipzig: Teubner, 1898.",
-    "added_by": "Anna Glenn"
+    "work": "Ab Urbe Condita",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Lucan",
+    "work": "Bellum Civile",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Lucan",
@@ -4297,6 +9337,14 @@
   },
   {
     "author": "Lucian",
+    "work": "Philopseudes",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0062.tlg062/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Lucian",
     "work": "Philopsuedes Sive Incredulus",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0450",
@@ -4464,6 +9512,46 @@
     "added_by": "Caitlin Diddams"
   },
   {
+    "author": "Lucifer Bishop of Cagliari",
+    "work": "De Non Conveniendo cum Haereticis",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0180a.stoa001/",
+    "print_source": "Lucifer, Bishop of Cagliari. Hartel, Wilhelm von, editor. Luciferi Calaritani Opuscula. Corpus scriptorum ecclesiasticorum Latinorum, Volume 14, 1886.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Lucifer Bishop of Cagliari",
+    "work": "De Non Parcendo in Deum Delinquentibus",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0180a.stoa002/",
+    "print_source": "Lucifer, Bishop of Cagliari. Hartel, Wilhelm von, editor. Luciferi Calaritani Opuscula. Corpus scriptorum ecclesiasticorum Latinorum, Volume 14, 1886.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Lucifer Bishop of Cagliari",
+    "work": "De Regibus Apostaticis",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0180a.stoa003/",
+    "print_source": "Lucifer, Bishop of Cagliari. Hartel, Wilhelm von, editor. Luciferi Calaritani Opuscula. Corpus scriptorum ecclesiasticorum Latinorum, Volume 14, 1886.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Lucifer Bishop of Cagliari",
+    "work": "Epistulae",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0180a.stoa005/",
+    "print_source": "Lucifer, Bishop of Cagliari. Hartel, Wilhelm von, editor. Luciferi Calaritani Opuscula. Corpus scriptorum ecclesiasticorum Latinorum, Volume 14, 1886.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Lucifer Bishop of Cagliari",
+    "work": "Moriendum Esse Pro Dei Filio",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0180a.stoa006/",
+    "print_source": "Lucifer, Bishop of Cagliari. Hartel, Wilhelm von, editor. Luciferi Calaritani Opuscula. Corpus scriptorum ecclesiasticorum Latinorum, Volume 14, 1886",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Lucretius",
     "work": "De Rerum Natura",
     "e_source": "Perseus",
@@ -4472,12 +9560,36 @@
     "added_by": "Chris Forstall"
   },
   {
+    "author": "Lupus Servatus",
+    "work": "Versus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Lupus Servatus, Ferrariensis",
+    "work": "Versus",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/LUP_FERR%7Cvers%7C001",
+    "print_source": "K. Strecker, 1923",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
     "author": "Lycophron",
     "work": "Alexandra",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0484",
     "print_source": "A.W. Mair, Alexandra.London: William Heinemann; New York: G.P. Putnam's Sons, 1921.",
     "added_by": "Jessica Micceri"
+  },
+  {
+    "author": "Lycurgus",
+    "work": "Against Leocrates",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0028.tlg001/",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Lycurgus",
@@ -4505,6 +9617,14 @@
   },
   {
     "author": "Macrobius",
+    "work": "Fragment",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Macrobius",
     "work": "In Somnium Scipionis commentarii",
     "e_source": "DigilibLT",
     "e_source_url": "http://digiliblt.lett.unipmn.it/opera.php?gruppo=opere&amp;iniziale=all&amp;id=dlt000338",
@@ -4514,10 +9634,122 @@
   {
     "author": "Macrobius",
     "work": "Saturnalia",
-    "e_source": "",
+    "e_source": "LacusCurtius",
     "e_source_url": "https://web.archive.org/web/20240812080521/https://penelope.uchicago.edu/Thayer/L/Roman/Texts/Macrobius/Saturnalia/1*.html",
     "print_source": "Ludwig von Jan. Macrobii Ambrosii Theodosii . . . Saturnaliorum libri VIIQuedlinburg and Leipzig. 1852.",
     "added_by": "V3 Legacy Import"
+  },
+  {
+    "author": "Maffeo Veggio",
+    "work": "Aeneid",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Magnus Felix Ennodius",
+    "work": "Benedictio Cerei I",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Magnus Felix Ennodius",
+    "work": "Benedictio Cerei Ii",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Magnus Felix Ennodius",
+    "work": "Carmina",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0114a.stoa003/",
+    "print_source": "Magnus Felix Ennodius. Magni Felicis Ennodii Opera Omnia (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 6). Hartel, Wilhelm, editor. Vienna: Gerold, 1882.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Magnus Felix Ennodius",
+    "work": "De Vita Beati Antoni Monachi",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Magnus Felix Ennodius",
+    "work": "Dictiones",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0114a.stoa004/",
+    "print_source": "Magnus Felix Ennodius. Magni Felicis Ennodii Opera Omnia (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 6). Hartel, Wilhelm, editor. Vienna: Gerold, 1882.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Magnus Felix Ennodius",
+    "work": "Ennodius Ambrosio Et Beato",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Magnus Felix Ennodius",
+    "work": "Epistulae",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0114a.stoa008/",
+    "print_source": "Magnus Felix Ennodius. Magni Felicis Ennodii Opera Omnia (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 6). Hartel, Wilhelm, editor. Vienna: Gerold, 1882.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Magnus Felix Ennodius",
+    "work": "Eucharisticum de Vita Sua",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Magnus Felix Ennodius",
+    "work": "Libellus Adversus Eos Qui Contra Synodum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Magnus Felix Ennodius",
+    "work": "Panegyricus Theodorico Regi Dictus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Magnus Felix Ennodius",
+    "work": "Petitorium Quo Absolutus Est Gerontius P",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Magnus Felix Ennodius",
+    "work": "Praeceptum Quando Iussi Sunt Omnes Episc",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Magnus Felix Ennodius",
+    "work": "Vita Epiphanii",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Manilius",
@@ -4526,6 +9758,38 @@
     "e_source_url": "https://web.archive.org/web/20240812080521/https://www.thelatinlibrary.com/manilius.html",
     "print_source": "Iacobus van Wageningen, M. Manili Astronomica. Leipzig: in aedibus B. G. Teubneri, 1915.",
     "added_by": "V3 Legacy Import"
+  },
+  {
+    "author": "Manilius",
+    "work": "Astronomicon",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Marbodus episcopus Redonensis",
+    "work": "Carmina Septem Fratrum Macchabeorum",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/MARBOD%7Cmacc%7C001",
+    "print_source": "Bourassé 1893 (PL 171)",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Marbodus episcopus Redonensis",
+    "work": "Versus de Fontaneto",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/ANGIL_MI%7Cfont%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Marbodus Redonensis",
+    "work": "Certamina Septem Fratrum Machabaeorum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Marcus Aurelius",
@@ -4539,7 +9803,7 @@
     "author": "Marcus Minucius Felix",
     "work": "Octavius",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0203",
     "print_source": "Bernhard Kytzler. M. Minuci Felicis Octavius. Leipzig: B.G. Teubner Verlagsgesellschaft. 1982.",
     "added_by": "Caitlin Diddams"
   },
@@ -4560,12 +9824,196 @@
     "added_by": "V3 Legacy Import"
   },
   {
+    "author": "Maximus of Tyre",
+    "work": "Dialexeis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0563.tlg001/",
+    "print_source": "Maximus of Tyre. Maximi Tyrii philosophumena. Hobein, Hermann, editor. Leipzig: Teubner, 1910.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Micon de Saint-Riquier",
+    "work": "Opus Prosodiacum, Prooemium",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/MICON%7Cpros%7C001",
+    "print_source": "L. Traube, 1896",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Micon of Saint Riquier",
+    "work": "Opus Prosodiacum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Micon of Saint Riquier",
+    "work": "Prologus in Tractatum de Primis Syllabis",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Milo of Saint Amand",
+    "work": "Carmina Figurata",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Milo of Saint Amand",
+    "work": "Carminum Appendix",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Milo of Saint Amand",
+    "work": "De Sobrietate",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Milo, monachus Elnonensis",
+    "work": "Carmina (id.)",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/MILO%7Ccarm%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Milo, monachus Elnonensis",
+    "work": "Carmina Figurata",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/MILO%7Ccafi%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Milo, monachus Elnonensis",
+    "work": "Carminum Appendix (id.)",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/MILO%7Ccaap%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Milo, monachus Elnonensis",
+    "work": "De Sobrietate",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/MILO%7Csobr%7C000",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Milo, monachus Elnonensis",
+    "work": "Vita Amandi (id.)",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/MILO%7Cviam%7C000",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Milton",
+    "work": "Paradise Lost",
+    "e_source": "Project Gutenberg",
+    "e_source_url": "https://www.gutenberg.org/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Minucius Felix",
+    "work": "Octavius",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Modoinus 'Naso', episcopus Augustodunensis",
+    "work": "Carminum Appendix",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/MODOIN%7Ccaap%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Modoinus 'Naso', episcopus Augustodunensis",
+    "work": "Eclogae",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/MODOIN%7Ceclo%7C000",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Moduin",
+    "work": "Carminum Appendix",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Moduin",
+    "work": "Eclogae",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Nepos",
     "work": "Vitae",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.02.0136",
     "print_source": "Albert Fleckeisen, Vitae. Leipzig: Teubner, 1886.",
     "added_by": "Anna Glenn"
+  },
+  {
+    "author": "Niciae Epistula",
+    "work": "Epistula",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0046.tlg001/",
+    "print_source": "Rudolf Hercher, Epistolographi Graeci, Paris. A. F. Didot. 1873",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Nicomachus of Gerasa",
+    "work": "Excerpta",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0358.tlg004/",
+    "print_source": "Nicomachus of Gerasa. Musici Scriptores Graeci. Jan, Karl von, editor. Leipzig: Teubner, 1895",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Nicomachus of Gerasa",
+    "work": "Introduction to Arithmetic",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0542.tlg001/",
+    "print_source": "Julius Pollux. Metrologicorum scriptorum reliquiae. Hultsch, Friedrich, editor. Leipzig: Teubner, 1864.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Nicomachus of Gerasa",
+    "work": "Manual of Harmonics",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0542.tlg002/",
+    "print_source": "Karl von Jan, Musici Scriptores Graeci, Leipzig: Teubner, 1895.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Nicomachus of Gerasa",
+    "work": "Problemata Arithmetica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0358.tlg005/",
+    "print_source": "Nicomachus of Gerasa. Introductio Arithmetica. Hoche, Richard, editor. Leipzig: Teubner, 1866.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Nithardus",
@@ -4601,11 +10049,83 @@
   },
   {
     "author": "Optatian",
+    "work": "Epistula",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Optatian",
     "work": "Epistula Porfyrii",
     "e_source": "digilibLT",
     "e_source_url": "http://digiliblt.lett.unipmn.it/opera.php",
     "print_source": "Iohannes Polara. Publilii Optatiani Porfyrii, Carmina, I. Turin: Paravia. 1973.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Optatus Saint Bishop of Mileve",
+    "work": "Appendix Decem Monumentorum Veterum",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0215a.stoa002/",
+    "print_source": "Optatus. S Optati Milevitani libri VII (Corpus scriptorum ecclesiasticorum Latinorum, Volume 26). Ziwsa, Karl, editor. Prague, Vienna, Leipzig: Tempsky, Freytag, 1893.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Optatus Saint Bishop of Mileve",
+    "work": "S Optati Milevitani Libri Vii",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0215a.stoa001/",
+    "print_source": "Optatus. S Optati Milevitani libri VII (Corpus scriptorum ecclesiasticorum Latinorum, Volume 26). Ziwsa, Karl, editor. Prague, Vienna, Leipzig: Tempsky, Freytag.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Orientius Saint",
+    "work": "Carmina",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0215b.stoa002/",
+    "print_source": "Orientius, Saint. Poetae Christiani Minores, Pars I (Corpus scriptorum ecclesiasticorum latinorum, Volume 16, Part 1). Petschenig, Michael, editor; Ellis, Robinson, editor; Brandes, Wilhelm, editor; Schenkl, Karl, editor. Vienna, Leipzig, Prague: Tempsky, Freytag, 1888.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Orientius Saint",
+    "work": "Commonitorium",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0215b.stoa001/",
+    "print_source": "Orientius, Saint. Poetae Christiani Minores, Pars I (Corpus scriptorum ecclesiasticorum latinorum, Volume 16, Part 1). Petschenig, Michael, editor; Ellis, Robinson, editor; Brandes, Wilhelm, editor; Schenkl, Karl, editor. Vienna, Leipzig, Prague: Tempsky, Freytag, 1888.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Orosius Paulus",
+    "work": "Commenitorium Orosii ad Augustinum de Er",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0215c.stoa003/",
+    "print_source": "Orosius, Paulus. Priscilliani quae supersunt (Corpus scriptorum ecclesiasticorum Latinorum, Volume 18). Schepps, Georg, editor. Prague, Vienna, Leipzig: Tempsky, Freytag, 1889.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Orosius Paulus",
+    "work": "Historiae Adversum Paganos",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0215c.stoa001/",
+    "print_source": "Orosius, Paulus. Historiarum adversum paganos libri VII (Corpus scriptorum ecclesiasticorum latinorum, Volume 5). Zangemeister, Karl, editor. Gerold: Vienna, 1882.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Orosius Paulus",
+    "work": "Liber Apologeticus",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0215c.stoa002/",
+    "print_source": "Orosius, Paulus. Historiarum adversum paganos libri VII (Corpus scriptorum ecclesiasticorum latinorum, Volume 5). Zangemeister, Karl, editor. Gerold: Vienna, 1882.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Orphica",
+    "work": "Fragmenta",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0579.tlg010/",
+    "print_source": "Hermann Diels, Die Fragmente der Vorsokratiker, Berlin. Weidmann. 1922, Vol. 2",
+    "added_by": "V6 Import"
   },
   {
     "author": "Ovid",
@@ -4649,6 +10169,14 @@
   },
   {
     "author": "Ovid",
+    "work": "Ibis",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ovid",
     "work": "Medicamina Faciei Femineae",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/",
@@ -4680,6 +10208,54 @@
     "added_by": "Chris Forstall"
   },
   {
+    "author": "Paradoxographus Florentinus",
+    "work": "Mirabilia de Aquis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0580.tlg001/",
+    "print_source": "Heinrich Öhler, Paradoxographi Florentini Anonymi Opusculum De Aquis Mirabilibus: Ad Fidem Codicum Manu Scriptorum Ed. Commentario Instructum., Tübingen. J. J. Heckenhauer. 1913",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Paschasius Radbertus",
+    "work": "Carmina",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Paschasius Radbertus",
+    "work": "Epitaphium Arsenii",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Paul the Apostle Saint",
+    "work": "Epigramma",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0222a.stoa001/",
+    "print_source": "Paul, the Apostle, Saint. Poetae Christiani Minores, Pars I (Corpus scriptorum ecclesiasticorum latinorum, Volume 16, Part 1). Petschenig, Michael, editor; Ellis, Robinson, editor; Brandes, Wilhelm, editor; Schenkl, Karl, editor. Vienna, Leipzig, Prague: Tempsky, Freytag, 1888.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Paulinus Aquileiensis",
+    "work": "Carmina",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/PAUL_AQU%7Ccarm%7C001",
+    "print_source": "E. D. Norberg, 1979",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Paulinus Aquileiensis",
+    "work": "Versus de Destructione Aquilegiae Numquam Restaurandae",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/PAUL_AQU%7Cvers%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
     "author": "Paulinus of Aquileia",
     "work": "Carmina",
     "e_source": "",
@@ -4699,7 +10275,7 @@
     "author": "Paulinus of Nola",
     "work": "Carmina",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0222",
     "print_source": "Wilhelm August Ritter von Hartel. Sancti Pontii Meropii Paulini Carmina. Vindobonae: Gerold. 1894.",
     "added_by": "Caitlin Diddams"
   },
@@ -4707,9 +10283,33 @@
     "author": "Paulinus of Nola",
     "work": "Epistulae",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0222",
     "print_source": "Wilhelm August Ritter von Hartel. Sancti Pontii Meropii Paulini Carmina. Vindobonae: Gerold. 1894.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Paulinus of Pella",
+    "work": "Eucharisticus",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0223a.stoa001/",
+    "print_source": "Paulinus of Pella. Poetae Christiani Minores, Pars I (Corpus scriptorum ecclesiasticorum latinorum, Volume 16, Part 1). Petschenig, Michael, editor; Ellis, Robinson, editor; Brandes, Wilhelm, editor; Schenkl, Karl, editor. Vienna, Leipzig, Prague: Tempsky, Freytag, 1888.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Paulinus Petricordiae",
+    "work": "De Vita Sancti Martini",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0224b.stoa001/",
+    "print_source": "Paulinus Petricordiae. Poetae Christiani Minores, Pars I (Corpus scriptorum ecclesiasticorum latinorum, Volume 16, Part 1). Petschenig, Michael, editor; Ellis, Robinson, editor; Brandes, Wilhelm, editor; Schenkl, Karl, editor. Vienna, Leipzig, Prague: Tempsky, Freytag, 1888.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Paulus Albarus, Cordubensis",
+    "work": "Carmina",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/PAUL_ALB%7Ccarm%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
   },
   {
     "author": "Paulus Diaconus",
@@ -4723,15 +10323,23 @@
     "author": "Paulus Orosius",
     "work": "Commenitorium Orosii ad Augustinum de Errore Priscillianistarum et Origenistarum",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0215c",
     "print_source": "Georg Schepps. Priscilliani Quae Supersunt, Accedit Orosii Commonitorium de Errore Priscillianistarum et Origenistarum. Vindobonae: Gerold. 1889.",
     "added_by": "Caitlin Diddams"
   },
   {
     "author": "Paulus Orosius",
+    "work": "Commonitorium de Errore Priscillianistarum Et Origenistarum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Paulus Orosius",
     "work": "Historiae Adversum Paganos",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0215c",
     "print_source": "Karl Friedrich Wilhelm. Historiarum Adversum Paganos Libri VII. Vindobonae: Gerold. 1882.",
     "added_by": "Caitlin Diddams"
   },
@@ -4739,9 +10347,17 @@
     "author": "Paulus Orosius",
     "work": "Liber Apologeticus",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0215c",
     "print_source": "Karl Friedrich Wilhelm. Historiarum Adversum Paganos Libri VII. Vindobonae: Gerold. 1882.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Pausanias",
+    "work": "Description of Greece",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0525.tlg001/",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Pausanias",
@@ -4758,6 +10374,374 @@
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0497",
     "print_source": "G.G.Ramsay, Juvenal and Persius with An English Translation. London: William Heinemann; G. P. Putnam's Son, 1918.",
     "added_by": "Anna Glenn"
+  },
+  {
+    "author": "Persius",
+    "work": "Saturae",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Petronius",
+    "work": "Fragmenta",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Petronius",
+    "work": "Satyricon",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Petrus Diaconus",
+    "work": "De Locis Santis",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0227b.stoa001/",
+    "print_source": "Petrus Diaconus. Itinera hierosolymitana saecvli IIII-VIII (Corpus scriptorum ecclesiasticorum Latinorum, Volume 39). Geyer, Paul, editor. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1898.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Petrus of Pisa",
+    "work": "Carmina",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Petrus Pisanus",
+    "work": "Carmina",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/PETR_PIS%7Ccarm%7C011",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Petrus Riga",
+    "work": "Aurora",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/PETR_RIG%7Cauro%7C000",
+    "print_source": "P. E. Beichner, 1965",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Phaedrus",
+    "work": "Fabulae Aesopiae",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Phalaridis Epistulae",
+    "work": "Epistulae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0053.tlg001/",
+    "print_source": "Rudolf Hercher, Epistolographi Graeci, Paris. A. F. Didot. 1873",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philastrius",
+    "work": "Diversarum Hereseon Liber",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0122a.stoa001/",
+    "print_source": "Philastrius. Diversarum hereseon liber. (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 38). Marc, Friedrich, editor. Prague; Vienna; Leipzig: Tempsky, Freytag, 1898.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philip Ii King of Macedonia",
+    "work": "Epistulae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0048.tlg001/",
+    "print_source": "Rudolf Hercher, Epistolographi Graeci, Paris. A. F. Didot. 1873",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Abrahamo",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg020/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 4. Cohn, Leonard, editor. Berlin: Reimer, 1902.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Aeternitate Mundi",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg029/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 6. Cohn, Leonard; Reiter, Siegfried, editors. Berlin: Reimer, 1915.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Agricultura",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg009/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 2. Wendland, Paul, editor. Berlin: Reimer, 1897.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Cherubim",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg003/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 1. Cohn, Leonard, editor. Berlin: Reimer, 1896.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Confusione Linguarum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg013/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 2. Wendland, Paul, editor. Berlin: Reimer, 1897.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Congressu Eruditionis Gratia",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg016/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 3. Wendland, Paul, editor. Berlin: Reimer, 1898.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Decalogo",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg023/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 4. Cohn, Leonard, editor.Berlin: Reimer, 1902.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Ebrietate",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg011/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 2. Wendland, Paul, editor. Berlin: Reimer, 1897.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Fuga Et Inventione",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg017/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 3. Wendland, Paul, editor. Berlin: Reimer, 1898.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Gigantibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg007/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 2. Wendland, Paul, editor. Berlin: Reimer, 1897.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Josepho",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg021/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 4. Cohn, Leonard, editor. Berlin: Reimer, 1902.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Migratione Abrahami",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg014/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 2. Wendland, Paul, editor. Berlin: Reimer, 1897.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Mutatione Nominum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg018/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 3. Wendland, Paul, editor. Berlin: Reimer, 1898.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Opificio Mundi",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg001/",
+    "print_source": "Philo Judaeus. Opera que supersunt, Volume 1. Cohn, Leonard, editor. Berlin: Reimer, 1896.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Plantatione",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg010/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 2. Wendland, Paul, editor. Berlin: Reimer, 1897.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Posteritate Caini",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg006/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 2. Wendland, Paul, editor. Berlin: Reimer, 1897.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Praemiis Et Poenis Et de Exsecrationibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg026/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 5. Cohn, Leonard, editor. Berlin: Reimer, 1906.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Sacrificiis Abelis Et Caini",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg004/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 1. Cohn, Leonard, editor. Berlin: Reimer, 1896.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Sobrietate",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg012/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 2. Wendland, Paul, editor. Berlin: Reimer, 1897.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Somniis Lib Iii",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg019/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 3. Wendland, Paul, editor. Berlin: Reimer, 1898.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Specialibus Legibus Lib Iiv",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg024/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 5. Cohn, Leonard, editor. Berlin: Reimer, 1906.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Virtutibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg025/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 5. Cohn, Leonard, editor. Berlin: Reimer, 1906.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "De Vita Mosis Lib Iii",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg022/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 4. Cohn, Leonard, editor. Berlin: Reimer, 1902.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "In Flaccum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg030/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 6. Cohn, Leonard; Reiter, Siegfried, editors. Berlin: Reimer, 1915.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "Legatio ad Gaium",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg031/",
+    "print_source": "Philo Judaeus. pera quae supersunt, Volume 6. Cohn, Leonard; Reiter, Siegfried, editors. Berlin: Reimer, 1915.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "Legum Allegoriarum Libri Iiii",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg002/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 1. Cohn, Leonard, editor. Berlin: Reimer, 1896.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "On Drunkenness",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg011/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 2. Wendland, Paul, editor. Berlin: Reimer, 1897.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "On Fugitives",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg017/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 3. Wendland, Paul, editor. Berlin: Reimer, 1898.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "On Rewards and Punishments",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg026/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 5. Cohn, Leonard, editor. Berlin: Reimer, 1906.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "On Sobriety",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg012/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 2. Wendland, Paul, editor. Berlin: Reimer, 1897.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "On the Creation of the World",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg001/",
+    "print_source": "Philo Judaeus. Opera que supersunt, Volume 1. Cohn, Leonard, editor. Berlin: Reimer, 1896.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "On Three Virtues That Is to Say on Courage Humanit",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg025/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 5. Cohn, Leonard, editor. Berlin: Reimer, 1906.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "Quis Rerum Divinarum Heres Sit",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg015/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 3. Wendland, Paul, editor. Berlin: Reimer, 1898.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "Quod Deterius Potiori Insidiari Soleat",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg005/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 1. Cohn, Leonard, editor. Berlin: Reimer, 1896.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Philo Judaeus",
+    "work": "To Prove That Every Man Who Is Virtuous Is Also Fr",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0018.tlg027/",
+    "print_source": "Philo Judaeus. Opera quae supersunt, Volume 6. Cohn, Leonard; Reiter, Siegfried, editors. Berlin: Reimer, 1915.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Philostratus the Athenian",
@@ -4862,6 +10846,14 @@
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.01.0175",
     "print_source": "Platonis Opera, ed. John Burnet.Oxford University Press, 1903.",
     "added_by": "Elizabeth Hunter"
+  },
+  {
+    "author": "Plato",
+    "work": "Apologia",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0059.tlg002/",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Plato",
@@ -5377,6 +11369,14 @@
   },
   {
     "author": "Plutarch",
+    "work": "Alexandrian Proverbs",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0007.tlg133/",
+    "print_source": "Plutarch. Plutarchi Chaeronensis Moralia, Vol. VI. Vernardakēs, Grēgorios N., editor. Leipzig: Teubner, 1895.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Plutarch",
     "work": "Amatoriae narrationes",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0316",
@@ -5537,11 +11537,27 @@
   },
   {
     "author": "Plutarch",
+    "work": "Cato Minor",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0007.tlg041/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Plutarch",
     "work": "Cato the Younger",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0088",
     "print_source": "Bernadotte Perrin, Plutarch's Lives. Cambridge, MA: Harvard University Press, 1919.",
     "added_by": "Elizabeth Hunter"
+  },
+  {
+    "author": "Plutarch",
+    "work": "Cicero",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0007.tlg055/",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Plutarch",
@@ -6234,8 +12250,8 @@
   {
     "author": "Plutarch",
     "work": "Quaestiones Convivales",
-    "e_source": "Perseus",
-    "e_source_url": "",
+    "e_source": "Open Greek and Latin",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/First1KGreek/tree/master/data/tlg0007/tlg011",
     "print_source": "George N. Bernadakis. Plutarch. Moralia. Leipzig. Teubner. 1892. 4.",
     "added_by": "V3 Legacy Import"
   },
@@ -6384,6 +12400,86 @@
     "added_by": "V3 Legacy Import"
   },
   {
+    "author": "Poeta Saxo",
+    "work": "Annales de Gestis Karoli Magni",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/POET_SAX%7Canna%7C001",
+    "print_source": "P. v. Winterfeld, 1899",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Poeta Saxo",
+    "work": "Carmina Augiensia",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/CARM_AUG%7Ccarm%7C001",
+    "print_source": "K. Strecker, 1923",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Poeta Saxo",
+    "work": "Carmina Bibliothecarum Et Psalteriorum",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/CARM_BIB%7Cvers%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Poeta Saxo",
+    "work": "Carmina Cenomanensia",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Poeta Saxo",
+    "work": "Corneli Translationes",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/TRANSL_C%7Ctran%7C001",
+    "print_source": "P. v. Winterfeld, 1899",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Polignac",
+    "work": "Antilucretius",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Polignac",
+    "work": "Epia",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Polignac",
+    "work": "Imitatio",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Polyaenus",
+    "work": "Excerpta Polyaeni",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0616.tlg002/",
+    "print_source": "Polyaenus Macedo, Excerpta Polyaeni, Melber and Woelfflin, Teubner, 1887",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Polyaenus",
+    "work": "Strategemata",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0616.tlg001/",
+    "print_source": "Polyaenus Macedo, Strategematon, Melber and Woelfflin, Teubner, 1887",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Polybius",
     "work": "Histories",
     "e_source": "Perseus",
@@ -6392,12 +12488,36 @@
     "added_by": "Bridget Murray"
   },
   {
+    "author": "Pontius Diaconus",
+    "work": "Acta Proconsularia",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0233d.stoa002/",
+    "print_source": "Pontius Diaconus. Thasci Caecili Cypriani Opera omnia, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 3.1). Hartel, Wilhelm von, editor. Vienna: Gerold, 1868.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pontius Diaconus",
+    "work": "Vita Caecilii Cypriani",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0233d.stoa001/",
+    "print_source": "Pontius Diaconus. Thasci Caecili Cypriani Opera omnia, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 3.1). Hartel, Wilhelm von, editor. Vienna: Gerold, 1868.",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Priscian",
     "work": "Carmen in laudem Anastasii imperatoris",
     "e_source": "MQDQ",
     "e_source_url": "http://www.mqdq.it/public/testo/testo/codice/PRISC%7Canas%7C001",
     "print_source": "A. Chauvot. 1986.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Priscian",
+    "work": "Carmen in Laudem Anastasii Imperatoris Part Preface",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Priscian",
@@ -6411,7 +12531,7 @@
     "author": "Priscillian",
     "work": "Canones",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0234e",
     "print_source": "Georg Schepps. Priscilliani Quae Supersunt, Accedit Orosii Commonitorium de Errore Priscillianistarum et Origenistarum. Vindobonae: Gerold. 1889.",
     "added_by": "Caitlin Diddams"
   },
@@ -6419,9 +12539,65 @@
     "author": "Priscillian",
     "work": "Tractatus Undecim",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0234e",
     "print_source": "Georg Schepps. Priscilliani Quae Supersunt, Accedit Orosii Commonitorium de Errore Priscillianistarum et Origenistarum. Vindobonae: Gerold. 1889.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Priscillian Bishop of Avila",
+    "work": "Canones in Pauli Apostoli Epistula Canon",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0234e.stoa001/",
+    "print_source": "Priscillian, Bishop of Avila. Priscilliani quae supersunt (Corpus scriptorum ecclesiasticorum Latinorum, Volume 18). Schepps, Georg, editor. Prague, Vienna, Leipzig: Tempsky, Freytag, 1889.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Priscillian Bishop of Avila",
+    "work": "Tractatus Undecim",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0234e.stoa002/",
+    "print_source": "Priscillian, Bishop of Avila. Priscilliani quae supersunt (Corpus scriptorum ecclesiasticorum Latinorum, Volume 18). Schepps, Georg, editor. Prague, Vienna, Leipzig: Tempsky, Freytag, 1889.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Proba Active 4th Century",
+    "work": "Cento",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0234f.stoa001/",
+    "print_source": "Proba, active 4th century. Poetae Christiani Minores, Pars I (Corpus scriptorum ecclesiasticorum latinorum, Volume 16, Part 1). Petschenig, Michael, editor; Ellis, Robinson, editor; Brandes, Wilhelm, editor; Schenkl, Karl, editor. Vienna, Leipzig, Prague: Tempsky, Freytag, 1888.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Propertius",
+    "work": "Elegiae 1",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Propertius",
+    "work": "Elegiae 2",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Propertius",
+    "work": "Elegiae 3",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Propertius",
+    "work": "Elegiae 4",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Propertius",
@@ -6476,7 +12652,7 @@
     "work": "Peristephanon",
     "e_source": "The Latin Library",
     "e_source_url": "http://www.thelatinlibrary.com/prudentius/prud1.shtml",
-    "print_source": "Edition Unknown.",
+    "print_source": "",
     "added_by": "Caitlin Diddams"
   },
   {
@@ -6484,8 +12660,24 @@
     "work": "Psychomachia",
     "e_source": "The Latin Library",
     "e_source_url": "http://www.thelatinlibrary.com/prudentius/prud.psycho.shtml",
-    "print_source": "Edition Unknown.",
+    "print_source": "",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Pseudo Dicaearchus Messeniushe",
+    "work": "Dicaearchi Ut Fertur Potius Vero Athenaei Descript",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0066.tlg001/",
+    "print_source": "Dicaearchus, Messenius (Pseudo). Heraclides, Criticus. Geographi Graeci Minores, Volume 1. Müller, Karl. Paris: Ambroise Firmin Didot, 1855.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudo Eucherius",
+    "work": "De Situ Hierusolimitanae Urbis Atque Ips",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Pseudo-Augustine",
@@ -6506,7 +12698,7 @@
   {
     "author": "Pseudo-Cyprian",
     "work": "Ad Flavium Felicem Resurrectione Mortuorum",
-    "e_source": "",
+    "e_source": "Tertullian Project",
     "e_source_url": "https://web.archive.org/web/20240812080521/http://www.tertullian.org/latin/carmen_de_iudicio_domini.htm",
     "print_source": "J.H. Wasink. Carmen ad Flavium Felicem de resurrectione mortuorum et de iudicio Domini, recensuit, prolegomenis commentario indicibus instruxit J.H.W, Florilegium Patristicum Supplementum I. Bonn. 1937.",
     "added_by": "V3 Legacy Import"
@@ -6626,7 +12818,7 @@
   {
     "author": "Pseudo-Cyprian",
     "work": "Genesis",
-    "e_source": "",
+    "e_source": "Tertullian Project",
     "e_source_url": "https://web.archive.org/web/20240812080521/http://www.tertullian.org/latin/carmen_genesis.htm",
     "print_source": "G. Hartel. S. Thasci Caecili Cypriani Opera Omnia, Corpus Scriptorum Ecclesiasticorum Latinorum 3.1868.",
     "added_by": "V3 Legacy Import"
@@ -6812,7 +13004,7 @@
     "work": "Copa",
     "e_source": "Forum Romanum",
     "e_source_url": "http://www.forumromanum.org/literature/copa.html",
-    "print_source": "Unknown Edition.",
+    "print_source": "",
     "added_by": "Caitlin Diddams"
   },
   {
@@ -6820,7 +13012,7 @@
     "work": "Culex",
     "e_source": "Forum Romanum",
     "e_source_url": "http://www.forumromanum.org/literature/culex.html",
-    "print_source": "Unknown Edition.",
+    "print_source": "",
     "added_by": "Caitlin Diddams"
   },
   {
@@ -6828,7 +13020,7 @@
     "work": "Dirae",
     "e_source": "Forum Romanum",
     "e_source_url": "http://www.forumromanum.org/literature/dirae.html",
-    "print_source": "Unknown Edition.",
+    "print_source": "",
     "added_by": "Caitlin Diddams"
   },
   {
@@ -6836,7 +13028,7 @@
     "work": "Elegiae in Maecenatem",
     "e_source": "Forum Romanum",
     "e_source_url": "http://www.forumromanum.org/literature/elegiae_maecenatem.html",
-    "print_source": "Unknown Edition.",
+    "print_source": "",
     "added_by": "Caitlin Diddams"
   },
   {
@@ -6844,7 +13036,7 @@
     "work": "Lydia",
     "e_source": "Forum Romanum",
     "e_source_url": "http://www.forumromanum.org/literature/lydia.html",
-    "print_source": "Unknown Edition.",
+    "print_source": "",
     "added_by": "Caitlin Diddams"
   },
   {
@@ -6852,7 +13044,7 @@
     "work": "Moretum",
     "e_source": "Forum Romanum",
     "e_source_url": "http://www.forumromanum.org/literature/moretum.html",
-    "print_source": "Unknown Edition.",
+    "print_source": "",
     "added_by": "Caitlin Diddams"
   },
   {
@@ -6860,16 +13052,200 @@
     "work": "Priapea",
     "e_source": "Forum Romanum",
     "e_source_url": "https://web.archive.org/web/20240812080521/http://www.forumromanum.org/literature/priapea.html",
-    "print_source": "Unknown Edition.",
+    "print_source": "",
     "added_by": "V3 Legacy Import"
   },
   {
     "author": "Pseudo-Vitensis",
     "work": "Notitia provinciarum et civitatum africae",
-    "e_source": "",
+    "e_source": "Mittellateinische Bibliothek",
     "e_source_url": "https://web.archive.org/web/20240812080521/http://www.mlat.uzh.ch/MLS/xanfang.php?tabelle=Victor_Vitensis_cps19&amp;corpus=19&amp;allow_download=0&amp;lang=0",
     "print_source": "Michael Petschenig Notitia provinciarum et civitatum Africae. Osterreichische Akademie der Wissenschaften, Wien, Osterreich, 1881.",
     "added_by": "V3 Legacy Import"
+  },
+  {
+    "author": "Pseudoaristotle",
+    "work": "De Mundo",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:stoa0033a.tlg028/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudoaristotle",
+    "work": "De Spiritu",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:stoa0033a.tlg043/",
+    "print_source": "Immanuel Bekker, Aristotelis Opera, Oxford. Oxford University Press. 1837",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudoarrianus",
+    "work": "Anonymi Arriani Ut Fertur Periplus Maris Erythraei",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0071.tlg001/",
+    "print_source": "Pseudo-Arrianus. Geographi graeci minores, Volume 1. Müller, Karl, editor. Paris: Ambroise Firmin Didot, 1855.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudoarrianus",
+    "work": "Anonymi Arriani Ut Fertur Periplus Ponti Euxini",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0075.tlg001/",
+    "print_source": "Pseudo-Arrianus. Geographi graeci minores, Volume 1. Müller, Karl, editor. Paris: Ambroise Firmin Didot, 1855.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudogalen",
+    "work": "Ad Gaurum Quomodo Animetur Fetus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0530.tlg006/",
+    "print_source": "Karl Kalbfleisch, Die neuplatonische, fälschlich dem Galen zugeschriebene Schrift Πρὸς Γαῦρον περὶ τοῦ πῶς ἐμψυχοῦνται τὰ ἔμβρυα, 1895",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudogalen",
+    "work": "De Fasciis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0530.tlg005/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Cnobloch. 1829",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudogalen",
+    "work": "De Optima Secta ad Thrasybulum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0530.tlg043/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Cnobloch. 1821",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudogalen",
+    "work": "De Remediis Parabilibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0530.tlg029/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Cnobloch. 1827",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudogalen",
+    "work": "De Theriaca ad Pamphilianum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0530.tlg032/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Cnobloch. 1827",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudogalen",
+    "work": "Introductio Seu Medicus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0530.tlg012/",
+    "print_source": "Karl Gottlob Kühn, Claudii Galeni Opera Omnia, Lipsiae. Cnobloch. 1827",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudolucian",
+    "work": "Affairs of the Heart",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0062.tlg053/",
+    "print_source": "Lucian. Luciani Samosatensis Opera, Vol. 2. Jacobitz, Karl, editor. Leipzig: Teubner, 1913.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudolucian",
+    "work": "Charidemus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0062.tlg067/",
+    "print_source": "Lucian. Luciani Samosatensis Opera, Vol. 1. Jacobitz, Karl, editor. Leipzig: Teubner, 1909.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudolucian",
+    "work": "Encomium of Demosthenes",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0062.tlg060/",
+    "print_source": "Lucian. Luciani Samosatensis Opera, Vol. 1. Jacobitz, Karl, editor. Leipzig: Teubner, 1909.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudolucian",
+    "work": "Halcyon",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0062.tlg069/",
+    "print_source": "Lucian. Luciani Samosatensis Opera, Vol. 3. Jacobitz, Karl, editor. Leipzig: Teubner, 1913.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudolucian",
+    "work": "Lucius or the Ass",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0062.tlg054/",
+    "print_source": "Lucian. Luciani Samosatensis Opera, Vol. 3. Jacobitz, Karl, editor. Leipzig: Teubner, 1913.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudolucian",
+    "work": "Philopatris",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0062.tlg063/",
+    "print_source": "Lucian. Luciani Samosatensis Opera, Vol. 1. Jacobitz, Karl, editor. Leipzig: Teubner, 1909.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudolucian",
+    "work": "The Cynic",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0062.tlg066/",
+    "print_source": "Lucian. Luciani Samosatensis Opera, Vol. 1. Jacobitz, Karl, editor. Leipzig: Teubner, 1909.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudomenander",
+    "work": "Sententiae Corresponds to Version Men Ar I Greek",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0541.tlg042/",
+    "print_source": "Manfred Ullmann, Die arabische Überlieferung der sogenannten Menandersentenzen, Wiesbaden. Kommissionsverlag Franz Steiner. 1961",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudomenander",
+    "work": "Sententiae Corresponds to Version Men Ar Ii Greek",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0541.tlg042/",
+    "print_source": "Manfred Ullmann, Die arabische Überlieferung der sogenannten Menandersentenzen, Wiesbaden. Kommissionsverlag Franz Steiner. 1961",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudoplutarch",
+    "work": "De Fluviis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0094.tlg001/",
+    "print_source": "Pseudo-Plutarch. Geographi graeci minores Volumen Secundum. Müller, Karl, editor. Paris: Ambroise Firmin Didot, 861.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudoplutarch",
+    "work": "On the Naming of Rivers Mountains and Things Found",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0094.tlg001/",
+    "print_source": "Pseudo-Plutarch. Geographi graeci minores Volumen Secundum. Müller, Karl, editor. Paris: Ambroise Firmin Didot, 861.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Pseudoscymnus",
+    "work": "Scymni Chii Ut Fertur Periegesis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0068.tlg001/",
+    "print_source": "Pseudo-Scymnus, creator; Geographi graeci minores Volumen Primum, ed. Karl Müller; Ambroise Firmin Didot, Paris, 1855",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Q Cicero",
+    "work": "On Running for Consul",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Q. Cicero",
@@ -6888,6 +13264,14 @@
     "added_by": "Emilie Bétrix"
   },
   {
+    "author": "Quintilian Pseudo",
+    "work": "Major Declamations",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Quintus Smyrnaeus",
     "work": "Fall of Troy",
     "e_source": "Perseus",
@@ -6896,10 +13280,42 @@
     "added_by": "L. Annaeus Seneca. Tragoediae. Rudolf Peiper. Gustav Richter. Leipzig. Teubner. 1921."
   },
   {
+    "author": "Radbertus Paschasius, abbas Corbeiensis",
+    "work": "Carmina",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/RADBERT%7Ccarm%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Remigius of Auxerre",
+    "work": "Expositione in Paschale Carmen",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0241d.stoa002/",
+    "print_source": "Remigius of Auxerre. Sedulii Opera omnia (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 10). Huemer, Johann, editor. Vienna: Gerold, 1885.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Rufinus",
+    "work": "Interpretatio Orationem Gregorii Nazianzeni",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Rufinus of Aquileia",
+    "work": "Interpretatio Orationum Gregorii Nazianz",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0244d.stoa005/",
+    "print_source": "Rufinus of Aquileia. Tyranni Rufini Orationum Gregorii Nazianzeni Novem Interpretatio (Corpus scriptorum ecclesiasticorum latinorum, Volume 46). Leipzig, Vienna: Tempsky, Freytag, 1910.",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Rufinus of Aquileia",
     "work": "Interpretatio Orationum Gregorii Nazianzeni",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0243",
     "print_source": "Johann Wrobel. Tyrannii Rufini Orationum Gregorii Nazianzeni Novem Interpretatio. Vindobonae: Gerold. 1910.",
     "added_by": "Caitlin Diddams"
   },
@@ -6912,12 +13328,60 @@
     "added_by": "Caitlin Diddams"
   },
   {
+    "author": "Rufus of Ephesus",
+    "work": "De Renum Et Vesicae Affectionibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0564.tlg001/",
+    "print_source": "Charles Daremburg, Émile Ruelle, Oeuvres de Rufus d'Éphèse, Paris. Imprimerie Nationale. 1879",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Rufus Soph",
+    "work": "Ars Rhetorica",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0606.tlg001/",
+    "print_source": "Rufus Soph., Ars rhetorica, Spengel, Teubner, 1853",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Ruricius I Bishop of Limoges",
+    "work": "Epistulae",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0245a.stoa001/",
+    "print_source": "Ruricius I, Bishop of Limoges. Fausti Reiensis praeter sermones pseudo-eusebianos opera (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 21). Engelbrecht, August, editor. Prague; Vienna; Leipzig: Tempsky, Freytag, 1891.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Rusticus Presbyter",
+    "work": "Epistula ad Eucherium Lugdunensem",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Rutilius",
+    "work": "De Reditu",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Rutilius",
     "work": "De Reditu Suo",
-    "e_source": "",
+    "e_source": "LacusCurtius",
     "e_source_url": "https://web.archive.org/web/20240812080521/https://penelope.uchicago.edu/Thayer/L/Roman/Texts/Rutilius_Namatianus/text*.html",
     "print_source": "J. Wight Duff and Arnold M. Duff. Minor Latin Poets Volume II Harvard University Press. 1934.",
     "added_by": "V3 Legacy Import"
+  },
+  {
+    "author": "Sallust",
+    "work": "Catilina",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Sallust",
@@ -6926,6 +13390,38 @@
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0002",
     "print_source": "Axel W. Ahlberg, Catilina, Iugurtha, Orationes Et Epistulae Excerptae De Historiis. Leipzig: Teubner, 1919.",
     "added_by": "Tony R Waleszczak"
+  },
+  {
+    "author": "Sallust",
+    "work": "Histories",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Sallust",
+    "work": "Jugurtha",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Salutati",
+    "work": "De Laboribus Herculis",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Salutati",
+    "work": "De Tyranno",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Salutati, Coluccio",
@@ -6944,10 +13440,34 @@
     "added_by": "V3 Legacy Import"
   },
   {
+    "author": "Salvian of Marseilles",
+    "work": "Ad Ecclesiam Libri Iiii",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0249a.stoa004/",
+    "print_source": "Salvian of Marseilles. Salviani presbyteri Massiliensis opera omnia (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 8). Vienna: Gerold, 1883.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Salvian of Marseilles",
+    "work": "De Gubernatione Dei",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0249a.stoa002/",
+    "print_source": "Salvian of Marseilles. Salviani presbyteri Massiliensis opera omnia (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 8). Vienna: Gerold, 1883.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Salvian of Marseilles",
+    "work": "Epistulae",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0249a.stoa003/",
+    "print_source": "Salvian of Marseilles. Sancti Eucherii Lugdunensis. Formulae spiritalis intellegentiae Instructionum libri duo Passio agaunensium martyrum Epistula de laude heremi (Corpus scriptorum ecclesiasticorum Latinorum, Volume 31). Wotke, Karl, editor. Prague; Vienna; Leipzig: Tempsky, Freytag, 1894.",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Salvianus",
     "work": "Ad Ecclesiam",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0250",
     "print_source": "Pauly, Franz Salviani presbyteri Massiliensis opera omnia. Vindobonae: Gerold, 1883.",
     "added_by": "Cari Haas"
   },
@@ -6955,7 +13475,7 @@
     "author": "Salvianus",
     "work": "De Gubernatione Dei",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0250",
     "print_source": "Pauly, Franz Salviani presbyteri Massiliensis opera omnia. Vindobonae: Gerold, 1883.",
     "added_by": "Cari Haas"
   },
@@ -6969,19 +13489,27 @@
   },
   {
     "author": "Scriptores Historiae Augustae",
-    "work": "Historia Augusta, Vol. 1",
-    "e_source": "Perseus",
-    "e_source_url": "http://www.perseus.tufts.edu/hopper/text;jsessionid=207BFD035F78CA3C95101DC5F6883565?doc=Perseus%3atext%3a2008.01.0508%3awork%3d1",
-    "print_source": "David Magie. Ainsworth O'Brien-Moore. Susan Helen Ballou. London: William Heinemann; New York: G.P. Putnam's Sons. 1921.",
-    "added_by": "Blake Cooper"
+    "work": "Historia Augusta",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
-    "author": "Scriptores Historiae Augustae",
-    "work": "Historia Augusta, Vol. 2",
-    "e_source": "Perseus",
-    "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0509%3awork%3d13",
-    "print_source": "David Magie. Ainsworth O'Brien-Moore. London: William Heinemann; New York: G.P. Putnam's Sons. 1924.",
-    "added_by": "Blake Cooper"
+    "author": "Scylax of Caranda",
+    "work": "Periplus Scylacis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0065.tlg001/",
+    "print_source": "Scylax of Caranda. Geographi Graeci Minores, Volume 1. Müller, Karl. Paris: Ambroise Firmin Didot, 1855.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Secundinus",
+    "work": "Epistula Secundini ad Augustinum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Secundinus Manichaeus",
@@ -7006,6 +13534,94 @@
     "e_source_url": "http://www.thelatinlibrary.com/sedulius.html",
     "print_source": "J. Huemer.Sedulii opera omnia, accedunt excerpta ex Remigii Expositione in Sedulii Paschale carmen.Corpus Scriptorum Ecclesiasticorum Latinorum 10; Gerold, 1885",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Sedulius",
+    "work": "Carmina ad Sedulium Spectantia",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0252.stoa003/",
+    "print_source": "Sedulius. Poetae Christiani Minores, Pars I (Corpus scriptorum ecclesiasticorum latinorum, Volume 16, Part 1). Petschenig, Michael, editor; Ellis, Robinson, editor; Brandes, Wilhelm, editor; Schenkl, Karl, editor. Vienna, Leipzig, Prague: Tempsky, Freytag, 1888.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Sedulius",
+    "work": "Epistola ad Macedonium",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Sedulius",
+    "work": "Epistola ad Macedonium Altera",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Sedulius",
+    "work": "Hymnus I",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Sedulius",
+    "work": "Hymnus Ii a Solis Ortus Cardine",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Sedulius",
+    "work": "Opus Paschale",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0252.stoa008/",
+    "print_source": "Sedulius. Sedulii Opera omnia (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 10). Huemer, Johann, editor. Vienna: Gerold, 1885.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Sedulius Scotus",
+    "work": "Carmen Pastorale",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/SEDUL_SC%7Cpast%7C001",
+    "print_source": "B. Bischoff, 1981",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Sedulius Scotus",
+    "work": "Carmina 1",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/SEDUL_SC%7Ccar1%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Sedulius Scotus",
+    "work": "Carmina 2",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/SEDUL_SC%7Ccar1%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Sedulius Scotus",
+    "work": "Carmina 3",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/SEDUL_SC%7Ccar1%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Sedulius Scotus",
+    "work": "Carminum Appendix",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/SEDUL_SC%7Ccar1%7C001",
+    "print_source": "L. Traube, 1886-96",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
   },
   {
     "author": "Seneca",
@@ -7033,6 +13649,14 @@
   },
   {
     "author": "Seneca",
+    "work": "Carminum Fragmenta",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Seneca",
     "work": "De Beneficiis",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2007.01.0023",
@@ -7054,6 +13678,14 @@
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2007.01.0015",
     "print_source": "L. Annaeus Seneca. Moral Essays. Volume 1. John W. Basore. London and New York. Heinemann. 1928.",
     "added_by": "Katherine Roache"
+  },
+  {
+    "author": "Seneca",
+    "work": "De Consolatione ad Helviam",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Seneca",
@@ -7188,7 +13820,7 @@
     "work": "Quaestiones Naturales",
     "e_source": "The Latin Library",
     "e_source_url": "http://www.thelatinlibrary.com/sen/sen.qn1.shtml",
-    "print_source": "Edition unknown.",
+    "print_source": "",
     "added_by": "Caitlin Diddams"
   },
   {
@@ -7240,6 +13872,270 @@
     "added_by": "Katherine Roache"
   },
   {
+    "author": "Septuaginta",
+    "work": "Abdias",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg040/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Aggaeus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg045/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Amos",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg037/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Baruch",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg050/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Bel Et Draco Translatio Graeca",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg058/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Canticum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg031/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 2: I Chronicles-Tobit. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1896.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Daniel Translatio Graeca",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg056/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Epistula Jeremiae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg052/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Esdras a",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg017/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 2: I Chronicles-Tobit. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1896.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Esther",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg019/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 2: I Chronicles-Tobit. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1896.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Ezechiel",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg053/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Habacuc",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg043/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Isaias",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg048/",
+    "print_source": "Septuaginta. The Book of Isaiah According to the Septuagint (Codex Alexandrinus). Ottley, Richard, Rusden, editor. Cambridge: C.J. Clay and Sons, 1904.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Jeremias",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg049/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Job",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg032/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 2: I Chronicles-Tobit. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1896.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Joel",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg039/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Jonas",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg041/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Judith",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg020/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 2: I Chronicles-Tobit. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1896.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Machabaeorum I",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg023/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Malachias",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg047/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Michaeas",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg038/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Nahum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg042/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Odae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg028/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Osee",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg036/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Paralipomenon I Sive Chronicon I",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg015/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 2: I Chronicles-Tobit. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1896.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Proverbia",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg029/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 2: I Chronicles-Tobit. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1896.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Psalmi",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg027/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 2: I Chronicles-Tobit. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1896.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Sapientia Salomonis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg033/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 2: I Chronicles-Tobit. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1896.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Sophonias",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg044/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Susanna Translatio Graeca",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg054/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Threni Seu Lamentationes",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg051/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Tobias",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg021/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 2: I Chronicles-Tobit. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1896.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Septuaginta",
+    "work": "Zacharias",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0527.tlg046/",
+    "print_source": "Septuaginta. The Old Testament in Greek According to the Septuagint. Volume 3: Hosea-4 Maccabees, Psalms of Solomon, Enoch, The Odes. Swete, Henry Barclay, editor. Cambridge: Cambridge University Press, 1905",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Servius Honoratus",
     "work": "Commentary on the Aeneid of Vergil",
     "e_source": "Perseus",
@@ -7262,6 +14158,62 @@
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2007.01.0092",
     "print_source": "Georgius Thilo, In Vergilii carmina comentarii. Leipzig: B. G. Teubner, 1881.",
     "added_by": "Elizabeth Hunter"
+  },
+  {
+    "author": "Servius Honoratus",
+    "work": "In Virgilii Georgicon Libros Commentarius",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Severus Sulpicius",
+    "work": "Chronica",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0270.stoa001/",
+    "print_source": "Severus, Sulpicius. Sulpicii Severi libri qui supersunt (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 1). Halm, Karl, editor. Vienna: Gerold, 1866.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Severus Sulpicius",
+    "work": "Dialogi",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0270.stoa003/",
+    "print_source": "Severus, Sulpicius. Sulpicii Severi libri qui supersunt (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 1). Halm, Karl, editor. Vienna: Gerold, 1866.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Severus Sulpicius",
+    "work": "Epistulae Tres",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0270.stoa005/",
+    "print_source": "Severus, Sulpicius. Sulpicii Severi libri qui supersunt (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 1). Halm, Karl, editor. Vienna: Gerold, 1866.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Severus Sulpicius",
+    "work": "Vita Sancti Martini",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0270.stoa002/",
+    "print_source": "Severus, Sulpicius. Sulpicii Severi libri qui supersunt (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 1). Halm, Karl, editor. Vienna: Gerold, 1866.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Sextus Empiricus",
+    "work": "Adversus Mathematicos",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0544.tlg002/",
+    "print_source": "Sextus Empiricus. Sexti Empiricii Opera, Volume 2-3. Mutschmann, Hermann; Mau, Jürgen, editors. Leipzig: Teubner, 1912-1954 (printing).",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Sextus Empiricus",
+    "work": "Pyrrhoniae Hypotyposes",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0544.tlg001/",
+    "print_source": "Sextus Empiricus. Sexti Empiricii Opera, Volume 1. Mutschmann, Hermann, editor. Leipzig: Teubner, 1912.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Shakespeare",
@@ -7288,12 +14240,124 @@
     "added_by": "Timothy Tilbe"
   },
   {
+    "author": "Shakespeare",
+    "work": "Sonnets",
+    "e_source": "Project Gutenberg",
+    "e_source_url": "https://www.gutenberg.org/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Sigloardus Remensis",
+    "work": "Rhythmi",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/SIGL_REM%7Crhyt%7C001",
+    "print_source": "P. v. Winterfeld, 1899",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
     "author": "Silius Italicus",
     "work": "Punica",
     "e_source": "Perseus",
     "e_source_url": "https://web.archive.org/web/20240812080521/http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0674",
     "print_source": "Walter Coventry Summers and John Percival Postgate, Silius Italicus. Corpus Poetarum Latinorum Vol. 2.. London. Sumptibus G. Bell et Filiorum. 1905.",
     "added_by": "V3 Legacy Import"
+  },
+  {
+    "author": "Smaragdus",
+    "work": "Carmen in Psalterio",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Smaragdus",
+    "work": "Carmina",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Smaragdus",
+    "work": "Epitaphium",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Smaragdus",
+    "work": "Versus ad Filium Ludovici Pii",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Smaragdus, abbas sancti Michaelis ad Mosam",
+    "work": "Carmen ad Agobardum",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/CARM_AGO%7Ccarm%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Smaragdus, abbas sancti Michaelis ad Mosam",
+    "work": "Carmen ad Ludovicum Pium",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/CARM_LDW%7Ccarm%7C001",
+    "print_source": "K. Strecker, 1923",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Smaragdus, abbas sancti Michaelis ad Mosam",
+    "work": "Carmen de Timone Comite",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/CARM_TIM%7Ccarm%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Smaragdus, abbas sancti Michaelis ad Mosam",
+    "work": "Carmen in Psalterio",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/SMAR%7Cpsal%7C001",
+    "print_source": "I. Schmale-Ott, 1953/54",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Smaragdus, abbas sancti Michaelis ad Mosam",
+    "work": "Carmina",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/SMAR%7Ccarm%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Smaragdus, abbas sancti Michaelis ad Mosam",
+    "work": "Epitaphium",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/SMAR%7Cepit%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Smaragdus, abbas sancti Michaelis ad Mosam",
+    "work": "Versus ad Ebonem Remensem",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/VERS_EBO%7Cvers%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Smaragdus, abbas sancti Michaelis ad Mosam",
+    "work": "Versus ad Filium Ludovici Pii",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/SMAR%7Cvers%7C001",
+    "print_source": "K. Strecker, 1923",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
   },
   {
     "author": "Sophocles",
@@ -7337,6 +14401,14 @@
   },
   {
     "author": "Sophocles",
+    "work": "Oedipus Coloneus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0011.tlg003/",
+    "print_source": "Christian Lobeck, Sophoclis Aiax, Berlin. Weidmann. 1866",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Sophocles",
     "work": "Oedipus Epi Kolono (Oedipus at Colonus)",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.01.0189",
@@ -7376,12 +14448,92 @@
     "added_by": "Katherine Roache"
   },
   {
+    "author": "Soranus",
+    "work": "De Fasciis",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0565.tlg003/",
+    "print_source": "Soranus. Sorani Gynaeciorum Libri IV: De Signis Fracturarum De Fasciis Vita Hippocratis Secundum Soranum. Ilberg, Johannes, editor. Leipzig and Berlin: Teubner, 1927.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Soranus",
+    "work": "De Signis Fracturarum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0565.tlg002/",
+    "print_source": "Soranus. Sorani Gynaeciorum Libri IV: De Signis Fracturarum De Fasciis Vita Hippocratis Secundum Soranum. Ilberg, Johannes, editor. Leipzig and Berlin: Teubner, 1927.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Soranus",
+    "work": "Gynaeciorum Libri Iv",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0565.tlg001/",
+    "print_source": "Soranus. Sorani Gynaeciorum Libri IV: De Signis Fracturarum De Fasciis Vita Hippocratis Secundum Soranum. Ilberg, Johannes, editor. Leipzig and Berlin: Teubner, 1927.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Soranus",
+    "work": "Vita Hippocratis Secundum Soranum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0565.tlg004/",
+    "print_source": "Soranus. Sorani Gynaeciorum Libri IV: De Signis Fracturarum De Fasciis Vita Hippocratis Secundum Soranum. Ilberg, Johannes, editor. Leipzig and Berlin: Teubner, 1927.",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Statius",
     "work": "Achilleid",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0500",
     "print_source": "John Henry Mozley, Statius: Vol II. New York: G.P. Putnam’s Sons. 1928.",
     "added_by": "Chris Forstall"
+  },
+  {
+    "author": "Statius",
+    "work": "Achilleis",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:phi0845.phi003/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Statius",
+    "work": "Siluae 1",
+    "e_source": "Greek & Latin Texts",
+    "e_source_url": "",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Statius",
+    "work": "Siluae 2",
+    "e_source": "Greek & Latin Texts",
+    "e_source_url": "",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Statius",
+    "work": "Siluae 3",
+    "e_source": "Greek & Latin Texts",
+    "e_source_url": "",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Statius",
+    "work": "Siluae 4",
+    "e_source": "Greek & Latin Texts",
+    "e_source_url": "",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Statius",
+    "work": "Siluae 5",
+    "e_source": "Greek & Latin Texts",
+    "e_source_url": "",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Statius",
@@ -7400,12 +14552,36 @@
     "added_by": "Chris Forstall"
   },
   {
+    "author": "Statius",
+    "work": "Thebais",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:phi0845.phi002/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Strabo",
+    "work": "Geography",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0099.tlg001/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Strabo",
     "work": "Geography (Greek). Machine readable text",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.01.0197",
     "print_source": "ed. A. Meineke, Geographica.Leipzig: Teubner, 1877.",
     "added_by": "James Gawley"
+  },
+  {
+    "author": "Strabo",
+    "work": "Strabonis Geographiae Chrestomathia Geographia Sel",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0099.tlg004/",
+    "print_source": "Anonymous. Geographi graeci minores, Volume 2. Müller, Karl, editor. Paris: Ambroise Firmin Didot, 1861.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Suetonius",
@@ -7419,7 +14595,7 @@
     "author": "Sulpicius Severus",
     "work": "Chronica",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0261",
     "print_source": "Karl Halm. Sulpicii Severi Libri Qui Supersunt. Vindobonae: Gerold. 1866.",
     "added_by": "Caitlin Diddams"
   },
@@ -7427,7 +14603,7 @@
     "author": "Sulpicius Severus",
     "work": "Dialogi",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0261",
     "print_source": "Karl Halm. Sulpicii Severi Libri Qui Supersunt. Vindobonae: Gerold. 1866.",
     "added_by": "Caitlin Diddams"
   },
@@ -7435,17 +14611,57 @@
     "author": "Sulpicius Severus",
     "work": "Epistolae Tres",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0261",
     "print_source": "Karl Halm. Sulpicii Severi Libri Qui Supersunt. Vindobonae: Gerold. 1866.",
     "added_by": "Caitlin Diddams"
   },
   {
     "author": "Sulpicius Severus",
+    "work": "Epistula ad Aurelium",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Sulpicius Severus",
+    "work": "Epistula ad Bassulae Parenti",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Sulpicius Severus",
+    "work": "Epistula Prima ad Eusebium",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Sulpicius Severus",
+    "work": "Vita Martini",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Sulpicius Severus",
     "work": "Vita Sancti Martini",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0261",
     "print_source": "Karl Pomeroy Harrington. Vita Sancti Martini Chapter XIII. Boston: Allyn and Bacon. 1925.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Swift",
+    "work": "Gullivers Travels",
+    "e_source": "Project Gutenberg",
+    "e_source_url": "https://www.gutenberg.org/",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Tacitus",
@@ -7547,15 +14763,23 @@
     "author": "Tertullian",
     "work": "Ad Nationes",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0275",
     "print_source": "Georg Wissowa. Quinti Septimi Florentis Tertulliani Opera Pars I. Vindobonae: Gerold. 1890.",
     "added_by": "Caitlin Diddams"
   },
   {
     "author": "Tertullian",
+    "work": "Ad Nationes Libri Duo",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0275.stoa002/",
+    "print_source": "Tertullian. Quinti Septimi Florentis Tertulliani opera, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 20). Reifferscheid, August; Wissowa, Georg, editors. Prague, Vienna, Leipzig: F. Tempsky, G. Freytag, 1890.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Tertullian",
     "work": "Adversus Hermogenem",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0275",
     "print_source": "Emil Kroymann. Quinti Septimi Florentis Tertulliani Opera Pars III. Vindobonae: Gerold. 1906.",
     "added_by": "Caitlin Diddams"
   },
@@ -7563,15 +14787,23 @@
     "author": "Tertullian",
     "work": "Adversus Marcionem",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0275",
     "print_source": "Emil Kroymann. Quinti Septimi Florentis Tertulliani Opera Pars III. Vindobonae: Gerold. 1906.",
     "added_by": "Caitlin Diddams"
   },
   {
     "author": "Tertullian",
+    "work": "Adversus Praxeam",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Tertullian",
     "work": "Adversus Praxean",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0275",
     "print_source": "Emil Kroymann. Quinti Septimi Florentis Tertulliani Opera Pars III. Vindobonae: Gerold. 1906.",
     "added_by": "Caitlin Diddams"
   },
@@ -7579,7 +14811,7 @@
     "author": "Tertullian",
     "work": "Adversus Valentinianos",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0275",
     "print_source": "Emil Kroymann. Quinti Septimi Florentis Tertulliani Opera Pars III. Vindobonae: Gerold. 1906.",
     "added_by": "Caitlin Diddams"
   },
@@ -7595,7 +14827,7 @@
     "author": "Tertullian",
     "work": "De Anima",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0275",
     "print_source": "Georg Wissowa. Quinti Septimi Florentis Tertulliani Opera Pars I. Vindobonae: Gerold. 1890.",
     "added_by": "Caitlin Diddams"
   },
@@ -7603,7 +14835,7 @@
     "author": "Tertullian",
     "work": "De Baptismo",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0275",
     "print_source": "Georg Wissowa. Quinti Septimi Florentis Tertulliani Opera Pars I. Vindobonae: Gerold. 1890.",
     "added_by": "Caitlin Diddams"
   },
@@ -7611,7 +14843,7 @@
     "author": "Tertullian",
     "work": "De Carnis Resurrectione",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0275",
     "print_source": "Emil Kroymann. Quinti Septimi Florentis Tertulliani Opera Pars III. Vindobonae: Gerold. 1906.",
     "added_by": "Caitlin Diddams"
   },
@@ -7619,23 +14851,39 @@
     "author": "Tertullian",
     "work": "De Idolatria",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0275",
     "print_source": "Georg Wissowa. Quinti Septimi Florentis Tertulliani Opera Pars I. Vindobonae: Gerold. 1890.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Tertullian",
+    "work": "De Idololatria",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Tertullian",
     "work": "De Ieiunio",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0275",
     "print_source": "Georg Wissowa. Quinti Septimi Florentis Tertulliani Opera Pars I. Vindobonae: Gerold. 1890.",
     "added_by": "Caitlin Diddams"
   },
   {
     "author": "Tertullian",
+    "work": "De Ieiunio Adversus Psychicos",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0275.stoa018/",
+    "print_source": "Tertullian. Quinti Septimi Florentis Tertulliani opera, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 20). Reifferscheid, August; Wissowa, Georg, editors. Prague, Vienna, Leipzig: F. Tempsky, G. Freytag, 1890.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Tertullian",
     "work": "De Oratione",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0275",
     "print_source": "Georg Wissowa. Quinti Septimi Florentis Tertulliani Opera Pars I. Vindobonae: Gerold. 1890.",
     "added_by": "Caitlin Diddams"
   },
@@ -7643,7 +14891,7 @@
     "author": "Tertullian",
     "work": "De Patientia",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0275",
     "print_source": "Emil Kroymann. Quinti Septimi Florentis Tertulliani Opera Pars III. Vindobonae: Gerold. 1906.",
     "added_by": "Caitlin Diddams"
   },
@@ -7651,7 +14899,7 @@
     "author": "Tertullian",
     "work": "De Pudicitia",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0275",
     "print_source": "Georg Wissowa. Quinti Septimi Florentis Tertulliani Opera Pars I. Vindobonae: Gerold. 1890.",
     "added_by": "Caitlin Diddams"
   },
@@ -7659,7 +14907,7 @@
     "author": "Tertullian",
     "work": "De Scorpiace",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0275",
     "print_source": "Georg Wissowa. Quinti Septimi Florentis Tertulliani Opera Pars I. Vindobonae: Gerold. 1890.",
     "added_by": "Caitlin Diddams"
   },
@@ -7675,9 +14923,57 @@
     "author": "Tertullian",
     "work": "De Testimionio Animae",
     "e_source": "Open Greek and Latin",
-    "e_source_url": "http://opengreekandlatin.github.io/csel-dev/",
+    "e_source_url": "https://github.com/OpenGreekAndLatin/csel-dev/tree/master/data/stoa0275",
     "print_source": "Georg Wissowa. Quinti Septimi Florentis Tertulliani Opera Pars I. Vindobonae: Gerold. 1890.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Tertullian",
+    "work": "De Testimonio Animae",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Tertullian",
+    "work": "Scorpiace",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0275.stoa030/",
+    "print_source": "Tertullian. Quinti Septimi Florentis Tertulliani opera, Pars I (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 20). Reifferscheid, August; Wissowa, Georg, editors. Prague, Vienna, Leipzig: F. Tempsky, G. Freytag, 1890.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Tertullian Pseudo",
+    "work": "Adversus Omnes Haereses",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Tertullian Pseudo",
+    "work": "De Iona Propheta",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Tertullian Pseudo",
+    "work": "De Sodoma",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Themistocles",
+    "work": "Epistulae",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0055.tlg001/",
+    "print_source": "Rudolf Hercher, Epistolographi Graeci, Paris. A. F. Didot. 1873",
+    "added_by": "V6 Import"
   },
   {
     "author": "Theocritus",
@@ -7694,6 +14990,14 @@
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3Atext%3A1999.01.0228%3Atext%3DId.",
     "print_source": "Theocritus. Idylls. R. J. Cholmeley. London. George Bell &amp; Sons. 1901.",
     "added_by": "Caitlin Diddams"
+  },
+  {
+    "author": "Theodosius",
+    "work": "De Situ Terrae Sanctae",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0278a.stoa001/",
+    "print_source": "Theodosius. Itinera hierosolymitana saecvli IIII-VIII (Corpus scriptorum ecclesiasticorum Latinorum, Volume 39). Geyer, Paul, editor. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1898.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Theodulf of Orleans",
@@ -7720,12 +15024,84 @@
     "added_by": "M. Paccara & F. Stella (University of Siena)"
   },
   {
+    "author": "Theodulfus, episcopus Aurelianensis",
+    "work": "Carminacarminum Appendix",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/THEODULF%7Ccarm%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Theodulfus, episcopus Aurelianensis",
+    "work": "Epitaphia",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/THEODULF%7Cepit%7C001",
+    "print_source": "E. Dümmler, 1881",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
     "author": "Theophrastus",
     "work": "Characters",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.01.0225",
     "print_source": "Hermann Diels, Characters. Oxford: Oxford University Press, 1909.",
     "added_by": "James Gawley"
+  },
+  {
+    "author": "Theophrastus",
+    "work": "Concerning Odours",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0093.ogl001/",
+    "print_source": "Theophrastus, Concerning Odours, Hort, Harvard, 1927",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Theophrastus",
+    "work": "Concerning Odours Greek",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0093.ogl001/",
+    "print_source": "Theophrastus, Concerning Odours, Hort, Harvard, 1927",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Theophrastus",
+    "work": "De Causis Plantarum",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0093.tlg003/",
+    "print_source": "Theophrastus, Theophrasti Eresii Opera quae supersunt omnia, Volume 3, Wimmer, Teubner, 1862",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Theophrastus",
+    "work": "De Lapidibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0093.tlg004/",
+    "print_source": "Theophrastus, Theophrasti Eresii Opera quae supersunt omnia, Volume 3, Wimmer, Teubner, 1862",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Theophrastus",
+    "work": "De Sensu Et Sensibilibus",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0093.tlg003/",
+    "print_source": "Theophrastus, Theophrasti Eresii Opera quae supersunt omnia, Volume 3, Wimmer, Teubner, 1862",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Theophrastus",
+    "work": "Enquiry Into Plants",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0093.ogl002/",
+    "print_source": "Theophrastus, Concerning Weather Signs, Hort, Harvard, 1927",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Theophrastus",
+    "work": "Fragmenta Varia 13190",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0093.tlg010x09/",
+    "print_source": "Friedrich Wimmer, Theophrasti Eresii Opera, Quae Supersunt, Omnia., Paris. A.F. Didot. 1866",
+    "added_by": "V6 Import"
   },
   {
     "author": "Thucydides",
@@ -7744,12 +15120,52 @@
     "added_by": "Chris Forstall"
   },
   {
+    "author": "Tibullus",
+    "work": "Elegiae 1",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Tibullus",
+    "work": "Elegiae 2",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Tibullus",
+    "work": "Elegies",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Tryphiodorus",
     "work": "The Taking of Ilios",
     "e_source": "Perseus",
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a2008.01.0491",
     "print_source": "A. W. Mair, Oppian, Colluthus, Tryphiodorus with an English Translation by A.W. Mair.London, William Heinemann, Ltd.; New York: G.P. Putnam's Sons, 1928.",
     "added_by": "Bridget Murray"
+  },
+  {
+    "author": "Tryphon I Grammaticus",
+    "work": "On Tropes",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0606.tlg001/",
+    "print_source": "Rufus Soph., Ars rhetorica, Spengel, Teubner, 1853",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Unknown",
+    "work": "Corpus Scriptorum Ecclesiasticorum Latin",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0040.stoa054/",
+    "print_source": "Augustine. Sancti Aureli Augustini Opera, Sectio VIII, Pars I (Corpus scriptorum ecclesiasticorum Latinorum, Volume 60). Urba, Karl; Zycha, Joseph; editors. Prague; Vienna; Leipzig: F. Tempsky; G. Freytag, 1913.",
+    "added_by": "V6 Import"
   },
   {
     "author": "Valerius Flaccus",
@@ -7800,6 +15216,118 @@
     "added_by": "Chris Forstall"
   },
   {
+    "author": "Vergil Pseudo",
+    "work": "Aetna",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Vergil Pseudo",
+    "work": "Appendix Vergiliana Combined",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Vergil Pseudo",
+    "work": "Catalepton",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Vergil Pseudo",
+    "work": "Ciris",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Vergil Pseudo",
+    "work": "Copa",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Vergil Pseudo",
+    "work": "Culex",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Vergil Pseudo",
+    "work": "Dirae",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Vergil Pseudo",
+    "work": "Elegiae in Maecenatem",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Vergil Pseudo",
+    "work": "Lydia",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Vergil Pseudo",
+    "work": "Moretum",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Vergil Pseudo",
+    "work": "Priapea",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Victor Claudius Marius",
+    "work": "Alethia",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0292b.stoa001/",
+    "print_source": "Victor, Claudius Marius. Saint. Poetae Christiani Minores, Pars I (Corpus scriptorum ecclesiasticorum latinorum, Volume 16, Part 1). Petschenig, Michael, editor; Ellis, Robinson, editor; Brandes, Wilhelm, editor; Schenkl, Karl, editor. Vienna, Leipzig, Prague: Tempsky, Freytag, 1888.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Victor Claudius Marius",
+    "work": "Commentariorum in Genesim Libri Tres",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0292b.stoa001/",
+    "print_source": "Victor, Claudius Marius. Saint. Poetae Christiani Minores, Pars I (Corpus scriptorum ecclesiasticorum latinorum, Volume 16, Part 1). Petschenig, Michael, editor; Ellis, Robinson, editor; Brandes, Wilhelm, editor; Schenkl, Karl, editor. Vienna, Leipzig, Prague: Tempsky, Freytag, 1888.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Victor Vitensis",
+    "work": "Historia Persecutionis Africanae Provinc",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0292d.stoa001/",
+    "print_source": "Victor Vitensis. Victoris episcopi Vitensis Historia persecutionis Africanae provinciae (Corpus Scriptorum Ecclesiasticorum, Volume 7). Petschenig, Michael, editor. Vienna: Gerold, 1881.",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Victorinus",
     "work": "De Machabeis",
     "e_source": "Open Greek and Latin",
@@ -7808,12 +15336,44 @@
     "added_by": "Caitlin Diddams"
   },
   {
+    "author": "Victorinus Saint Bishop of Poetovio",
+    "work": "Commentarii in Apocalypsin",
+    "e_source": "Open Greek and Latin / CSEL",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:latinLit:stoa0292e.stoa001/",
+    "print_source": "Victorinus Saint, Bishop of Poetovio. Victorini Episcopi Petavionensis Opera (Corpus Scriptorum Ecclesiasticorum Latinorum, Volume 49). Haussleiter, Johann, editor. Vienna, Leipzig: Tempsky, Freytag, 1916.",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Vitensis",
+    "work": "Historia Persecutionic Africanae Proviniae",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
     "author": "Vitensis",
     "work": "Historia Persecutionis Africanae Provinciae",
-    "e_source": "",
+    "e_source": "Internet Archive",
     "e_source_url": "https://web.archive.org/web/20240812080521/https://archive.org/details/victorisvitensi00victgoog/page/n20/mode/2up",
     "print_source": "Carolus Halm. Victoris Vitensis Historia Persecutionis Africanae Provinciae sub Geiserico et Hunrico regibus wandalorum. Berolini: Apud Weidmannos. 1879.",
     "added_by": "V3 Legacy Import"
+  },
+  {
+    "author": "Vitensis Pseudo",
+    "work": "Notitia Provinciarum Et Civitatum Africae",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Vitruvius",
+    "work": "De Architectura",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Vitruvius Pollio",
@@ -7824,12 +15384,252 @@
     "added_by": "Anna Glenn"
   },
   {
+    "author": "Vulfinus Diensis",
+    "work": "Vita Marcelli Metrica",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/VULF%7Ccarm%7C001",
+    "print_source": "K. Strecker, 1923",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Walafrid Strabo",
+    "work": "De Cultu Hortorum Carmen",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Walafrid Strabo",
+    "work": "De Vita Et Fine Mammae",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Walafrid Strabo",
+    "work": "In Natalem S Mammetis Hymnus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Walafrid Strabo",
+    "work": "Visio Wettini",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Walafrid Strabo",
+    "work": "Vita Sancti Galli Confessoris",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Walahfridus Strabo, abbas Augiensis",
+    "work": "Carmina",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Walahfridus Strabo, abbas Augiensis",
+    "work": "Carmina Varia",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/WALAHFR%7Ccarm%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Walahfridus Strabo, abbas Augiensis",
+    "work": "Carminum Appendix",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/WALAHFR%7Ccarm%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Walahfridus Strabo, abbas Augiensis",
+    "work": "De Cultu Hortorum Carmen",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/WALAHFR%7Chort%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Walahfridus Strabo, abbas Augiensis",
+    "work": "De Vita Et Fine Mammae",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/WALAHFR%7Cmamm%7C00a",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Walahfridus Strabo, abbas Augiensis",
+    "work": "In Natalem Mammetis Hymnus",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/WALAHFR%7Chymn%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Walahfridus Strabo, abbas Augiensis",
+    "work": "Versus de Blaithmaic",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/WALAHFR%7Cblai%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Walahfridus Strabo, abbas Augiensis",
+    "work": "Visio Wettini",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/WALAHFR%7Cwett%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Walahfridus Strabo, abbas Augiensis",
+    "work": "Vita Sancti Galli Confessoris",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/WALAHFR%7Cgall%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Wandalbert",
+    "work": "De Creatione Mundi",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Wandalbert",
+    "work": "De Mensium Nominibus",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Wandalbert",
+    "work": "Horarium",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Wandalbert",
+    "work": "Horologium",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Wandalbertus",
+    "work": "Martyrologium",
+    "e_source": "The Latin Library",
+    "e_source_url": "https://www.thelatinlibrary.com",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "Wandalbertus, diaconus Prumensis",
+    "work": "De Creatione Mundi",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/WANDALB%7Ccrea%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Wandalbertus, diaconus Prumensis",
+    "work": "De Mensium Nominibus",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/WANDALB%7Cmens%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Wandalbertus, diaconus Prumensis",
+    "work": "Horarium",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/WANDALB%7Chora%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Wandalbertus, diaconus Prumensis",
+    "work": "Horologium",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/WANDALB%7Choro%7C001",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
+    "author": "Wandalbertus, diaconus Prumensis",
+    "work": "Martyrologium",
+    "e_source": "Musisque Deoque",
+    "e_source_url": "https://www.musamedievalis.it/testo/testo/codice/WANDALB%7Cmart%7C00a",
+    "print_source": "E. Dümmler, 1884",
+    "added_by": "M. Paccara & F. Stella (University of Siena); John James"
+  },
+  {
     "author": "William of Tyre",
     "work": "Historia Rerum in Partibus Transmarinis Gestarum",
     "e_source": "The Latin Library",
     "e_source_url": "https://web.archive.org/web/20240812080521/https://www.thelatinlibrary.com/williamtyre.html",
-    "print_source": "Print edition unknown",
+    "print_source": "",
     "added_by": "V3 Legacy Import"
+  },
+  {
+    "author": "Wordsworth",
+    "work": "Prelude",
+    "e_source": "Project Gutenberg",
+    "e_source_url": "https://www.gutenberg.org/",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "World English Bible",
+    "work": "Pentateuch",
+    "e_source": "Greek & Latin Texts",
+    "e_source_url": "",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "World English Bible",
+    "work": "Prophets",
+    "e_source": "Greek & Latin Texts",
+    "e_source_url": "",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "World English Bible",
+    "work": "Revelation",
+    "e_source": "Greek & Latin Texts",
+    "e_source_url": "",
+    "print_source": "",
+    "added_by": "V6 Import"
+  },
+  {
+    "author": "World English Bible",
+    "work": "Writings",
+    "e_source": "Greek & Latin Texts",
+    "e_source_url": "",
+    "print_source": "",
+    "added_by": "V6 Import"
   },
   {
     "author": "Xenophon",
@@ -7838,5 +15638,13 @@
     "e_source_url": "http://www.perseus.tufts.edu/hopper/text?doc=Perseus%3atext%3a1999.01.0201",
     "print_source": "Xenophontis opera omnia, vol. 3.Oxford, Clarendon Press, 1904 (repr. 1961).",
     "added_by": "Bridget Murray"
+  },
+  {
+    "author": "Zenobius Sophista",
+    "work": "Epitome of Proverbs",
+    "e_source": "Open Greek and Latin / Scaife",
+    "e_source_url": "https://scaife.perseus.org/library/urn:cts:greekLit:tlg0098.tlg001/",
+    "print_source": "Zenobius Sophista. Corpus paroemiographorum Graecorum, Vol. 1. Leutsch, Ernst von; Schneidewin, Friedrich Wilhelm, editors. Göttingen: Vandenhoeck and Ruprecht, 1839.",
+    "added_by": "V6 Import"
   }
 ]


### PR DESCRIPTION
This PR cleans up the text credits page by removing redundant placeholders, generating specific Scaife URLs, and accurately resolving TEI-XML print bibliographies for all CTS URNs.