### PR TITLE
chore: remove 8 grc text files containing only '404: Not Found'

### DIFF
--- a/texts/grc/aeschylus.persae.tess
+++ b/texts/grc/aeschylus.persae.tess
@@ -1,1 +1,0 @@
-404: Not Found

--- a/texts/grc/aeschylus.septem_contra_thebas.tess
+++ b/texts/grc/aeschylus.septem_contra_thebas.tess
@@ -1,1 +1,0 @@
-404: Not Found

--- a/texts/grc/aeschylus.supplices.tess
+++ b/texts/grc/aeschylus.supplices.tess
@@ -1,1 +1,0 @@
-404: Not Found

--- a/texts/grc/euripides.iphigenia_in_aulis.tess
+++ b/texts/grc/euripides.iphigenia_in_aulis.tess
@@ -1,1 +1,0 @@
-404: Not Found

--- a/texts/grc/euripides.iphigenia_in_tauris.tess
+++ b/texts/grc/euripides.iphigenia_in_tauris.tess
@@ -1,1 +1,0 @@
-404: Not Found

--- a/texts/grc/euripides.supplices.tess
+++ b/texts/grc/euripides.supplices.tess
@@ -1,1 +1,0 @@
-404: Not Found

--- a/texts/grc/euripides.troades.tess
+++ b/texts/grc/euripides.troades.tess
@@ -1,1 +1,0 @@
-404: Not Found

--- a/texts/grc/sophocles.oedipus_coloneus.tess
+++ b/texts/grc/sophocles.oedipus_coloneus.tess
@@ -1,1 +1,0 @@
-404: Not Found


### PR DESCRIPTION
These 14-byte stubs were the body of a failed HTTP fetch written to disk instead of being skipped. Affected works (all have alternative Greek-titled siblings in texts/grc/):

- aeschylus.persae.tess
- aeschylus.septem_contra_thebas.tess
- aeschylus.supplices.tess
- euripides.iphigenia_in_aulis.tess
- euripides.iphigenia_in_tauris.tess
- euripides.supplices.tess
- euripides.troades.tess
- sophocles.oedipus_coloneus.tess