### PR TITLE
fix: three audit findings verified against production code

### DIFF
--- a/backend/blueprints/hapax.py
+++ b/backend/blueprints/hapax.py
@@ -996,9 +996,35 @@ def get_rare_words_from_cache(language, max_occurrences=10):
     return rare_words
 
 
+def _base_filename_expr(alias='t'):
+    """Return a SQL expression that collapses partition filenames to their base work.
+
+    The inverted index treats each .tess file as a separate text_id. A long
+    work like Homer's Iliad is indexed as both the full file
+    (homer.iliad.tess) AND each of its 24 part files (homer.iliad.part.N.tess).
+    Counting distinct text_ids therefore inflates document frequency for any
+    word in such a work, pushing genuine hapaxes out of the rare-word range.
+
+    This expression rewrites 'homer.iliad.part.1.tess' to 'homer.iliad.tess'
+    so COUNT(DISTINCT ...) counts each work once regardless of how it was
+    partitioned for indexing.
+    """
+    fn = f"{alias}.filename"
+    return (
+        f"CASE WHEN instr({fn}, '.part.') > 0 "
+        f"THEN substr({fn}, 1, instr({fn}, '.part.') - 1) || '.tess' "
+        f"ELSE {fn} END"
+    )
+
+
 def get_document_frequency(lemma, language):
     """Get the number of distinct texts that contain this lemma (document frequency).
-    Uses the inverted index for accurate corpus-wide rarity measurement."""
+    Uses the inverted index for accurate corpus-wide rarity measurement.
+
+    Partition files (homer.iliad.part.N.tess) are collapsed to their base
+    work (homer.iliad.tess) so a word indexed across both the full file and
+    its parts contributes a document frequency of 1, not 1 + part_count.
+    """
     conn = get_connection(language)
     if not conn:
         return 0
@@ -1014,8 +1040,11 @@ def get_document_frequency(lemma, language):
             expanded.add(lemma.replace('j', 'i'))
 
         placeholders = ','.join(['?' for _ in expanded])
+        base_expr = _base_filename_expr('t')
         cursor.execute(
-            f'SELECT COUNT(DISTINCT text_id) FROM postings WHERE lemma IN ({placeholders})',
+            f'SELECT COUNT(DISTINCT {base_expr}) '
+            f'FROM postings p JOIN texts t ON p.text_id = t.text_id '
+            f'WHERE p.lemma IN ({placeholders})',
             list(expanded)
         )
         return cursor.fetchone()[0]
@@ -1053,8 +1082,11 @@ def get_document_frequencies_batch(lemmas, language):
 
             all_variants = list(expanded_map.keys())
             placeholders = ','.join(['?' for _ in all_variants])
+            base_expr = _base_filename_expr('t')
             cursor.execute(
-                f'SELECT lemma, COUNT(DISTINCT text_id) FROM postings WHERE lemma IN ({placeholders}) GROUP BY lemma',
+                f'SELECT p.lemma, COUNT(DISTINCT {base_expr}) '
+                f'FROM postings p JOIN texts t ON p.text_id = t.text_id '
+                f'WHERE p.lemma IN ({placeholders}) GROUP BY p.lemma',
                 all_variants
             )
 

--- a/backend/matcher.py
+++ b/backend/matcher.py
@@ -171,13 +171,30 @@ def find_crosslingual_phonetic_matches(source_units, target_units,
                     continue
                 used_grc.add(gi)
                 used_lat.add(li)
-                token_matches.append({
-                    'source_original': grc_orig,
-                    'target_original': lat_orig,
-                    'source_token': grc_tr,
-                    'target_token': lat_norm,
-                    'similarity': sim / 100.0,
-                })
+                # The per-token match dict's source / target fields must
+                # match the orientation of the pair_key below. When Latin
+                # is the source (grc_is_source=False), swap the labels so
+                # source_original is the Latin token and target_original is
+                # the Greek token. Previously these were hardcoded to the
+                # Greek-source case, which silently mislabeled every
+                # Latin-source / Greek-target search and broke downstream
+                # highlighting in one direction.
+                if grc_is_source:
+                    token_matches.append({
+                        'source_original': grc_orig,
+                        'target_original': lat_orig,
+                        'source_token': grc_tr,
+                        'target_token': lat_norm,
+                        'similarity': sim / 100.0,
+                    })
+                else:
+                    token_matches.append({
+                        'source_original': lat_orig,
+                        'target_original': grc_orig,
+                        'source_token': lat_norm,
+                        'target_token': grc_tr,
+                        'similarity': sim / 100.0,
+                    })
 
             if token_matches:
                 # Map back to (src_idx, tgt_idx) in original orientation

--- a/backend/synonym_dict.py
+++ b/backend/synonym_dict.py
@@ -1050,10 +1050,17 @@ def find_greek_latin_matches(greek_lemmas: list, latin_lemmas: list, use_stoplis
             continue
 
         grc_lookup = grc_norm.replace('ς', 'σ')  # medial sigma to match dict keys
-        # Normalize v→u in curated translations to match text processor's Latin lemmas
+        # Normalize v→u so every layer of the Greek-Latin dictionary matches
+        # what the UD lemmatizer emits on the target side. The V3 dictionary
+        # (~34,500 entries) stores Latin glosses with v-forms (vasto, venio,
+        # vulnero) while the text processor produces u-forms (uasto, uenio,
+        # uulnero). Only the curated layer was previously normalized, so any
+        # V3 or gazetteer entry whose Latin gloss contains a 'v' could never
+        # intersect the target text's lemma set. Apply the same replacement
+        # to all three sources so they share a single canonical lookup space.
         curated_translations = {w.replace('v', 'u') for w in CURATED_GREEK_LATIN.get(grc_lookup, [])}
-        v3_translations = gl_dict_norm.get(grc_norm, set()) if gl_dict_norm else set()
-        gazetteer_translations = gazetteer.get(grc_norm, set())
+        v3_translations = {w.replace('v', 'u') for w in (gl_dict_norm.get(grc_norm, set()) if gl_dict_norm else set())}
+        gazetteer_translations = {w.replace('v', 'u') for w in gazetteer.get(grc_norm, set())}
         latin_translations = curated_translations.union(v3_translations).union(gazetteer_translations)
 
         if latin_translations:


### PR DESCRIPTION
Three audit findings from the 2026-06-10 codebase audit, each verified against the production source before fixing. Three independent commits so they can be reverted individually.

## Items #1 and #2 are not in this PR

The audit also flagged a phonetic-channel n_channels inflation and a streaming-context bug. On verification, neither applies to production:

- The phonetic channel is active on production (`PHONETIC_WEIGHT = 1.5`); the disable Mythos noticed is dev-only. The n_channels behavior is intentional when the weight is positive.
- The streaming-context bug was already fixed on production by PR #89's analytics work. `req_user_id`, `req_city`, `req_country`, `req_ip` are captured before `def generate():` and the generator uses local variables.

## What this PR fixes

**Hapax document frequency was inflated by partition files** (audit #3, commit 8e3dc4c). Long works are indexed twice: as a full-text file and as per-part files. The old `COUNT(DISTINCT text_id)` counted Iliad as 25 documents instead of 1. Concrete measurement: μῆνις went from doc_freq=109 to doc_freq=69 after the fix (40 duplicate text_ids collapsed). Affects the rare_word channel on every search path.

**V3 and gazetteer Greek-Latin dictionary entries are now v→u normalized** (audit #4, commit 6f2a40f). The text processor emits u-forms for Latin lemmas, but only the curated layer of the Greek-Latin dictionary was normalized. 67 V3 entries (0.2 percent) have 'v' in any Latin gloss; the affected entries are substantive epic verbs (ἔρχομαι→venio, πορθέω→vasto, etc.). Affects the Greek-Latin cross-lingual dictionary channel.

**Cross-lingual phonetic match labels now match pair_key orientation** (audit #5, commit 87562b7). The pair_key was correctly flipped based on search direction, but the per-token `source_original` / `target_original` fields were hardcoded to the Greek-source case. Latin→Greek searches had token labels silently swapped. Affects highlighting on the Latin→Greek production direction.

## What I have not done

I have not run benchmark validation. Each of these affects either ranking (audit #3 via rare_word doc_freq, audit #4 via dictionary recall) or display (audit #5). The expected direction is positive — more accurate doc_freq means hapaxes survive better, more dictionary coverage means more matches found, correct labels means correct highlighting — but the magnitude on the relevant benchmark (Lucan-Vergil for Latin-Latin, Knauer for Greek-Latin) needs to be measured.

If you want to merge based on the code reasoning, fine. If you want to validate first, the right move is to run the benchmarks against this branch and compare to main.