### PR TITLE
fix: revert analytics tag to snake_case for fusion search

### DIFF
--- a/backend/blueprints/fusion.py
+++ b/backend/blueprints/fusion.py
@@ -126,7 +126,7 @@ def search_fusion_stream():
                 meta = cached_meta or {}
                 
                 # Log the cached search
-                log_search('Fusion Search', language, source_id, target_id, None,
+                log_search('fusion_search', language, source_id, target_id, None,
                            'fusion', len(cached_results), True, req_user_id, req_city, req_country, req_ip)
                            
                 yield f"data: {json.dumps({'type': 'complete', 'results': display, 'total_matches': len(cached_results), 'source_lines': meta.get('source_lines', 0), 'target_lines': meta.get('target_lines', 0), 'elapsed_time': round(time.time() - start_time, 2), 'cached': True, 'fusion': True})}\n\n"
@@ -225,7 +225,7 @@ def search_fusion_stream():
             )
 
             # Log the search
-            log_search('Fusion Search', language, source_id, target_id, None,
+            log_search('fusion_search', language, source_id, target_id, None,
                        'fusion', len(final_results), False, req_user_id, req_city, req_country, req_ip)
 
             elapsed_time = round(time.time() - start_time, 2)


### PR DESCRIPTION
## Summary

- PR #89 inadvertently changed the `log_search` event_type tag for fusion search from `fusion_search` (snake_case, the convention used by `text_comparison` and `line_search` in search.py / app.py) to `Fusion Search` (title case).
- Revert so analytics rows continue accumulating under the historical `fusion_search` tag rather than splitting into a new bucket.
- Display normalization (title casing for the dashboard view) belongs in the analytics view layer, not in the event_type column.

## Test plan

- [x] grep confirms two occurrences in `backend/blueprints/fusion.py` (lines 129 and 228) both restored to `'fusion_search'`
- [x] No other files touched
- [ ] After merge: pull on production and touch WSGI; verify new fusion searches log under `fusion_search` in the analytics dashboard