### PR TITLE
Fix enclitic-stripping in lemma cache fallback

### DIFF
--- a/scripts/batch_lemma_cache.py
+++ b/scripts/batch_lemma_cache.py
@@ -127,14 +127,24 @@ class FastTextProcessor:
 
             if lemma is None and self.latin_lemmatizer:
                 try:
-                    t = stripped_base if stripped_base else token
-                    result = self.latin_lemmatizer.lemmatize([t])
-                    lemma = result[0][1] if result else (stripped_base or norm)
+                    # Try the FULL form first; the enclitic-stripped base is a
+                    # heuristic that mangles words like lanugine -> lanugi.
+                    result = self.latin_lemmatizer.lemmatize([token])
+                    lemma = result[0][1] if result else None
+                    if (lemma is None or lemma == token or lemma == norm) and stripped_base:
+                        result = self.latin_lemmatizer.lemmatize([stripped_base])
+                        alt = result[0][1] if result else None
+                        if alt and alt != stripped_base:
+                            lemma = alt
+                    if lemma is None:
+                        lemma = norm
                 except Exception:
-                    lemma = stripped_base or norm
+                    lemma = norm
 
             if lemma is None:
-                lemma = stripped_base or norm
+                # No CLTK: keep the full normalized form. A raw form is honest;
+                # an unvalidated stripped stem is garbage (lanugine -> lanugi).
+                lemma = norm
 
             self.lemma_cache[cache_key] = lemma
             lemmas.append(lemma)


### PR DESCRIPTION
The FastTextProcessor fallback in `scripts/batch_lemma_cache.py` wrote the enclitic-stripped base as the lemma when a form was absent from the lookup table and CLTK was unavailable. Words like *lanugine* (strip *-ne*) became the mangled stem *lanugi* instead of reducing to *lanugo* or staying as the full form.

Production runs without CLTK, so it hit this on every table-miss enclitic form, corrupting the lemma cache. The mangled stems masquerade as ultra-rare words and distort rarity scoring. Found while diagnosing a sunk allusion (Statius *Achilleid* 1.163 / Ovid *Met.* 12.291, *lanugine* in both).

**Fix:** try the full form first; fall back to the enclitic-stripped base only when it reduces productively; otherwise keep the full normalized form. This mirrors the guard already in `backend/text_processor.py` (the index-build path), which is why production's *index* was unaffected but its *cache* was not.

Validated on the five Latin benchmarks: found-counts unchanged, and top-of-list precision improved on the Lucan pair (P@10 40->50) as the fake-rare stems left the top ranks.