### PR TITLE
Fix: Broken Links on Sources Page (Resolves #77)

### DIFF
--- a/client/src/components/about/TextCredits.jsx
+++ b/client/src/components/about/TextCredits.jsx
@@ -6,7 +6,7 @@ const SOURCE_LINKS = {
   'DigilibLT': 'https://digiliblt.uniupo.it/',
   'Open Greek and Latin Project': 'https://opengreekandlatin.org/',
   'Musisque Deoque': 'http://www.mqdq.it/',
-  'Corpus Scriptorum Latinorum': 'http://www.forumromanum.org/literature/index.html',
+  'Corpus Scriptorum Latinorum': 'https://web.archive.org/web/20220305141011/http://www.forumromanum.org/literature/index.html',
 };
 
 function IntroLink({ name, url }) {

--- a/client/src/components/about/TextCredits.jsx
+++ b/client/src/components/about/TextCredits.jsx
@@ -3,8 +3,8 @@ import { useState, useEffect, useMemo } from 'react';
 const SOURCE_LINKS = {
   'The Latin Library': 'http://thelatinlibrary.com/',
   'The Perseus Project': 'http://www.perseus.tufts.edu/',
-  'DigilibLT': 'http://digiliblt.lett.unipmn.it/',
-  'Open Greek and Latin Project': 'http://www.dh.uni-leipzig.de/wo/projects/open-greek-and-latin-project/',
+  'DigilibLT': 'https://digiliblt.uniupo.it/',
+  'Open Greek and Latin Project': 'https://opengreekandlatin.org/',
   'Musisque Deoque': 'http://www.mqdq.it/',
   'Corpus Scriptorum Latinorum': 'http://www.forumromanum.org/literature/index.html',
 };


### PR DESCRIPTION
### Description
Resolves #77 by updating the broken source URLs in the `About \> Sources` page to their active, modern counterparts.

### Changes Made:
* **DigilibLT:** The old domain returned a blank Nginx page. Updated to the active institutional URL: `https://digiliblt.uniupo.it/`
* **Open Greek and Latin Project:** The old domain redirected to a generic humanities department page. Updated to the official project site: `https://opengreekandlatin.org/`
* **Corpus Scriptorum Latinorum:** The legacy domain (`forumromanum.org`) expired and was redirecting to a malicious squatter site. Updated this link to point to a stable **Internet Archive Wayback Machine** snapshot to preserve the historical context safely.
* Verified that The Latin Library, The Perseus Project, and Musisque Deoque links remain active and correct.