### PR TITLE
revert: restore claude_pr_review.py MODEL to claude-fable-5

### DIFF
--- a/.github/scripts/claude_pr_review.py
+++ b/.github/scripts/claude_pr_review.py
@@ -24,7 +24,7 @@ import urllib.request
 import urllib.error
 
 ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
-MODEL = "claude-opus-4-8"
+MODEL = "claude-fable-5"
 MAX_TOKENS = 2000
 DIFF_TOKEN_BUDGET_CHARS = 60_000  # ~15K tokens, leaves headroom for prompt + reply
 


### PR DESCRIPTION
## Summary

PR #124 inadvertently changed the auto-review model from `claude-fable-5` to `claude-opus-4-8` in `.github/scripts/claude_pr_review.py`. The new value is not a valid model identifier, so the Claude PR auto-review workflow would fail on every future PR API call.

This one-line revert restores the previous working value.

## Why this is being filed independently

The change was out of scope for PR #124's actual purpose (SSE keep-alive heartbeat + frontend error handling for large fusion searches). The auto-review on PR #124 itself flagged this exact concern (\"completely out of scope for an SSE-timeout fix, and neither value is a real model identifier\"). The substantive parts of PR #124 are working as intended on production. Only this one regression needs reverting.

## Test plan

- [ ] Open or sync a PR; verify the Claude auto-review workflow runs and produces a comment (it will use `claude-fable-5` again after this merges).