### PR TITLE
feat: add Claude PR automation (first-pass review + safety classifier)

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,0 +1,41 @@
+# Claude PR automation
+
+This directory holds the scripts and workflows that automate first-pass PR review for Tesserae V6.
+
+## Files
+
+- `claude_pr_review.py` — Calls the Anthropic API with a PR's diff, file list, and metadata. Writes a markdown review to a file. Used by `.github/workflows/claude-pr-review.yml`.
+- `claude_pr_safe_check.py` — Classifies a PR by safety pattern (`safe:docs`, `safe:typo`, `safe:dep-patch`, or `unsafe:<reason>`). Used by `.github/workflows/claude-pr-auto-approve.yml`.
+
+## Workflows
+
+- `.github/workflows/claude-pr-review.yml` — Runs on every PR open and update. Posts a Claude-authored first-pass review as a comment. Always runs; does not gate the merge.
+- `.github/workflows/claude-pr-auto-approve.yml` — Runs on every PR open and update. Classifies the PR. If the classification is one of the safe patterns AND the repository variable `CLAUDE_AUTO_APPROVE_ENABLED` is `true`, posts a GitHub "APPROVE" review on Neil's behalf. **Never auto-merges.** The merge button stays with Neil.
+
+## Setup
+
+1. **Add the Anthropic API key as a repository secret.**
+   ```
+   gh secret set ANTHROPIC_API_KEY --repo tesserae/tesserae-v6
+   ```
+   Paste the API key from `console.anthropic.com` when prompted.
+
+2. **(Optional) Turn on auto-approve.** Detection always runs and posts the classifier verdict as a comment. To actually have the workflow approve safe-pattern PRs:
+   ```
+   gh variable set CLAUDE_AUTO_APPROVE_ENABLED --body "true" --repo tesserae/tesserae-v6
+   ```
+   Default is off, by design. Watch a few weeks of detection-only verdicts first.
+
+## Cost model
+
+Each first-pass review costs roughly $0.01 to $0.05 against the Anthropic API account, depending on diff size. The workflow uses Claude Sonnet 4.5 with a 60K-character diff budget. For Tesserae's volume (a few PRs per week), monthly cost is in the low single dollars.
+
+The safety classifier is rule-based Python with no API calls and no cost.
+
+## Safety properties
+
+- The review workflow only posts comments. It cannot push code, merge PRs, or change branch protection.
+- The auto-approve workflow posts comments and (when enabled) a GitHub APPROVE review. It does not merge.
+- Both workflows skip draft PRs.
+- Both workflows have `permissions: contents:read, pull-requests:write` and nothing else.
+- The `ANTHROPIC_API_KEY` is only readable inside the workflow's execution; it is not exposed in the comment, in logs (it is masked by Actions), or to forks (workflows on forked PRs do not get repo secrets by default).

--- a/.github/scripts/claude_pr_review.py
+++ b/.github/scripts/claude_pr_review.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Call Claude to review a PR and write a markdown review to stdout.
+
+Inputs come from environment variables (set by the GitHub Actions workflow):
+  ANTHROPIC_API_KEY     - Anthropic API key (GitHub Actions secret)
+  PR_NUMBER             - PR number being reviewed
+  PR_TITLE              - PR title
+  PR_AUTHOR             - PR author's GitHub username
+  PR_BODY               - PR body / description (may be empty)
+  PR_BASE               - base branch name (usually "main")
+  PR_HEAD               - head branch name
+  PR_FILES_JSON         - JSON list of changed files with additions/deletions
+  PR_DIFF_PATH          - path to file containing the unified diff
+
+The script writes the review markdown to PR_REVIEW_OUT path.
+
+The review is a short, factual code review aligned with the Tesserae V6 review
+style. It is NOT a merge approval. It is a digest for a human reviewer.
+"""
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
+MODEL = "claude-sonnet-4-5"
+MAX_TOKENS = 2000
+DIFF_TOKEN_BUDGET_CHARS = 60_000  # ~15K tokens, leaves headroom for prompt + reply
+
+
+def truncate_diff(diff: str, budget: int) -> str:
+    """Truncate a unified diff to the given character budget, preferring to cut at file
+    boundaries (lines starting with 'diff --git') so the review still sees whole files."""
+    if len(diff) <= budget:
+        return diff
+    head = diff[:budget]
+    last_file_boundary = head.rfind("\ndiff --git")
+    if last_file_boundary > budget // 2:
+        truncated = head[:last_file_boundary]
+        omitted = diff[last_file_boundary:]
+        return truncated + (
+            f"\n\n[diff truncated after {len(truncated):,} chars; "
+            f"{len(omitted):,} chars omitted across additional files]\n"
+        )
+    return head + "\n\n[diff truncated]\n"
+
+
+def build_prompt(pr_number, pr_title, pr_author, pr_body, pr_files, diff) -> str:
+    files_summary = "\n".join(
+        f"  - {f['path']} (+{f['additions']}/-{f['deletions']})"
+        for f in pr_files[:30]
+    )
+    if len(pr_files) > 30:
+        files_summary += f"\n  - ... and {len(pr_files) - 30} more files"
+
+    return f"""You are doing a first-pass code review of a pull request to the Tesserae V6 repository on behalf of the maintainer Neil Coffee. Your review is a digest that helps Neil decide whether to merge, request changes, or look more carefully. You are not the final approver.
+
+# Tesserae V6 context
+
+Tesserae V6 is a multi-channel intertextual search system for classical languages (Latin, Greek, English, Coptic, Arabic, Persian; Hebrew and Urdu in progress). The backend is Flask (Python) under `backend/`. The frontend is React + Vite under `client/`, built to `dist/`. Production runs on Apache + mod_wsgi at tesserae.caset.buffalo.edu.
+
+# Risk areas to flag explicitly
+
+- **Highest risk** if touched: `backend/fusion.py` and `backend/scorer.py` (search scoring), `backend/matcher.py` (matching channels), `backend/synonym_dict.py` (Greek-Latin dictionary), `backend/text_processor.py` (tokenization, lemmatization), database migrations, anything involving auth or admin login.
+- **Medium risk**: `backend/blueprints/admin.py`, `client/src/components/admin/`, anything that adds a new Python dependency in `requirements.txt` or `package.json`.
+- **Low risk**: documentation (`*.md`), text-source metadata, the contents of `texts/`, benchmark files under `evaluation/`.
+
+# What to look for
+
+1. **Scope.** Is the diff focused on one change, or sprawling?
+2. **Untouched expectations.** Are the right paths touched and are out-of-scope paths left alone?
+3. **Risk classification.** Using the table above, what is the overall risk?
+4. **Specific things Neil should verify.** Two or three concrete items, with file:line references.
+5. **Cleanliness.** Any obvious code-quality issues, missing tests, dead code, or commented-out debug statements? Any chance of conflict with the production-deploy workflow (frontend rebuild, WSGI touch)?
+6. **Merge recommendation.** One of: ready to merge, request changes, needs Neil's judgment.
+
+# PR being reviewed
+
+- **Number:** #{pr_number}
+- **Title:** {pr_title}
+- **Author:** @{pr_author}
+- **Body:**
+
+{pr_body or '(no body)'}
+
+# Files changed
+
+{files_summary or '(no files)'}
+
+# Unified diff
+
+```diff
+{diff}
+```
+
+# Output format
+
+Write a single markdown comment, structured as follows. No preamble, no signoff.
+
+```markdown
+**Claude PR review (automated first pass)**
+
+**Summary.** One sentence on what the PR does.
+
+**Risk classification.** Low / Medium / High, with the path(s) that drive the classification.
+
+**Things to check.**
+- file.py:line — specific thing to verify.
+- file.py:line — another.
+
+**Recommendation.** Ready to merge / Request changes (and what changes) / Needs Neil's judgment (and why).
+
+_This is an automated review. Neil reviews and approves the actual merge._
+```
+"""
+
+
+def call_anthropic(api_key: str, prompt: str) -> str:
+    body = {
+        "model": MODEL,
+        "max_tokens": MAX_TOKENS,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    req = urllib.request.Request(
+        ANTHROPIC_URL,
+        data=json.dumps(body).encode("utf-8"),
+        headers={
+            "content-type": "application/json",
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"Anthropic API error {e.code}: {body}")
+
+    parts = data.get("content", [])
+    text_blocks = [p.get("text", "") for p in parts if p.get("type") == "text"]
+    if not text_blocks:
+        raise SystemExit(f"Unexpected Anthropic response: {json.dumps(data)[:500]}")
+    return "\n".join(text_blocks).strip()
+
+
+def main():
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        sys.exit("ANTHROPIC_API_KEY not set")
+
+    pr_number = os.environ.get("PR_NUMBER", "?")
+    pr_title = os.environ.get("PR_TITLE", "")
+    pr_author = os.environ.get("PR_AUTHOR", "")
+    pr_body = os.environ.get("PR_BODY", "")
+    pr_diff_path = os.environ.get("PR_DIFF_PATH", "/tmp/pr.diff")
+    pr_files_json = os.environ.get("PR_FILES_JSON", "[]")
+    out_path = os.environ.get("PR_REVIEW_OUT", "/tmp/review.md")
+
+    pr_files = json.loads(pr_files_json)
+
+    with open(pr_diff_path) as f:
+        diff = truncate_diff(f.read(), DIFF_TOKEN_BUDGET_CHARS)
+
+    prompt = build_prompt(pr_number, pr_title, pr_author, pr_body, pr_files, diff)
+    review = call_anthropic(api_key, prompt)
+
+    with open(out_path, "w") as f:
+        f.write(review)
+    print(f"Wrote review to {out_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/claude_pr_safe_check.py
+++ b/.github/scripts/claude_pr_safe_check.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Classify a PR by safety pattern. Writes a one-line verdict to stdout.
+
+Inputs (environment variables):
+  PR_FILES_JSON  - JSON list of changed files with additions/deletions/path
+  PR_DIFF_PATH   - path to unified diff (used for some pattern checks)
+
+Output (stdout): one of
+  safe:docs            - docs-only change (only .md, .txt, .rst, LICENSE)
+  safe:typo            - single tiny change (additions + deletions <= 4 across 1-2 files,
+                         no high-risk paths touched)
+  safe:dep-patch       - dependency-file-only change with patch-version bumps
+  unsafe:<reason>      - anything else, with a short reason
+
+This script is conservative: it only emits "safe:..." when it is confident the
+change cannot break runtime behavior. Anything ambiguous returns "unsafe:...".
+
+Exit code is always 0; the verdict is read from stdout by the workflow.
+"""
+import json
+import os
+import re
+import sys
+
+# Files that, if touched, immediately disqualify a PR from any safe pattern.
+HIGH_RISK_PATHS = (
+    "backend/fusion.py",
+    "backend/scorer.py",
+    "backend/matcher.py",
+    "backend/synonym_dict.py",
+    "backend/text_processor.py",
+    "backend/app.py",
+    "backend/blueprints/admin.py",
+    "backend/blueprints/search.py",
+    "backend/blueprints/fusion.py",
+    "backend/blueprints/hapax.py",
+)
+
+# Docs-only safe pattern: only these extensions and filenames allowed.
+DOCS_EXTENSIONS = {".md", ".txt", ".rst"}
+DOCS_FILENAMES = {"LICENSE", "AUTHORS", "CONTRIBUTORS", "NOTICE"}
+
+# Dependency files. A PR that only touches these AND has only patch-version bumps
+# qualifies as safe:dep-patch.
+DEP_FILES = {"requirements.txt", "package.json", "package-lock.json"}
+
+
+def is_doc_file(path: str) -> bool:
+    name = path.rsplit("/", 1)[-1]
+    if name in DOCS_FILENAMES:
+        return True
+    for ext in DOCS_EXTENSIONS:
+        if path.endswith(ext):
+            return True
+    return False
+
+
+def touches_high_risk(files) -> str:
+    for f in files:
+        for risky in HIGH_RISK_PATHS:
+            if f["path"] == risky or f["path"].startswith(risky + "/"):
+                return f["path"]
+    return ""
+
+
+def is_patch_version_bump_diff(diff: str) -> bool:
+    """A patch version bump in requirements.txt or package.json changes only the
+    third (patch) component of a semver string. Examples allowed:
+      - pycountry==24.6.1 -> pycountry==24.6.2
+      - "react": "^18.2.0" -> "react": "^18.2.3"
+
+    Returns True only if every changed (added/removed) line that looks like a
+    version pin shows a patch-level diff and no other content changes are present.
+    """
+    semver_re = re.compile(r"(\d+)\.(\d+)\.(\d+)")
+    seen_pair = False
+
+    additions = []
+    removals = []
+    for line in diff.splitlines():
+        if line.startswith("+++") or line.startswith("---") or line.startswith("diff --git"):
+            continue
+        if line.startswith("+"):
+            additions.append(line[1:].strip())
+        elif line.startswith("-"):
+            removals.append(line[1:].strip())
+
+    if not additions or not removals:
+        return False
+
+    if len(additions) != len(removals):
+        return False
+
+    for add, rem in zip(additions, removals):
+        if add == rem:
+            continue
+        am = semver_re.search(add)
+        rm = semver_re.search(rem)
+        if not am or not rm:
+            return False
+        # Major and minor must match; patch can differ.
+        if am.group(1) != rm.group(1) or am.group(2) != rm.group(2):
+            return False
+        seen_pair = True
+
+    return seen_pair
+
+
+def main():
+    files = json.loads(os.environ.get("PR_FILES_JSON", "[]"))
+    diff_path = os.environ.get("PR_DIFF_PATH", "/tmp/pr.diff")
+
+    if not files:
+        print("unsafe:no-files-detected")
+        return
+
+    risky = touches_high_risk(files)
+    if risky:
+        print(f"unsafe:touches-high-risk-path:{risky}")
+        return
+
+    if all(is_doc_file(f["path"]) for f in files):
+        print("safe:docs")
+        return
+
+    total_add = sum(f["additions"] for f in files)
+    total_del = sum(f["deletions"] for f in files)
+    if len(files) <= 2 and total_add + total_del <= 4:
+        print("safe:typo")
+        return
+
+    if files and all(f["path"].rsplit("/", 1)[-1] in DEP_FILES for f in files):
+        try:
+            with open(diff_path) as fp:
+                diff = fp.read()
+        except OSError:
+            diff = ""
+        if is_patch_version_bump_diff(diff):
+            print("safe:dep-patch")
+            return
+        print("unsafe:dep-non-patch-bump")
+        return
+
+    print("unsafe:requires-human-review")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/claude-pr-auto-approve.yml
+++ b/.github/workflows/claude-pr-auto-approve.yml
@@ -1,0 +1,104 @@
+name: Claude PR auto-approve (low-risk only)
+
+# This workflow classifies a PR by safety pattern and optionally auto-approves
+# (NOT auto-merges) PRs that match one of three very-low-risk patterns:
+#
+#   safe:docs       - documentation-only changes
+#   safe:typo       - single tiny change (additions + deletions <= 4, no high-risk paths)
+#   safe:dep-patch  - dependency patch-version bumps only
+#
+# Detection always runs and posts a one-line comment. Whether the workflow
+# actually approves (i.e., creates a GitHub "APPROVE" review on Neil's behalf)
+# is gated by the repository variable CLAUDE_AUTO_APPROVE_ENABLED.
+#
+# Default: detection on, approval off. To turn approval on:
+#   gh variable set CLAUDE_AUTO_APPROVE_ENABLED --body "true" --repo tesserae/tesserae-v6
+#
+# Even with approval enabled, this workflow NEVER auto-merges. Neil clicks the
+# merge button. The intent is to give Neil a one-click merge experience on
+# trivial PRs while keeping the merge gate human.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  classify:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    outputs:
+      verdict: ${{ steps.classify.outputs.verdict }}
+    steps:
+      - name: Check out PR
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Fetch PR diff and file list
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh pr diff "$PR_NUMBER" --repo "$REPO" > /tmp/pr.diff
+          gh pr view "$PR_NUMBER" --repo "$REPO" --json files \
+            --jq '[.files[] | {path: .path, additions: .additions, deletions: .deletions}]' \
+            > /tmp/pr_files.json
+
+      - name: Run safe-pattern classifier
+        id: classify
+        run: |
+          set -euo pipefail
+          export PR_FILES_JSON="$(cat /tmp/pr_files.json)"
+          export PR_DIFF_PATH=/tmp/pr.diff
+          verdict="$(python3 .github/scripts/claude_pr_safe_check.py)"
+          echo "Verdict: $verdict"
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+
+      - name: Post classification comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          VERDICT: ${{ steps.classify.outputs.verdict }}
+        run: |
+          set -euo pipefail
+          case "$VERDICT" in
+            safe:*)
+              tag="$(echo "$VERDICT" | cut -d: -f2)"
+              body="**Claude safety classifier:** \`$VERDICT\`. This PR matches the **$tag** safe-pattern (no high-risk paths touched, change is small or scope-limited). Auto-approve is **${{ vars.CLAUDE_AUTO_APPROVE_ENABLED || 'off' }}** for this repo. Neil retains the merge decision."
+              ;;
+            *)
+              reason="$(echo "$VERDICT" | cut -d: -f2-)"
+              body="**Claude safety classifier:** \`$VERDICT\`. Reason: $reason. No auto-approval; Neil's eye recommended."
+              ;;
+          esac
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body"
+
+  auto-approve:
+    needs: classify
+    if: |
+      vars.CLAUDE_AUTO_APPROVE_ENABLED == 'true' &&
+      startsWith(needs.classify.outputs.verdict, 'safe:')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-approve safe-pattern PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          VERDICT: ${{ needs.classify.outputs.verdict }}
+        run: |
+          gh pr review "$PR_NUMBER" --repo "$REPO" --approve \
+            --body "Auto-approved by the Claude safety classifier (verdict: $VERDICT). Merge gate stays with Neil."

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,73 @@
+name: Claude PR review (instant first pass)
+
+# This workflow runs a Claude first-pass review on every PR open and update.
+# The review is posted as a comment on the PR. It is informational only.
+# Neil retains the merge decision.
+#
+# Required secrets:
+#   ANTHROPIC_API_KEY  - set at Settings > Secrets and variables > Actions
+#
+# The default GITHUB_TOKEN handles comment posting.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Fetch PR diff and file list
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh pr diff "$PR_NUMBER" --repo "$REPO" > /tmp/pr.diff
+          gh pr view "$PR_NUMBER" --repo "$REPO" --json files \
+            --jq '[.files[] | {path: .path, additions: .additions, deletions: .deletions}]' \
+            > /tmp/pr_files.json
+          echo "Diff size: $(wc -c < /tmp/pr.diff) bytes"
+          echo "File count: $(jq length < /tmp/pr_files.json)"
+
+      - name: Generate Claude review
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_DIFF_PATH: /tmp/pr.diff
+          PR_REVIEW_OUT: /tmp/review.md
+        run: |
+          set -euo pipefail
+          export PR_FILES_JSON="$(cat /tmp/pr_files.json)"
+          python3 .github/scripts/claude_pr_review.py
+          echo "=== Review preview ==="
+          head -40 /tmp/review.md
+
+      - name: Post review comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/review.md


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude-pr-review.yml`, which runs on every PR open and update and posts a Claude-authored first-pass review as a comment. Always runs; informational only.
- Adds `.github/workflows/claude-pr-auto-approve.yml`, which classifies each PR by safety pattern (`safe:docs` / `safe:typo` / `safe:dep-patch` / `unsafe:<reason>`) and posts the verdict. Auto-approve action is gated by a repository variable (default off).
- Adds two helper scripts under `.github/scripts/` and a README explaining setup, cost, and safety properties.

## Setup needed after merge

1. Add the Anthropic API key as a repository secret:
   ```
   gh secret set ANTHROPIC_API_KEY --repo tesserae/tesserae-v6
   ```
2. (Optional, default off) To enable auto-approve on safe-pattern PRs once you've watched a few weeks of classifier output:
   ```
   gh variable set CLAUDE_AUTO_APPROVE_ENABLED --body "true" --repo tesserae/tesserae-v6
   ```

## What this does NOT do

- Never auto-merges. The merge button stays with you.
- Does not run on draft PRs.
- Does not run on forked PRs from outside the org with access to secrets (GitHub blocks fork secret access by default).
- Does not modify code, branch protection, or any other repository setting.

## Risk classification

The safety classifier marks a PR as `unsafe:touches-high-risk-path` if any of these are modified:
- `backend/fusion.py`, `backend/scorer.py`, `backend/matcher.py` (scoring)
- `backend/synonym_dict.py` (dictionary)
- `backend/text_processor.py` (tokenization, lemmatization)
- `backend/app.py`, `backend/blueprints/{admin,search,fusion,hapax}.py`

Safe patterns:
- `safe:docs` — only `.md`, `.txt`, `.rst`, or `LICENSE` / `AUTHORS` / `CONTRIBUTORS` files touched
- `safe:typo` — at most 2 files and at most 4 lines total changed, no high-risk paths
- `safe:dep-patch` — only `requirements.txt`, `package.json`, `package-lock.json` touched, only patch-version semver bumps

## Test plan

- [ ] Merge this PR.
- [ ] Run `gh secret set ANTHROPIC_API_KEY` with the key from `console.anthropic.com`.
- [ ] Open a trivial test PR (e.g., edit a docs file) and confirm the Claude review comment appears within a couple of minutes, plus the safety classifier verdict.
- [ ] Watch a few real PRs go through and verify the verdicts look right before enabling auto-approve.

## Cost estimate

About $0.01 to $0.05 per first-pass review against the Anthropic API account. At Tesserae's volume, low single dollars per month.