### PR TITLE
fix: make Source Work and Target Work required on all search pages (Fixes #98)

### DIFF
--- a/client/src/components/search/CrossLingualSearch.jsx
+++ b/client/src/components/search/CrossLingualSearch.jsx
@@ -359,11 +359,8 @@ export default function CrossLingualSearch() {
                 value={sourceAuthor}
                 onChange={(key) => {
                   setSourceAuthor(key);
-                  const works = getAuthorWorks(hierarchy[currentPair.source], key);
-                  if (works.length > 0) {
-                    setSourceWork(works[0].work_key);
-                    setSourceSection(works[0].whole_text || works[0].parts?.[0]?.id || '');
-                  }
+                  setSourceWork('');
+                  setSourceSection('');
                 }}
                 authors={hierarchy[currentPair.source]}
               />
@@ -374,11 +371,16 @@ export default function CrossLingualSearch() {
                 value={sourceWork}
                 onChange={e => {
                   setSourceWork(e.target.value);
-                  const { wholeText, parts } = getWorkParts(hierarchy[currentPair.source], sourceAuthor, e.target.value);
-                  setSourceSection(wholeText || parts[0]?.id || '');
+                  if (e.target.value) {
+                    const { wholeText, parts } = getWorkParts(hierarchy[currentPair.source], sourceAuthor, e.target.value);
+                    setSourceSection(wholeText || parts[0]?.id || '');
+                  } else {
+                    setSourceSection('');
+                  }
                 }}
                 className="w-full border rounded px-3 py-2"
               >
+                <option value="">Select a work...</option>
                 {getAuthorWorks(hierarchy[currentPair.source], sourceAuthor).map(w => (
                   <option key={w.work_key} value={w.work_key}>{w.work}</option>
                 ))}
@@ -414,11 +416,8 @@ export default function CrossLingualSearch() {
                 value={targetAuthor}
                 onChange={(key) => {
                   setTargetAuthor(key);
-                  const works = getAuthorWorks(hierarchy[currentPair.target], key);
-                  if (works.length > 0) {
-                    setTargetWork(works[0].work_key);
-                    setTargetSection(works[0].whole_text || works[0].parts?.[0]?.id || '');
-                  }
+                  setTargetWork('');
+                  setTargetSection('');
                 }}
                 authors={hierarchy[currentPair.target]}
               />
@@ -429,11 +428,16 @@ export default function CrossLingualSearch() {
                 value={targetWork}
                 onChange={e => {
                   setTargetWork(e.target.value);
-                  const { wholeText, parts } = getWorkParts(hierarchy[currentPair.target], targetAuthor, e.target.value);
-                  setTargetSection(wholeText || parts[0]?.id || '');
+                  if (e.target.value) {
+                    const { wholeText, parts } = getWorkParts(hierarchy[currentPair.target], targetAuthor, e.target.value);
+                    setTargetSection(wholeText || parts[0]?.id || '');
+                  } else {
+                    setTargetSection('');
+                  }
                 }}
                 className="w-full border rounded px-3 py-2"
               >
+                <option value="">Select a work...</option>
                 {getAuthorWorks(hierarchy[currentPair.target], targetAuthor).map(w => (
                   <option key={w.work_key} value={w.work_key}>{w.work}</option>
                 ))}

--- a/client/src/components/search/TextSelector.jsx
+++ b/client/src/components/search/TextSelector.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { SearchableAuthorSelect } from '../common';
 
 const TextSelector = ({
@@ -29,6 +29,14 @@ const TextSelector = ({
     return hierarchy.find(a => a.author_key === selectedAuthor);
   }, [hierarchy, selectedAuthor]);
 
+  // When the author changes, clear the selected work so the user must pick one
+  const handleAuthorChange = useCallback((newAuthor) => {
+    if (newAuthor !== selectedAuthor) {
+      setSelectedText('');
+    }
+    setSelectedAuthor(newAuthor);
+  }, [selectedAuthor, setSelectedAuthor, setSelectedText]);
+
   return (
     <div className="space-y-3">
       <div>
@@ -37,7 +45,7 @@ const TextSelector = ({
         </label>
         <SearchableAuthorSelect
           value={selectedAuthor}
-          onChange={setSelectedAuthor}
+          onChange={handleAuthorChange}
           filter={filter}
           setFilter={setFilter}
           showDropdown={showDropdown}


### PR DESCRIPTION
This PR fixes issue #98. When a user switches to a different author on any of the search pages, the work dropdown now resets to 'Select a work...' and the search button is disabled until a work is explicitly selected.

Previously, switching authors left the old work active in the React state. The dropdown showed 'Select a work...' visually, but the old value remained in the state, causing the app to submit searches with incorrect inputs.

Changes:
* In TextSelector.jsx, added a callback to clear the selected work when the author changes.
* In CrossLingualSearch.jsx, updated the author change handlers to clear both the selected work ID and its text value when changing authors.
* The search button remains disabled until a valid work is selected in both dropdowns.