### PR TITLE
fix: three low-stakes bugs found by the 2026-06 Mythos codebase audit

### DIFF
--- a/backend/blueprints/hapax.py
+++ b/backend/blueprints/hapax.py
@@ -28,6 +28,7 @@ from flask import Blueprint, jsonify, request
 from flask_login import current_user
 import os
 import json
+import unicodedata
 
 from backend.logging_config import get_logger
 from backend.frequency_cache import load_frequency_cache
@@ -146,17 +147,34 @@ def extract_reference_numbers(ref_str):
 
 
 def is_word_in_stoplist(word, language):
-    """Check if a word is in the stoplist for the given language"""
+    """Check if a word is in the stoplist for the given language.
+
+    Greek inputs from the lemma pipeline are accent-stripped (NFKD +
+    combining-character removal) and have final sigma normalized to medial
+    sigma. GREEK_STOPWORDS is written with full diacritics ('καί', 'γάρ')
+    for source-readability, so the lookup side must apply the same
+    normalization the lemma pipeline uses before comparing. Without this,
+    high-frequency Greek function words leak past the stoplist into
+    rare-bigram results because the literal string comparison never
+    matches.
+    """
     if not word:
         return False
-    
-    word_lower = word.lower().strip()
-    
+
     if language == 'la':
-        return word_lower in LATIN_STOPWORDS
+        return word.lower().strip() in LATIN_STOPWORDS
     elif language == 'grc':
-        return word_lower in GREEK_STOPWORDS
-    
+        normalized = unicodedata.normalize('NFKD', word.lower().strip())
+        normalized = ''.join(c for c in normalized if unicodedata.category(c) != 'Mn')
+        normalized = normalized.replace('ς', 'σ')
+        for entry in GREEK_STOPWORDS:
+            entry_norm = unicodedata.normalize('NFKD', entry.lower().strip())
+            entry_norm = ''.join(c for c in entry_norm if unicodedata.category(c) != 'Mn')
+            entry_norm = entry_norm.replace('ς', 'σ')
+            if entry_norm == normalized:
+                return True
+        return False
+
     return False
 
 

--- a/backend/synonym_dict.py
+++ b/backend/synonym_dict.py
@@ -881,7 +881,15 @@ def find_greek_english_matches(greek_lemmas: list, english_lemmas: list,
             en_indices = [i for i, l in enumerate(english_lower_list) if l == en_word]
             if en_indices:
                 seen.add(pair_key)
-                grc_indices = [i for i, l in enumerate(greek_lemmas) if _normalize_greek(l) == grc_norm]
+                # grc_norm was constructed with ".replace('ς', 'σ')" (final
+                # sigma normalized to medial sigma). The per-lemma
+                # comparison must apply the same replacement; otherwise
+                # masculine nouns ending in final sigma (most Greek -ος
+                # forms: λόγος, θεός, ἄνθρωπος, etc.) emit empty
+                # source_indices, silently breaking downstream highlighting
+                # and any scorer that uses the indices.
+                grc_indices = [i for i, l in enumerate(greek_lemmas)
+                               if _normalize_greek(l).replace('ς', 'σ') == grc_norm]
                 matches.append({
                     'source_lemma': grc_lemma,
                     'target_lemma': en_word,

--- a/backend/text_processor.py
+++ b/backend/text_processor.py
@@ -498,16 +498,29 @@ class TextProcessor:
             if norm_token in latin_table:
                 lemma = latin_table[norm_token]
             else:
+                # Try enclitic stripping ('que', 'ne', 'ue'), but only commit
+                # to it when the stripped form actually resolves in the
+                # lemma table. The previous version set stripped_base on any
+                # `.endswith` match, which then propagated to the CLTK
+                # fallback and the final fallback even for words that merely
+                # end in '-ne' or '-ue' (vimine, paene, Cyrene). The wrong
+                # truncated lemma got cached permanently. Only record
+                # stripped_base when the stripping is productive.
                 for enclitic in ['que', 'ne', 'ue']:
                     if norm_token.endswith(enclitic) and len(norm_token) > len(enclitic) + 1:
                         base = norm_token[:-len(enclitic)]
-                        stripped_base = base
                         if base in latin_table:
                             lemma = latin_table[base]
+                            stripped_base = base
+                            break
                         elif base + 'm' in latin_table:
                             lemma = latin_table[base + 'm']
-                        break
-            
+                            stripped_base = base
+                            break
+                        # base did not resolve in either form; do not commit
+                        # to stripping. Leave stripped_base as None so the
+                        # fallbacks below use the original token.
+
             if lemma is None and self.use_cltk_latin and self.latin_lemmatizer:
                 try:
                     token_to_try = stripped_base if stripped_base else token
@@ -516,7 +529,7 @@ class TextProcessor:
                     lemma = re.sub(r'\d+$', '', raw_lemma)
                 except Exception:
                     lemma = stripped_base or norm_token
-            
+
             if lemma is None:
                 lemma = stripped_base or norm_token
             


### PR DESCRIPTION
Three small, well-localized fixes verified against the source code before commit. All three came out of a careful audit pass.

Each fix is independently revertable. None of them touch the scoring formulas, the fusion math, or any database schema.

## The three fixes

**Greek stopword leak in hapax.py.** `GREEK_STOPWORDS` is stored with full diacritics (`'καί'`, `'γάρ'`). Lemmas reach `is_word_in_stoplist` already accent-stripped and sigma-normalized. The literal-string comparison never matched, so common Greek function words were leaking past the stoplist into rare-bigram results. Now normalized on both sides.

**Empty source_indices in synonym_dict.py.** In `find_greek_english_matches`, `grc_norm` was built with `.replace('ς', 'σ')` but the per-lemma recovery comparison did not apply the same replacement. Greek -ος forms emitted empty `source_indices` even when matches were correctly reported. Now applies the same replacement on both sides.

**Latin enclitic stripping mangling legitimate words.** The `_latin_lemmatize` loop committed to enclitic-stripping on any `.endswith` match, even when the stripped base did not resolve. Genuine Latin words ending in -ne or -ue (vimine, paene, Cyrene) were mangled to truncated forms and cached permanently. Now only commits to stripping when the stripped base resolves.