### PR TITLE
Add unit tests for matcher and app initialization

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Smoke tests for Flask application initialization and basic routes.
+Ensures application starts up and registers blueprints without requiring
+a populated PostgreSQL database.
+"""
+
+import os
+import sys
+import pytest
+from flask import Flask
+
+# Ensure project root is in python path
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+
+@pytest.fixture(scope="module")
+def app_instance():
+    """Module-scoped fixture yielding Flask app configured with in-memory DB."""
+    # Temporarily set environment variables to avoid database connection errors
+    # and configure direct API server prefixes.
+    old_db = os.environ.get("DATABASE_URL")
+    old_direct = os.environ.get("TESSERAE_DIRECT_SERVER")
+    old_secret = os.environ.get("SESSION_SECRET")
+    
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    os.environ["TESSERAE_DIRECT_SERVER"] = "1"
+    os.environ["SESSION_SECRET"] = "test-secret-key"
+    
+    try:
+        from backend.app import app
+        yield app
+    finally:
+        # Restore environment variables
+        if old_db is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = old_db
+            
+        if old_direct is None:
+            os.environ.pop("TESSERAE_DIRECT_SERVER", None)
+        else:
+            os.environ["TESSERAE_DIRECT_SERVER"] = old_direct
+
+        if old_secret is None:
+            os.environ.pop("SESSION_SECRET", None)
+        else:
+            os.environ["SESSION_SECRET"] = old_secret
+
+
+def test_app_initialization(app_instance):
+    """Confirm Flask app initializes and is of correct instance type."""
+    assert app_instance is not None
+    assert isinstance(app_instance, Flask)
+    assert app_instance.name == "backend.app"
+
+
+def test_blueprint_registration(app_instance):
+    """Verify core blueprints are registered with correct prefixes."""
+    blueprints = app_instance.blueprints
+    
+    # Check that core search and corpus blueprints are present
+    assert "search" in blueprints
+    assert "corpus" in blueprints
+    assert "hapax" in blueprints
+    assert "fusion" in blueprints
+    assert "admin" in blueprints
+    assert "intertext" in blueprints
+
+
+def test_health_check_endpoints(app_instance):
+    """Verify that basic health check endpoints return successful status."""
+    with app_instance.test_client() as client:
+        # 1. Root health check
+        resp1 = client.get("/health")
+        assert resp1.status_code == 200
+        data1 = resp1.get_json()
+        assert data1 == {"status": "ok", "message": "Tesserae V6 is running"}
+        
+        # 2. Prefixed API health check
+        resp2 = client.get("/api/health")
+        assert resp2.status_code == 200
+        data2 = resp2.get_json()
+        assert data2 == {"status": "ok", "message": "Tesserae V6 is running"}
+
+
+def test_version_endpoint(app_instance):
+    """Verify version endpoint returns git version metadata structure."""
+    with app_instance.test_client() as client:
+        resp = client.get("/api/version")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "version" in data
+        assert "last_updated" in data

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""
+Unit tests for core search and matching logic in backend/matcher.py.
+Tests are kept fast, deterministic, and isolated without requiring a database
+or loading massive corpus index files.
+"""
+
+import os
+import sys
+import pytest
+from collections import Counter
+
+# Ensure project root is in python path
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from backend.matcher import (
+    normalize_greek,
+    normalize_latin,
+    transliterate_greek_to_latin,
+    find_crosslingual_phonetic_matches,
+    Matcher
+)
+
+
+# ── 1. Basic Text Normalization & Transliteration ────────────────────
+
+def test_normalize_greek():
+    # Accent/diacritic stripping and lowercasing
+    assert normalize_greek("μῆνιν") == "μηνιν"
+    assert normalize_greek("ἄειδε") == "αειδε"
+    assert normalize_greek("Θεά") == "θεα"
+    assert normalize_greek("") == ""
+
+
+def test_normalize_latin():
+    # Lowercasing and u/v equivalence
+    assert normalize_latin("virumque") == "uirumque"
+    assert normalize_latin("URBS") == "urbs"
+    assert normalize_latin("VIVUS") == "uiuus"
+
+
+def test_transliterate_greek_to_latin():
+    # Greek character mappings to Latin phonetics
+    assert transliterate_greek_to_latin("μῆνιν") == "menin"
+    assert transliterate_greek_to_latin("ἄειδε") == "aeide"
+    assert transliterate_greek_to_latin("θεά") == "thea"
+    # Sigma replacement and passthrough of non-Greek
+    assert transliterate_greek_to_latin("χῶρος") == "choros"
+    assert transliterate_greek_to_latin("latin-text") == "latin-text"
+
+
+# ── 2. Stoplist Building Tests ───────────────────────────────────────
+
+@pytest.fixture
+def sample_units():
+    # Tiny hand-crafted units for frequency counting
+    return [
+        {"tokens": ["arma", "virumque", "cano"], "lemmas": ["arma", "vir", "cano"]},
+        {"tokens": ["arma", "et", "bella"], "lemmas": ["arma", "et", "bellum"]},
+        {"tokens": ["et", "cano", "bella"], "lemmas": ["et", "cano", "bellum"]},
+    ]
+
+
+def test_build_stoplist_manual(sample_units):
+    m = Matcher()
+    # Explicit top list size stoplist
+    stoplist = m.build_stoplist_manual(sample_units, stoplist_size=2, language='la')
+    # Should include base stopwords + the top 2 manually computed (et, arma)
+    assert "et" in stoplist
+    assert "arma" in stoplist
+    # Base stops must be merged
+    assert "in" in stoplist
+
+
+def test_build_stoplist(sample_units):
+    m = Matcher()
+    # Build stoplist using Zipf elbow detection
+    # Mocking corpus frequencies
+    corpus_freqs = {"arma": 100, "et": 90, "cano": 10}
+    stoplist = m.build_stoplist(
+        sample_units, 
+        sample_units, 
+        stoplist_basis='corpus', 
+        language='la', 
+        corpus_frequencies=corpus_freqs,
+        match_type='lemma'
+    )
+    # Should contain default Latin stops plus top frequency words
+    assert "et" in stoplist
+    assert "in" in stoplist
+
+
+# ── 3. Exact and Lemma Matching Tests ─────────────────────────────────
+
+def test_find_exact_matches():
+    m = Matcher()
+    
+    # Exact matching strictly checks identical surface forms (tokens)
+    source_units = [
+        {"tokens": ["arma", "virumque", "cano"], "lemmas": ["arma", "vir", "cano"]}
+    ]
+    target_units = [
+        {"tokens": ["arma", "virumque", "belli"], "lemmas": ["arma", "vir", "bellum"]}
+    ]
+    
+    # Exact match for "arma", "virumque"
+    matches, stop_words_count = m.find_matches(
+        source_units,
+        target_units,
+        settings={"match_type": "exact", "min_matches": 2, "stoplist_size": -1}
+    )
+    
+    assert len(matches) == 1
+    assert matches[0]["source_idx"] == 0
+    assert matches[0]["target_idx"] == 0
+    assert set(matches[0]["matched_lemmas"]) == {"arma", "virumque"}
+
+
+def test_find_lemma_matches():
+    m = Matcher()
+    
+    # Lemma matching checks base dictionary forms
+    source_units = [
+        {"tokens": ["armis", "virumque"], "lemmas": ["arma", "vir"]}
+    ]
+    target_units = [
+        {"tokens": ["armorum", "viro"], "lemmas": ["arma", "vir"]}
+    ]
+    
+    matches, _ = m.find_matches(
+        source_units,
+        target_units,
+        settings={"match_type": "lemma", "min_matches": 2, "stoplist_size": -1}
+    )
+    
+    assert len(matches) == 1
+    assert set(matches[0]["matched_lemmas"]) == {"arma", "vir"}
+
+
+def test_find_matches_min_matches_filter():
+    m = Matcher()
+    
+    source_units = [
+        {"tokens": ["armis", "virumque"], "lemmas": ["arma", "vir"]}
+    ]
+    target_units = [
+        {"tokens": ["armorum", "belli"], "lemmas": ["arma", "bellum"]}
+    ]
+    
+    # Needs at least 2 matching lemmas, but only "arma" matches
+    matches, _ = m.find_matches(
+        source_units,
+        target_units,
+        settings={"match_type": "lemma", "min_matches": 2, "stoplist_size": -1}
+    )
+    assert len(matches) == 0
+
+
+# ── 4. Synonym / Semantic Matching ───────────────────────────────────
+
+def test_find_synonym_matches():
+    m = Matcher()
+    # Seed synonyms directly
+    m.synonym_dict = {
+        "ensis": {"gladius", "spatha"},
+        "gladius": {"ensis", "spatha"}
+    }
+    
+    source_units = [
+        {"tokens": ["ensis", "arma"], "lemmas": ["ensis", "arma"]}
+    ]
+    target_units = [
+        {"tokens": ["gladius", "arma"], "lemmas": ["gladius", "arma"]}
+    ]
+    
+    matches, _ = m.find_matches(
+        source_units,
+        target_units,
+        settings={"match_type": "syn", "min_matches": 2, "stoplist_size": -1}
+    )
+    
+    assert len(matches) == 1
+    assert set(matches[0]["matched_lemmas"]) == {"ensis", "arma"}
+
+
+# ── 5. Sound & Edit Distance Matching ────────────────────────────────
+
+def test_find_sound_matches():
+    m = Matcher()
+    
+    # Sound matching computes trigram overlaps of tokens
+    source_units = [
+        {"tokens": ["claudere"], "lemmas": ["claudo"]}
+    ]
+    target_units = [
+        {"tokens": ["claudite"], "lemmas": ["claudo"]}
+    ]
+    
+    matches, _ = m.find_sound_matches(
+        source_units,
+        target_units,
+        settings={"min_sound_score": 0.2, "sound_top_n": 5}
+    )
+    
+    assert len(matches) > 0
+    assert matches[0]["source_idx"] == 0
+    assert matches[0]["target_idx"] == 0
+    assert matches[0]["sound_score"] > 0
+
+
+def test_find_edit_distance_matches():
+    m = Matcher()
+    
+    # Edit distance (fuzz Levenshtein similarity) matching
+    source_units = [
+        {"tokens": ["liber", "arma"], "lemmas": ["liber", "arma"]}
+    ]
+    target_units = [
+        {"tokens": ["libri", "arma"], "lemmas": ["liber", "arma"]}
+    ]
+    
+    matches, _ = m.find_edit_distance_matches(
+        source_units,
+        target_units,
+        settings={"min_similarity": 0.60, "max_results": 10}
+    )
+    
+    assert len(matches) > 0
+    assert matches[0]["source_idx"] == 0
+    assert matches[0]["target_idx"] == 0
+
+
+# ── 6. Crosslingual Phonetic Matching ───────────────────────────────
+
+def test_find_crosslingual_phonetic_matches():
+    # Source is Greek, target is Latin/transliterated
+    source_units = [
+        {"tokens": ["μῆνιν"], "lemmas": ["μηνιν"]}
+    ]
+    target_units = [
+        {"tokens": ["menim"], "lemmas": ["menim"]}
+    ]
+    
+    matches = find_crosslingual_phonetic_matches(
+        source_units,
+        target_units,
+        source_language="grc",
+        target_language="la",
+        min_similarity=0.70,
+        min_token_len=3
+    )
+    
+    assert len(matches) > 0
+    # Key is (src_idx, tgt_idx)
+    assert (0, 0) in matches
+    match_detail = matches[(0, 0)][0]
+    assert match_detail["source_token"] == "menin" # transliterated
+    assert match_detail["target_token"] == "menim"
+    assert match_detail["source_original"] == "μῆνιν"
+    assert match_detail["similarity"] > 0.70


### PR DESCRIPTION
Fixes #132

Summary:
- Added `tests/test_matcher.py` covering core matcher behavior with mocked/small inputs.
- Added `tests/test_app.py` for Flask app initialization and route smoke tests.
- Tests avoid populated database, full corpus indexes, embeddings, or external NLP model requirements.

Testing:
- `pytest tests/test_matcher.py tests/test_app.py -v`
- Result: 16 passed

Note:
- `tests/test_endpoints.py` was not run because main currently contains a legacy `sys.exit()` issue that is addressed separately in PR/branch for #131.