### PR TITLE
Security: Invalidate user sessions when admin role is removed (Fixes #86)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -274,6 +274,8 @@ def init_db():
             cur.execute('''
                 ALTER TABLE feedback ADD COLUMN IF NOT EXISTS responded_at TIMESTAMP
             ''')
+            # Migration for users table to track session versions (Issue #86)
+            cur.execute('ALTER TABLE users ADD COLUMN IF NOT EXISTS session_version INTEGER DEFAULT 1')
             cur.execute('''
                 CREATE TABLE IF NOT EXISTS settings (
                     key VARCHAR(255) PRIMARY KEY,

--- a/backend/blueprints/admin.py
+++ b/backend/blueprints/admin.py
@@ -118,8 +118,24 @@ def _normalize_language_code(value):
 
 def check_admin_auth():
     """Check admin authentication via session"""
+    admin_user_id = session.get('admin_user_id')
+    if not admin_user_id:
+        return False
+        
     roles = [_normalize_role_name(r) for r in (session.get('admin_roles') or [])]
-    return bool(session.get('admin_user_id')) and any(role in ('ADMIN', 'SUPER_ADMIN') for role in roles)
+    if not any(role in ('ADMIN', 'SUPER_ADMIN') for role in roles):
+        return False
+        
+    try:
+        user = User.query.get(admin_user_id)
+        if not user or (user.session_version or 1) != session.get('admin_session_version', 1):
+            session.clear()
+            return False
+    except Exception as e:
+        logger.error(f"Failed to validate admin session version: {e}")
+        return False
+        
+    return True
 
 
 def _load_admin_roles(user_id):
@@ -277,6 +293,7 @@ def admin_login():
     session['admin_user_id'] = user.id
     session['admin_email'] = user.email
     session['admin_roles'] = roles
+    session['admin_session_version'] = user.session_version
     session.permanent = True
 
     try:
@@ -646,6 +663,7 @@ def update_user_roles(user_id):
                     """,
                     (user_id, role_id, get_admin_username()),
                 )
+                cur.execute("UPDATE users SET session_version = session_version + 1 WHERE id = %s", (user_id,))
                 log_admin_action('role_added', 'user', user_id, {'role': role_name})
                 return jsonify({'success': True, 'message': f'{role_name} added'})
 
@@ -659,6 +677,7 @@ def update_user_roles(user_id):
                 """,
                 (user_id, role_id),
             )
+            cur.execute("UPDATE users SET session_version = session_version + 1 WHERE id = %s", (user_id,))
             log_admin_action('role_removed', 'user', user_id, {'role': role_name})
             return jsonify({'success': True, 'message': f'{role_name} removed'})
     except Exception as e:

--- a/backend/models.py
+++ b/backend/models.py
@@ -27,6 +27,7 @@ class User(UserMixin, db.Model):
     orcid_name = db.Column(db.String, nullable=True)
     must_reset_password = db.Column(db.Boolean, default=False)
     share_to_public_default = db.Column(db.Boolean, default=True)
+    session_version = db.Column(db.Integer, default=1)
     created_at = db.Column(db.DateTime, default=datetime.now)
     updated_at = db.Column(db.DateTime, default=datetime.now, onupdate=datetime.now)
     


### PR DESCRIPTION
### Description
This PR addresses **Issue #86**, adding a critical security tightening measure to the admin session handling architecture.

Previously, due to standard cookie-based session behavior, if an administrator's role was revoked via the database or Admin Panel, their active sessions would continue to hold the `admin_roles` payload until they explicitly logged out.

### Technical Implementation
1. **Schema Update:** Added a `session_version` (Integer) column to the `User` model. Integrated an `ALTER TABLE` block in `backend/app.py`'s `init_db()` routine so the migration runs seamlessly on backend startup.
2. **Session Injection:** `backend/blueprints/admin.py::admin_login()` now injects the user's current `session_version` into the Flask session payload as `admin_session_version`.
3. **Strict Validation Pipeline:** The `check_admin_auth()` decorator has been upgraded. Rather than purely relying on the cookie, it now performs an ultra-fast primary-key database lookup (`User.query.get`). If the database `session_version` does not perfectly match the cookie's `admin_session_version`, the session is immediately wiped (`session.clear()`) and the action is blocked. A fallback (`user.session_version or 1`) handles live migration null states gracefully.
4. **Role Update Triggers:** In `update_user_roles` (the endpoint for adding/removing admin roles), executing either action now fires an `UPDATE users SET session_version = session_version + 1` query for the target user, guaranteeing instantaneous validation failure on their next action.