### PR TITLE
Fix Unicode path handling for Greek text search and corpus frequency loading

### DIFF
--- a/backend/frequency_cache.py
+++ b/backend/frequency_cache.py
@@ -5,6 +5,7 @@ from collections import Counter
 from datetime import datetime
 
 from backend.logging_config import get_logger
+from backend.utils import safe_listdir
 
 logger = get_logger('frequency_cache')
 
@@ -44,7 +45,7 @@ def get_corpus_checksum(language):
     if not os.path.exists(lang_dir):
         return None
     
-    files = sorted([f for f in os.listdir(lang_dir) if f.endswith('.tess')])
+    files = sorted([f for f in safe_listdir(lang_dir) if f.endswith('.tess')])
     file_info = []
     for f in files:
         path = os.path.join(lang_dir, f)
@@ -74,11 +75,12 @@ def load_frequency_cache(language):
 def save_frequency_cache(language, frequencies, total_lemmas, checksum):
     """Save frequency data to cache file"""
     cache_path = get_cache_path(language)
+    lang_dir = os.path.join(TEXTS_DIR, language)
     data = {
         'language': language,
         'frequencies': frequencies,
         'total_lemmas': total_lemmas,
-        'text_count': len([f for f in os.listdir(os.path.join(TEXTS_DIR, language)) if f.endswith('.tess')]) if os.path.exists(os.path.join(TEXTS_DIR, language)) else 0,
+        'text_count': len([f for f in safe_listdir(lang_dir) if f.endswith('.tess')]) if os.path.exists(lang_dir) else 0,
         'checksum': checksum,
         'last_updated': datetime.now().isoformat()
     }
@@ -96,7 +98,7 @@ def calculate_corpus_frequencies(language, text_processor):
         return {}
     
     all_lemmas = []
-    all_files = [f for f in os.listdir(lang_dir) if f.endswith('.tess')]
+    all_files = [f for f in safe_listdir(lang_dir) if f.endswith('.tess')]
     text_files = deduplicate_text_files(all_files)
     
     logger.info(f"Calculating corpus frequencies for {language}: {len(text_files)} texts (excluded {len(all_files) - len(text_files)} duplicate segments)...")

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -70,21 +70,38 @@ def resolve_text_path(texts_dir, language, text_id):
     if not os.path.isdir(lang_dir):
         return None
 
-    # 1. Try direct match, validating resolved path stays inside lang_dir
-    direct_path = os.path.realpath(os.path.join(lang_dir, text_id))
+    # 1. Try direct match first. Under ASCII filesystem locales this can raise
+    # UnicodeEncodeError for Greek filenames, so fall through to byte-level
+    # directory scanning when that happens.
     try:
-        if os.path.commonpath([lang_dir, direct_path]) != lang_dir:
+        direct_path = os.path.realpath(os.path.join(lang_dir, text_id))
+        try:
+            if os.path.commonpath([lang_dir, direct_path]) != lang_dir:
+                return None
+        except ValueError:
             return None
-    except ValueError:
-        return None
-    if os.path.exists(direct_path):
-        return direct_path
+        if os.path.exists(direct_path):
+            return direct_path
+    except (OSError, UnicodeEncodeError):
+        direct_path = None
 
-    # 2. Try normalized match (NFC)
-    # Browsers often send NFC, but the filesystem may store filenames in NFD
+    # 2. Try normalized match (NFC) against raw directory entries so we can
+    # recover surrogateescaped paths even when Python cannot encode the input
+    # Unicode filename using the current filesystem locale.
     target_norm = unicodedata.normalize('NFC', text_id)
     try:
-        for filename in os.listdir(lang_dir):
+        lang_dir_bytes = os.fsencode(lang_dir)
+        for filename_bytes in os.listdir(lang_dir_bytes):
+            filename = fix_surrogate_escapes(os.fsdecode(filename_bytes))
+            if unicodedata.normalize('NFC', filename) == target_norm:
+                return os.fsdecode(os.path.join(lang_dir_bytes, filename_bytes))
+    except OSError:
+        pass
+
+    # 3. Final fallback using string directory listing for environments where
+    # bytes paths are unavailable.
+    try:
+        for filename in safe_listdir(lang_dir):
             if unicodedata.normalize('NFC', filename) == target_norm:
                 return os.path.join(lang_dir, filename)
     except OSError:

--- a/tests/test_frequency_cache.py
+++ b/tests/test_frequency_cache.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from backend import frequency_cache
+
+
+def test_get_corpus_checksum_uses_safe_filenames(tmp_path, monkeypatch):
+    texts_dir = tmp_path / "texts"
+    lang_dir = texts_dir / "grc"
+    lang_dir.mkdir(parents=True, exist_ok=True)
+    filename = "aelius_herodianus.περι_καθολικης_προσῳδιας.tess"
+    text_path = lang_dir / filename
+    text_path.write_text("test line\n", encoding="utf-8")
+
+    monkeypatch.setattr(frequency_cache, "TEXTS_DIR", str(texts_dir))
+    monkeypatch.setattr(frequency_cache, "safe_listdir", lambda path: [filename])
+
+    checksum = frequency_cache.get_corpus_checksum("grc")
+
+    assert isinstance(checksum, str)
+    assert len(checksum) == 32
+
+
+def test_save_frequency_cache_counts_texts_with_safe_listdir(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    texts_dir = tmp_path / "texts"
+    lang_dir = texts_dir / "grc"
+    lang_dir.mkdir(parents=True, exist_ok=True)
+    (lang_dir / "ascii_text.tess").write_text("alpha\n", encoding="utf-8")
+    (lang_dir / "aelius_herodianus.περι_καθολικης_προσῳδιας.tess").write_text("beta\n", encoding="utf-8")
+
+    monkeypatch.setattr(frequency_cache, "CACHE_DIR", str(cache_dir))
+    monkeypatch.setattr(frequency_cache, "TEXTS_DIR", str(texts_dir))
+    os.makedirs(cache_dir, exist_ok=True)
+
+    data = frequency_cache.save_frequency_cache("grc", {"lemma": 2}, 2, "checksum")
+
+    assert data["text_count"] == 2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import unicodedata
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from backend import utils
+
+
+def test_resolve_text_path_handles_unicode_filename_when_direct_exists_raises(tmp_path, monkeypatch):
+    texts_dir = tmp_path / "texts"
+    lang_dir = texts_dir / "grc"
+    lang_dir.mkdir(parents=True, exist_ok=True)
+
+    filename = "aelius_herodianus.περι_καθολικης_προσῳδιας.tess"
+    text_path = lang_dir / filename
+    text_path.write_text("test line\n", encoding="utf-8")
+
+    real_exists = utils.os.path.exists
+    direct_path = os.path.realpath(os.path.join(str(lang_dir), filename))
+
+    def unicode_hostile_exists(path):
+        if path == direct_path:
+            raise UnicodeEncodeError('ascii', filename, 20, 24, 'ordinal not in range(128)')
+        return real_exists(path)
+
+    monkeypatch.setattr(utils.os.path, 'exists', unicode_hostile_exists)
+
+    resolved = utils.resolve_text_path(str(texts_dir), "grc", filename)
+
+    assert resolved is not None
+    assert real_exists(resolved)
+    assert utils.fix_surrogate_escapes(os.path.basename(resolved)) == filename
+
+
+def test_resolve_text_path_matches_unicode_normalization_variants(tmp_path):
+    texts_dir = tmp_path / "texts"
+    lang_dir = texts_dir / "grc"
+    lang_dir.mkdir(parents=True, exist_ok=True)
+
+    filename_nfc = "tryphon_i_grammaticus.περὶ_τρόπων.tess"
+    filename_nfd = unicodedata.normalize("NFD", filename_nfc)
+    (lang_dir / filename_nfd).write_text("test line\n", encoding="utf-8")
+
+    resolved = utils.resolve_text_path(str(texts_dir), "grc", filename_nfc)
+
+    assert resolved is not None
+    assert unicodedata.normalize('NFC', os.path.basename(resolved)) == filename_nfc


### PR DESCRIPTION
## Summary

  This PR fixes two production Unicode failures affecting Greek text workflows under Apache/mod_wsgi.

  1. Greek `search-fusion` requests could fail immediately with:

  ```text
  'ascii' codec can't encode characters in position 54-57: ordinal not in range(128)
  ```

  This happened when a Greek filename such as aelius_herodianus.περι_καθολικης_προσῳδιας.tess was used in path resolution.

  2. search-stream requests using stoplist_basis = corpus could fail while loading corpus frequencies with:

  'utf-8' codec can't encode characters in position 511-535: surrogates not allowed

  This happened during corpus file enumeration/checksum generation when Greek filenames were encountered under the production environment.

  ## Root Cause

  There were two separate Unicode-sensitive paths:

  - backend/utils.py
      - resolve_text_path() used a direct os.path.exists() / string path flow that can raise UnicodeEncodeError in ASCII-biased filesystem
        environments under mod_wsgi.
  - backend/frequency_cache.py
      - Corpus frequency and checksum code used raw os.listdir() on the corpus directory, which could surface surrogate-escaped filenames and
        later fail during UTF-8 encoding.

  ## Changes

  - Hardened resolve_text_path() in backend/utils.py
      - Catches UnicodeEncodeError on direct path resolution
      - Falls back to byte-level directory listing with Unicode normalization
      - Preserves NFC/NFD filename matching behavior
  - Updated backend/frequency_cache.py
      - Replaced raw os.listdir() corpus-file enumeration with safe_listdir()
      - Applies to:
          - corpus checksum generation
          - cached text count
          - corpus frequency calculation