### PR TITLE
test: bump PR review model to claude-fable-5

### DIFF
--- a/.github/scripts/claude_pr_review.py
+++ b/.github/scripts/claude_pr_review.py
@@ -24,7 +24,7 @@ import urllib.request
 import urllib.error
 
 ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
-MODEL = "claude-sonnet-4-5"
+MODEL = "claude-fable-5"
 MAX_TOKENS = 2000
 DIFF_TOKEN_BUDGET_CHARS = 60_000  # ~15K tokens, leaves headroom for prompt + reply
 


### PR DESCRIPTION
Test the model bump to Fable 5 (released 2026-06-09) on the PR-review workflow. When the workflow fires on this PR, it will run with the Fable 5 model, so the review comment we see is exactly the kind of review Fable 5 would post on every PR going forward. Comparison vs Sonnet 4.5 will inform whether we keep the bump or revert it.

After comparing: either merge if Fable 5 reviews are noticeably better, or close.