### PR TITLE
fix(ci): trigger Claude PR workflows on ready_for_review

### DIFF
--- a/.github/workflows/claude-pr-auto-approve.yml
+++ b/.github/workflows/claude-pr-auto-approve.yml
@@ -20,7 +20,7 @@ name: Claude PR auto-approve (low-risk only)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -11,7 +11,7 @@ name: Claude PR review (instant first pass)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Adds `ready_for_review` to the `on: pull_request: types: [...]` lists in both Claude workflows
- Fixes the silent-skip when a draft PR is converted to "Ready for Review"
- Reported by Harsha on Slack 2026-06-11

## Why

The two Claude PR automation workflows (`claude-pr-review.yml` and `claude-pr-auto-approve.yml`) previously fired only on `opened`, `synchronize`, and `reopened`. A draft PR converted to "Ready for Review" emits a `ready_for_review` event, which was not in either trigger list. Result: drafts marked ready never received an auto-review or safety classification — a real gap in the team's intended workflow.

## Test plan

- [ ] Open a draft PR, mark it Ready for Review, confirm both Claude workflows fire
- [ ] Open a regular (non-draft) PR, confirm both still fire on opened/synchronize