### PR TITLE
fix: update auto-review MODEL to claude-opus-4-8

### DIFF
--- a/.github/scripts/claude_pr_review.py
+++ b/.github/scripts/claude_pr_review.py
@@ -24,7 +24,7 @@ import urllib.request
 import urllib.error
 
 ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
-MODEL = "claude-fable-5"
+MODEL = "claude-opus-4-8"
 MAX_TOKENS = 2000
 DIFF_TOKEN_BUDGET_CHARS = 60_000  # ~15K tokens, leaves headroom for prompt + reply
 


### PR DESCRIPTION
## Summary

The auto-review workflow has been silently failing on every PR since 2026-06-16, including the 2026-06-18 push to PR #115. The API rejects `claude-fable-5` with:

> Anthropic API error 404: Claude Fable 5 is not available. Please use Opus 4.8.

## Background

PR #124 (Harika) changed `MODEL = "claude-fable-5"` to `"claude-opus-4-8"` as part of the SSE keep-alive PR. I (Neil, with Claude) misread that change as a scope-violation with an invalid model ID and opened PR #125 to revert it. The revert restored the broken state. The auto-review on the revert PR itself failed for the same reason but I did not check the workflow status.

## Verification

Tested all three IDs against the live API on 2026-06-21:

| Model ID | Result |
|---|---|
| `claude-opus-4-7` | OK |
| `claude-opus-4-8` | OK |
| `claude-fable-5` | not_found_error - "Please use Opus 4.8" |

Going with `claude-opus-4-8` per the API's own recommendation in the error message.

## Test plan

- [ ] After merge, push a trivial change to any PR and confirm the "Claude PR review (instant first pass)" check returns SUCCESS rather than FAILURE
- [ ] Confirm the auto-review comment posts on the PR