### PR TITLE
test: verify auto-review workflow is unblocked

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,6 +1,6 @@
 # Claude PR automation
 
-This directory holds the scripts and workflows that automate first-pass PR review for Tesserae V6.
+This directory holds the scripts and workflows that automate first-pass PR review for Tesserae V6. The model ID is set in `claude_pr_review.py:27`; update it when Anthropic deprecates the current model.
 
 ## Files
 


### PR DESCRIPTION
Trivial doc change to trigger the auto-review workflow against current main, confirming PR #126's MODEL fix took effect.

Will close without merging once the auto-review check returns SUCCESS.