### PR TITLE
Improve fusion batch progress UI

### DIFF
--- a/backend/blueprints/fusion.py
+++ b/backend/blueprints/fusion.py
@@ -193,6 +193,13 @@ def search_fusion_stream():
                     yield send_event("progress", {
                         "step": f"Running {evt_data['channel']} ({label})",
                         "detail": "",
+                        "fusion_batch": {
+                            "phase": phase,
+                            "channel": evt_data['channel'],
+                            "index": evt_data['step'],
+                            "total": evt_data['total'],
+                            "status": "running",
+                        },
                     })
 
                 elif event_type == "channel_done":
@@ -205,6 +212,14 @@ def search_fusion_stream():
                     yield send_event("progress", {
                         "step": step_text,
                         "detail": "",
+                        "fusion_batch": {
+                            "phase": phase,
+                            "channel": evt_data['channel'],
+                            "index": evt_data['step'],
+                            "total": evt_data['total'],
+                            "status": "skipped" if evt_data.get('skipped') else "done",
+                            "result_count": evt_data.get('count', 0),
+                        },
                     })
 
                 elif event_type == "intermediate":

--- a/client/src/components/search/SearchResults.jsx
+++ b/client/src/components/search/SearchResults.jsx
@@ -36,6 +36,12 @@ const SearchResults = ({
   const chartRef = useRef(null);
   const [pauseUpdates, setPauseUpdates] = useState(false);
   const [frozenResults, setFrozenResults] = useState(null);
+  const fusionBatchTotal = fusionProgress?.batchTotal || fusionProgress?.channelsTotal || 0;
+  const fusionBatchIndex = fusionProgress?.batchIndex || fusionProgress?.channelsDone?.length || 0;
+  const fusionBatchPercent = fusionBatchTotal > 0
+    ? Math.min(100, Math.round((fusionBatchIndex / fusionBatchTotal) * 100))
+    : 0;
+  const fusionPhaseLabel = fusionProgress?.phase === 'window' ? 'Window pass' : 'Line pass';
 
   // Auto-unpause when search completes
   useEffect(() => {
@@ -377,7 +383,7 @@ const SearchResults = ({
           {isSlowSearch && !isQueued && (
             <div className="text-sm text-gray-600 mb-4 text-center">
               {matchType === 'fusion'
-                ? 'Fusion search runs all 9 channels \u2014 results will appear as channels complete.'
+                ? 'Fusion search runs in batches. Results appear as each batch completes.'
                 : 'Initial sound or edit distance searches on large texts typically take several minutes.'}
             </div>
           )}
@@ -424,26 +430,45 @@ const SearchResults = ({
   return (
     <div className="space-y-4">
       {loading && fusionProgress && (
-        <div className={`${pauseUpdates ? 'bg-amber-50 border-amber-200' : 'bg-blue-50 border-blue-200'} border rounded-lg p-3 flex items-center gap-3`}>
-          {!pauseUpdates && (
-            <div className="w-5 h-5 border-2 border-blue-200 border-t-blue-600 rounded-full animate-spin flex-shrink-0" />
+        <div className={`${pauseUpdates ? 'bg-amber-50 border-amber-200' : 'bg-blue-50 border-blue-200'} border rounded-lg p-3`}>
+          <div className="flex items-center gap-3">
+            {!pauseUpdates && (
+              <div className="w-5 h-5 border-2 border-blue-200 border-t-blue-600 rounded-full animate-spin flex-shrink-0" />
+            )}
+            <div className="flex-1 min-w-0">
+              <div className={`text-sm font-medium ${pauseUpdates ? 'text-amber-800' : 'text-blue-800'}`}>
+                {pauseUpdates ? 'Display paused, search continues in background' : (progressText || 'Searching...')}
+              </div>
+              <div className={`mt-1 text-xs ${pauseUpdates ? 'text-amber-600' : 'text-blue-600'}`}>
+                {fusionPhaseLabel}
+                {fusionBatchTotal > 0 && ` | batch ${fusionBatchIndex} of ${fusionBatchTotal}`}
+                {fusionProgress.currentChannel && ` | ${fusionProgress.currentChannel}`}
+                {fusionProgress.totalMatches > 0 && ` | ${fusionProgress.totalMatches.toLocaleString()} candidates`}
+                {fusionProgress.resultCount > 0 && ` | showing ${fusionProgress.resultCount.toLocaleString()}`}
+              </div>
+            </div>
+            <button
+              onClick={handlePauseToggle}
+              className={`text-xs px-3 py-1 rounded font-medium flex-shrink-0 ${
+                pauseUpdates
+                  ? 'bg-amber-600 text-white hover:bg-amber-700'
+                  : 'bg-blue-100 text-blue-700 hover:bg-blue-200'
+              }`}
+            >
+              {pauseUpdates ? 'Resume' : 'Pause'}
+            </button>
+            <span className={`text-xs ${pauseUpdates ? 'text-amber-500' : 'text-blue-500'} tabular-nums flex-shrink-0`}>
+              {elapsedTime > 0 && formatElapsedTime(elapsedTime)}
+            </span>
+          </div>
+          {fusionBatchTotal > 0 && (
+            <div className={`mt-3 h-1.5 rounded-full overflow-hidden ${pauseUpdates ? 'bg-amber-100' : 'bg-blue-100'}`}>
+              <div
+                className={`h-full transition-all duration-300 ${pauseUpdates ? 'bg-amber-500' : 'bg-blue-600'}`}
+                style={{ width: `${fusionBatchPercent}%` }}
+              />
+            </div>
           )}
-          <span className={`text-sm font-medium ${pauseUpdates ? 'text-amber-800' : 'text-blue-800'} flex-1 min-w-0`}>
-            {pauseUpdates ? 'Display paused \u2014 search continues in background' : (progressText || 'Searching...')}
-          </span>
-          <button
-            onClick={handlePauseToggle}
-            className={`text-xs px-3 py-1 rounded font-medium flex-shrink-0 ${
-              pauseUpdates
-                ? 'bg-amber-600 text-white hover:bg-amber-700'
-                : 'bg-blue-100 text-blue-700 hover:bg-blue-200'
-            }`}
-          >
-            {pauseUpdates ? 'Resume' : 'Pause'}
-          </button>
-          <span className={`text-xs ${pauseUpdates ? 'text-amber-500' : 'text-blue-500'} tabular-nums flex-shrink-0`}>
-            {elapsedTime > 0 && formatElapsedTime(elapsedTime)}
-          </span>
         </div>
       )}
       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 mb-4">

--- a/client/src/hooks/useSearch.js
+++ b/client/src/hooks/useSearch.js
@@ -52,11 +52,26 @@ export const useSearch = () => {
     setIsQueued(false);
     setQueuedMessage('');
 
-    const handleProgress = (step, detail, elapsed) => {
+    const handleProgress = (step, detail, elapsed, meta = null) => {
       setIsQueued(false);
       setQueuedMessage('');
       setProgressText(detail ? `${step}: ${detail}` : step);
       setElapsedTime(Math.floor(elapsed));
+      if (meta?.fusion_batch) {
+        const batch = meta.fusion_batch;
+        setFusionProgress(prev => ({
+          channelsDone: prev?.channelsDone || [],
+          channelsTotal: batch.total || prev?.channelsTotal || 0,
+          phase: batch.phase || prev?.phase || 'line',
+          currentChannel: batch.channel,
+          batchIndex: batch.index || 0,
+          batchTotal: batch.total || 0,
+          batchStatus: batch.status || 'running',
+          currentBatchResults: batch.result_count || 0,
+          totalMatches: prev?.totalMatches || 0,
+          resultCount: prev?.resultCount || 0,
+        }));
+      }
     };
 
     const handleQueued = (reason, waitTime) => {
@@ -73,10 +88,19 @@ export const useSearch = () => {
       if (isFusion) {
         const handleIntermediate = (intermediateData) => {
           setResults(intermediateData.results || []);
+          const channelsDone = intermediateData.channels_done || [];
+          const channelsTotal = intermediateData.channels_total || 9;
           setFusionProgress({
-            channelsDone: intermediateData.channels_done || [],
-            channelsTotal: intermediateData.channels_total || 9,
+            channelsDone,
+            channelsTotal,
             phase: intermediateData.phase || 'line',
+            batchIndex: channelsDone.length,
+            batchTotal: channelsTotal,
+            batchStatus: 'done',
+            currentChannel: channelsDone[channelsDone.length - 1] || '',
+            currentBatchResults: 0,
+            totalMatches: intermediateData.total_matches || 0,
+            resultCount: (intermediateData.results || []).length,
           });
         };
         data = await searchFusionStream(params, handleProgress, abortController.current.signal, handleIntermediate, handleQueued);

--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -83,7 +83,7 @@ export const searchTextsStream = async (params, onProgress, signal, onQueued) =>
           const data = JSON.parse(line.slice(6));
           if (data.type === 'progress') {
             if (onProgress) {
-              onProgress(data.step, data.detail, data.elapsed);
+              onProgress(data.step, data.detail, data.elapsed, data);
             }
           } else if (data.type === 'queued') {
             if (onQueued) {
@@ -144,7 +144,7 @@ export const searchFusionStream = async (params, onProgress, signal, onIntermedi
           const data = JSON.parse(line.slice(6));
           if (data.type === 'progress') {
             if (onProgress) {
-              onProgress(data.step, data.detail, data.elapsed);
+              onProgress(data.step, data.detail, data.elapsed, data);
             }
           } else if (data.type === 'queued') {
             if (onQueued) {


### PR DESCRIPTION
Adds batch-level fusion progress metadata to the streaming endpoint and updates the frontend to show phase, batch count, current channel, candidate counts, and a progress bar without changing fusion search behavior.