### PR TITLE
Feature/curated stoplists help

### DIFF
--- a/backend/blueprints/search.py
+++ b/backend/blueprints/search.py
@@ -37,6 +37,7 @@ from backend.logging_config import get_logger
 from backend.services import get_user_location, log_search
 from backend.cache import get_cached_results, save_cached_results, clear_cache
 from backend.concurrency_gate import SearchSlot
+from backend.matcher import get_curated_stoplists
 
 logger = get_logger('search')
 
@@ -1333,6 +1334,18 @@ def search():
     except Exception as e:
         logger.exception(f"Search failed: {e}")
         return jsonify({"error": str(e)})
+
+
+@search_bp.route('/stoplists', methods=['GET'])
+def get_curated_stoplists_endpoint():
+    """Return the primary matcher stoplists used by the Help page.
+
+    This intentionally differs from POST /stoplist, which computes a
+    text-specific list using selected source and target texts.
+    """
+    response = jsonify({'stoplists': get_curated_stoplists()})
+    response.headers['Cache-Control'] = 'no-store'
+    return response
 
 
 @search_bp.route('/stoplist', methods=['POST'])

--- a/backend/matcher.py
+++ b/backend/matcher.py
@@ -448,6 +448,29 @@ DEFAULT_LATIN_STOP_WORDS = set(DEFAULT_LATIN_STOP_WORDS_LIST)
 DEFAULT_GREEK_STOP_WORDS = set(DEFAULT_GREEK_STOP_WORDS_LIST)
 DEFAULT_ENGLISH_STOP_WORDS = set(DEFAULT_ENGLISH_STOP_WORDS_LIST)
 
+
+def get_curated_stoplists():
+    """Return the primary matcher stoplists in a display-safe API shape.
+
+    The matcher keeps ordered lists because manual stoplist sizes use their
+    ranking, while matching itself uses sets. De-duplicate the public view
+    without changing matching behavior or manual-list ordering.
+    """
+    stoplists = (
+        ('la', 'Latin', DEFAULT_LATIN_STOP_WORDS_LIST),
+        ('grc', 'Greek', DEFAULT_GREEK_STOP_WORDS_LIST),
+        ('en', 'English', DEFAULT_ENGLISH_STOP_WORDS_LIST),
+    )
+    return {
+        language: {
+            'label': label,
+            'words': list(dict.fromkeys(words)),
+            'count': len(dict.fromkeys(words)),
+        }
+        for language, label, words in stoplists
+    }
+
+
 class Matcher:
     def __init__(self):
         self.synonym_dict = {}

--- a/client/src/components/pages/HelpPage.jsx
+++ b/client/src/components/pages/HelpPage.jsx
@@ -1,9 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { STOPLIST_INFO } from '../../data/stoplists';
 
 export default function HelpPage() {
   const [activeSection, setActiveSection] = useState('getting-started');
   const [expandedStoplists, setExpandedStoplists] = useState({});
+  const [curatedStoplists, setCuratedStoplists] = useState(null);
+  const [stoplistsError, setStoplistsError] = useState(null);
   const [requestName, setRequestName] = useState('');
   const [requestEmail, setRequestEmail] = useState('');
   const [requestAuthor, setRequestAuthor] = useState('');
@@ -33,6 +35,46 @@ export default function HelpPage() {
   ]);
   const [formatterOutput, setFormatterOutput] = useState('');
   const [formatterCopied, setFormatterCopied] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadCuratedStoplists = async () => {
+      try {
+        const response = await fetch('/api/stoplists', {
+          headers: { Accept: 'application/json' },
+          cache: 'no-store'
+        });
+        if (!response.ok) {
+          throw new Error(`Unable to load stoplists (${response.status})`);
+        }
+
+        const payload = await response.json();
+        const languageCards = [
+          ['la', 'latin'],
+          ['grc', 'greek'],
+          ['en', 'english']
+        ].map(([language, key]) => {
+          const stoplist = payload.stoplists?.[language];
+          if (!stoplist || !Array.isArray(stoplist.words)) {
+            throw new Error('The stoplist response is incomplete');
+          }
+          return { key, label: stoplist.label, data: stoplist };
+        });
+
+        if (!cancelled) {
+          setCuratedStoplists(languageCards);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setStoplistsError(error.message || 'Unable to load the curated stoplists.');
+        }
+      }
+    };
+
+    loadCuratedStoplists();
+    return () => { cancelled = true; };
+  }, []);
 
   const updateFormatterSlot = (slotId, field, value) => {
     setFormatterCopied(false);
@@ -166,12 +208,6 @@ export default function HelpPage() {
   };
 
   const hasFormatterRawText = formatterSlots.some(slot => slot.rawText.trim());
-
-  const curatedStoplists = [
-    { key: 'latin', label: 'Latin', data: STOPLIST_INFO.latin },
-    { key: 'greek', label: 'Greek', data: STOPLIST_INFO.greek },
-    { key: 'english', label: 'English', data: STOPLIST_INFO.english }
-  ];
 
   const toggleStoplist = (language) => {
     setExpandedStoplists((current) => ({
@@ -739,45 +775,53 @@ export default function HelpPage() {
                 Expand a language to see every curated entry. Greek entries are shown in the accentless normalized
                 form used by the matcher.
               </p>
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-3">
-                {curatedStoplists.map(({ key, label, data }) => {
-                  const isExpanded = Boolean(expandedStoplists[key]);
-                  return (
-                    <div key={key} className="bg-gray-50 rounded-lg p-3">
-                      <div className="flex items-center justify-between gap-2">
-                        <h5 className="font-medium text-gray-800">{label} ({data.words.length} words)</h5>
-                        <button
-                          type="button"
-                          className="text-xs font-medium text-blue-700 hover:text-blue-900 whitespace-nowrap"
-                          onClick={() => toggleStoplist(key)}
-                          aria-expanded={isExpanded}
-                          aria-controls={`${key}-curated-stoplist`}
-                        >
-                          {isExpanded ? 'Hide full list' : 'Show full list'}
-                        </button>
-                      </div>
-                      {isExpanded ? (
-                        <div
-                          id={`${key}-curated-stoplist`}
-                          className="mt-3 max-h-72 overflow-y-auto rounded border border-gray-200 bg-white p-2"
-                        >
-                          <div className="flex flex-wrap gap-1" aria-label={`Full curated ${label} stoplist`}>
-                            {data.words.map((word) => (
-                              <code key={word} className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-700">
-                                {word}
-                              </code>
-                            ))}
-                          </div>
+              {curatedStoplists === null && !stoplistsError ? (
+                <p className="text-sm text-gray-500" role="status">Loading the current curated stoplists…</p>
+              ) : stoplistsError ? (
+                <p className="text-sm text-red-700" role="alert">
+                  The current curated stoplists could not be loaded. Please try again later.
+                </p>
+              ) : (
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-3">
+                  {curatedStoplists.map(({ key, label, data }) => {
+                    const isExpanded = Boolean(expandedStoplists[key]);
+                    return (
+                      <div key={key} className="bg-gray-50 rounded-lg p-3">
+                        <div className="flex items-center justify-between gap-2">
+                          <h5 className="font-medium text-gray-800">{label} ({data.words.length} words)</h5>
+                          <button
+                            type="button"
+                            className="text-xs font-medium text-blue-700 hover:text-blue-900 whitespace-nowrap"
+                            onClick={() => toggleStoplist(key)}
+                            aria-expanded={isExpanded}
+                            aria-controls={`${key}-curated-stoplist`}
+                          >
+                            {isExpanded ? 'Hide full list' : 'Show full list'}
+                          </button>
                         </div>
-                      ) : (
-                        <p className="text-xs text-gray-500 italic mt-1">
-                          {data.words.slice(0, 13).join(', ')}...
-                        </p>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
+                        {isExpanded ? (
+                          <div
+                            id={`${key}-curated-stoplist`}
+                            className="mt-3 max-h-72 overflow-y-auto rounded border border-gray-200 bg-white p-2"
+                          >
+                            <div className="flex flex-wrap gap-1" aria-label={`Full curated ${label} stoplist`}>
+                              {data.words.map((word) => (
+                                <code key={word} className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-700">
+                                  {word}
+                                </code>
+                              ))}
+                            </div>
+                          </div>
+                        ) : (
+                          <p className="text-xs text-gray-500 italic mt-1">
+                            {data.words.slice(0, 13).join(', ')}...
+                          </p>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
 
               <h4 className="font-medium text-gray-900 mt-6 mb-2">Stoplist Options</h4>
               <dl className="space-y-3">

--- a/client/src/components/pages/HelpPage.jsx
+++ b/client/src/components/pages/HelpPage.jsx
@@ -3,6 +3,7 @@ import { STOPLIST_INFO } from '../../data/stoplists';
 
 export default function HelpPage() {
   const [activeSection, setActiveSection] = useState('getting-started');
+  const [expandedStoplists, setExpandedStoplists] = useState({});
   const [requestName, setRequestName] = useState('');
   const [requestEmail, setRequestEmail] = useState('');
   const [requestAuthor, setRequestAuthor] = useState('');
@@ -165,6 +166,19 @@ export default function HelpPage() {
   };
 
   const hasFormatterRawText = formatterSlots.some(slot => slot.rawText.trim());
+
+  const curatedStoplists = [
+    { key: 'latin', label: 'Latin', data: STOPLIST_INFO.latin },
+    { key: 'greek', label: 'Greek', data: STOPLIST_INFO.greek },
+    { key: 'english', label: 'English', data: STOPLIST_INFO.english }
+  ];
+
+  const toggleStoplist = (language) => {
+    setExpandedStoplists((current) => ({
+      ...current,
+      [language]: !current[language]
+    }));
+  };
 
   const sections = [
     { id: 'getting-started', label: 'Getting Started' },
@@ -721,25 +735,48 @@ export default function HelpPage() {
               </ul>
 
               <h4 className="font-medium text-gray-900 mt-6 mb-2">Curated Stop Words by Language</h4>
+              <p className="text-gray-600 text-sm mb-3">
+                Expand a language to see every curated entry. Greek entries are shown in the accentless normalized
+                form used by the matcher.
+              </p>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-3">
-                <div className="bg-gray-50 rounded-lg p-3">
-                  <h5 className="font-medium text-gray-800 mb-1">Latin ({STOPLIST_INFO.latin.count} words)</h5>
-                  <p className="text-xs text-gray-500 italic">
-                    {STOPLIST_INFO.latin.examples.join(', ')}...
-                  </p>
-                </div>
-                <div className="bg-gray-50 rounded-lg p-3">
-                  <h5 className="font-medium text-gray-800 mb-1">Greek ({STOPLIST_INFO.greek.count} words)</h5>
-                  <p className="text-xs text-gray-500 italic">
-                    {STOPLIST_INFO.greek.examples.join(', ')}...
-                  </p>
-                </div>
-                <div className="bg-gray-50 rounded-lg p-3">
-                  <h5 className="font-medium text-gray-800 mb-1">English ({STOPLIST_INFO.english.count} words)</h5>
-                  <p className="text-xs text-gray-500 italic">
-                    {STOPLIST_INFO.english.examples.join(', ')}...
-                  </p>
-                </div>
+                {curatedStoplists.map(({ key, label, data }) => {
+                  const isExpanded = Boolean(expandedStoplists[key]);
+                  return (
+                    <div key={key} className="bg-gray-50 rounded-lg p-3">
+                      <div className="flex items-center justify-between gap-2">
+                        <h5 className="font-medium text-gray-800">{label} ({data.words.length} words)</h5>
+                        <button
+                          type="button"
+                          className="text-xs font-medium text-blue-700 hover:text-blue-900 whitespace-nowrap"
+                          onClick={() => toggleStoplist(key)}
+                          aria-expanded={isExpanded}
+                          aria-controls={`${key}-curated-stoplist`}
+                        >
+                          {isExpanded ? 'Hide full list' : 'Show full list'}
+                        </button>
+                      </div>
+                      {isExpanded ? (
+                        <div
+                          id={`${key}-curated-stoplist`}
+                          className="mt-3 max-h-72 overflow-y-auto rounded border border-gray-200 bg-white p-2"
+                        >
+                          <div className="flex flex-wrap gap-1" aria-label={`Full curated ${label} stoplist`}>
+                            {data.words.map((word) => (
+                              <code key={word} className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-700">
+                                {word}
+                              </code>
+                            ))}
+                          </div>
+                        </div>
+                      ) : (
+                        <p className="text-xs text-gray-500 italic mt-1">
+                          {data.words.slice(0, 13).join(', ')}...
+                        </p>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
 
               <h4 className="font-medium text-gray-900 mt-6 mb-2">Stoplist Options</h4>

--- a/client/src/data/stoplists.js
+++ b/client/src/data/stoplists.js
@@ -1,79 +1,3 @@
-const CURATED_STOPLISTS = {
-  latin: {
-    words: [
-      'et', 'in', 'est', 'non', 'ut', 'cum', 'ad', 'sed',
-      'si', 'quod', 'qui', 'quae', 'que', 'de', 'ex', 'per',
-      'ab', 'ac', 'atque', 'aut', 'nec', 'neque', 'enim', 'nam',
-      'iam', 'tamen', 'autem', 'quidem', 'hic', 'haec', 'hoc', 'ille',
-      'illa', 'illud', 'is', 'ea', 'id', 'ipse', 'ipsa', 'ipsum',
-      'se', 'suus', 'sua', 'suum', 'esse', 'sum', 'fui', 'sunt',
-      'erat', 'erant', 'fuit', 'ait', 'a', 'o', 'te', 'tu',
-      'me', 'ego', 'nos', 'vos', 'noster', 'vester', 'omnis', 'omnia',
-      'omnes', 'nullus', 'nulla', 'nullum', 'unus', 'duo', 'tres', 'primus',
-      'secundus', 'tertius', 'ubi', 'nunc', 'sic', 'tam', 'tum', 'ita',
-      'ibi', 'hinc', 'inde', 'quo', 'qua', 'quam', 'quando', 'unde',
-      'cur', 'ergo', 'igitur'
-    ]
-  },
-  greek: {
-    words: [
-      'και', 'δε', 'τε', 'γαρ', 'μεν', 'δη', 'ου', 'ουκ',
-      'ουχ', 'μη', 'αλλα', 'αλλ', 'ουδε', 'μηδε', 'ουτε', 'μητε',
-      'ειτε', 'ητοι', 'νυ', 'τοι', 'περ', 'γε', 'κε', 'κεν',
-      'ρα', 'εν', 'εις', 'εκ', 'εξ', 'προς', 'απο', 'περι',
-      'κατα', 'μετα', 'δια', 'υπο', 'υπερ', 'παρα', 'επι', 'αντι',
-      'συν', 'προ', 'αρ', 'επ', 'απ', 'κατ', 'μετ', 'παρ',
-      'υπ', 'αμφ', 'αντ', 'ο', 'η', 'το', 'οι', 'αι',
-      'τα', 'τον', 'την', 'του', 'της', 'τω', 'τη', 'τοις',
-      'ταις', 'τους', 'τας', 'των', 'ος', 'ης', 'ον', 'οστις',
-      'ητις', 'οτι', 'ως', 'αν', 'ει', 'ω', 'ην', 'οις',
-      'αις', 'ους', 'ας', 'ων', 'α', 'αυτος', 'αυτη', 'αυτο',
-      'αυτον', 'αυτην', 'αυτου', 'αυτης', 'αυτω', 'αυτοι', 'αυται', 'αυτα',
-      'αυτους', 'αυτας', 'αυτων', 'αυτοις', 'αυταις', 'ουτος', 'τουτο', 'τουτον',
-      'ταυτην', 'τουτου', 'ταυτης', 'τουτω', 'ταυτη', 'ουτοι', 'ταυτα', 'τουτους',
-      'ταυτας', 'τουτων', 'τουτοις', 'ταυταις', 'εκεινος', 'εκεινη', 'εκεινο', 'εκεινον',
-      'εκεινην', 'εκεινου', 'εκεινης', 'εκεινω', 'εκεινοι', 'εκειναι', 'εκεινα', 'εκεινους',
-      'εκεινας', 'εκεινων', 'εκεινοις', 'εκειναις', 'εγω', 'εμε', 'με', 'εμου',
-      'μου', 'εμοι', 'μοι', 'συ', 'σε', 'σου', 'σοι', 'ημεις',
-      'ημας', 'ημων', 'ημιν', 'υμεις', 'υμας', 'υμων', 'υμιν', 'τις',
-      'τι', 'τινα', 'τινος', 'τινι', 'τινες', 'τινων', 'τισι', 'τισιν',
-      'εστι', 'εστιν', 'ειμι', 'ησαν', 'εσμεν', 'εστε', 'εισι', 'εισιν',
-      'βη', 'βαν', 'βας', 'βησαν', 'εβη', 'φη', 'εφη', 'φησι',
-      'ηλθε', 'ηλθον', 'νυν', 'ετι', 'ουν', 'αρα', 'τοτε', 'ποτε',
-      'πω', 'πως', 'που', 'οπου', 'οθεν', 'ενθα', 'ενθεν', 'οπως',
-      'ωστε', 'ουτω', 'ουτως'
-    ]
-  },
-  english: {
-    words: [
-      'the', 'be', 'to', 'of', 'and', 'a', 'in', 'that',
-      'have', 'i', 'it', 'for', 'not', 'on', 'with', 'he',
-      'as', 'you', 'do', 'at', 'this', 'but', 'his', 'by',
-      'from', 'they', 'we', 'say', 'her', 'she', 'or', 'an',
-      'will', 'my', 'one', 'all', 'would', 'there', 'their', 'what',
-      'so', 'up', 'out', 'if', 'about', 'who', 'get', 'which',
-      'go', 'me', 'when', 'make', 'can', 'like', 'no', 'just',
-      'him', 'know', 'take', 'into', 'your', 'some', 'could', 'them',
-      'see', 'other', 'than', 'then', 'now', 'its', 'is', 'am',
-      'are', 'was', 'were', 'been', 'being', 'has', 'had', 'having',
-      'thou', 'thee', 'thy', 'thine', 'thyself', 'ye', 'art', 'doth',
-      'dost', 'hath', 'hast', 'shalt', 'wilt', 'canst', 'wouldst', 'shouldst',
-      'couldst', 'didst', 'hadst', 'mayst', 'mightst', 'wast', 'wert', 'wherefore',
-      'wherein', 'whereon', 'thereof', 'therein', 'herein', 'hereby', 'hither', 'thither',
-      'whither', 'hence', 'thence', 'ere', 'oft', 'nay', 'yea', 'aye',
-      'prithee', 'methinks', 'forsooth', 'verily', 'tis', 'twas', 'twere', 'twill',
-      'twould', 'o', 'oh', 'ah', 'alas', 'lo', 'behold', 'nought',
-      'naught', 'upon', 'unto', 'thus', 'such', 'each', 'every', 'both',
-      'own', 'same', 'much', 'more', 'most', 'yet', 'still', 'even',
-      'also', 'too', 'very', 'here', 'how', 'why', 'where', 'whence',
-      'whether', 'while', 'whilst', 'though', 'although', 'because', 'since', 'before',
-      'after', 'until', 'till', 'shall', 'should', 'may', 'might', 'must',
-      'need', 'dare', 'let', 'lest', 'nor', 'neither', 'either', 'none',
-      'any', 'many', 'few', 'less', 'least'
-    ]
-  }
-};
-
 export const STOPLIST_INFO = {
   description: "The Default stoplist combines curated function words with automatic high-frequency detection using Zipf's law. In Fusion mode, the curated stoplist also plays a key role in scoring: it identifies function-word matches so they can be ranked below content-word matches.",
 
@@ -83,10 +7,6 @@ export const STOPLIST_INFO = {
     "The two lists are combined to filter out noise while preserving meaningful vocabulary",
     "In Fusion mode: the curated list is used in the scoring layer to penalize function-word-only matches (e.g., sharing tum + nec) while preserving content-word matches (e.g., pectore + curas)"
   ],
-
-  latin: CURATED_STOPLISTS.latin,
-  greek: CURATED_STOPLISTS.greek,
-  english: CURATED_STOPLISTS.english,
 
   options: {
     default: "Uses curated stop words + Zipf elbow detection (recommended)",

--- a/client/src/data/stoplists.js
+++ b/client/src/data/stoplists.js
@@ -1,3 +1,79 @@
+const CURATED_STOPLISTS = {
+  latin: {
+    words: [
+      'et', 'in', 'est', 'non', 'ut', 'cum', 'ad', 'sed',
+      'si', 'quod', 'qui', 'quae', 'que', 'de', 'ex', 'per',
+      'ab', 'ac', 'atque', 'aut', 'nec', 'neque', 'enim', 'nam',
+      'iam', 'tamen', 'autem', 'quidem', 'hic', 'haec', 'hoc', 'ille',
+      'illa', 'illud', 'is', 'ea', 'id', 'ipse', 'ipsa', 'ipsum',
+      'se', 'suus', 'sua', 'suum', 'esse', 'sum', 'fui', 'sunt',
+      'erat', 'erant', 'fuit', 'ait', 'a', 'o', 'te', 'tu',
+      'me', 'ego', 'nos', 'vos', 'noster', 'vester', 'omnis', 'omnia',
+      'omnes', 'nullus', 'nulla', 'nullum', 'unus', 'duo', 'tres', 'primus',
+      'secundus', 'tertius', 'ubi', 'nunc', 'sic', 'tam', 'tum', 'ita',
+      'ibi', 'hinc', 'inde', 'quo', 'qua', 'quam', 'quando', 'unde',
+      'cur', 'ergo', 'igitur'
+    ]
+  },
+  greek: {
+    words: [
+      'και', 'δε', 'τε', 'γαρ', 'μεν', 'δη', 'ου', 'ουκ',
+      'ουχ', 'μη', 'αλλα', 'αλλ', 'ουδε', 'μηδε', 'ουτε', 'μητε',
+      'ειτε', 'ητοι', 'νυ', 'τοι', 'περ', 'γε', 'κε', 'κεν',
+      'ρα', 'εν', 'εις', 'εκ', 'εξ', 'προς', 'απο', 'περι',
+      'κατα', 'μετα', 'δια', 'υπο', 'υπερ', 'παρα', 'επι', 'αντι',
+      'συν', 'προ', 'αρ', 'επ', 'απ', 'κατ', 'μετ', 'παρ',
+      'υπ', 'αμφ', 'αντ', 'ο', 'η', 'το', 'οι', 'αι',
+      'τα', 'τον', 'την', 'του', 'της', 'τω', 'τη', 'τοις',
+      'ταις', 'τους', 'τας', 'των', 'ος', 'ης', 'ον', 'οστις',
+      'ητις', 'οτι', 'ως', 'αν', 'ει', 'ω', 'ην', 'οις',
+      'αις', 'ους', 'ας', 'ων', 'α', 'αυτος', 'αυτη', 'αυτο',
+      'αυτον', 'αυτην', 'αυτου', 'αυτης', 'αυτω', 'αυτοι', 'αυται', 'αυτα',
+      'αυτους', 'αυτας', 'αυτων', 'αυτοις', 'αυταις', 'ουτος', 'τουτο', 'τουτον',
+      'ταυτην', 'τουτου', 'ταυτης', 'τουτω', 'ταυτη', 'ουτοι', 'ταυτα', 'τουτους',
+      'ταυτας', 'τουτων', 'τουτοις', 'ταυταις', 'εκεινος', 'εκεινη', 'εκεινο', 'εκεινον',
+      'εκεινην', 'εκεινου', 'εκεινης', 'εκεινω', 'εκεινοι', 'εκειναι', 'εκεινα', 'εκεινους',
+      'εκεινας', 'εκεινων', 'εκεινοις', 'εκειναις', 'εγω', 'εμε', 'με', 'εμου',
+      'μου', 'εμοι', 'μοι', 'συ', 'σε', 'σου', 'σοι', 'ημεις',
+      'ημας', 'ημων', 'ημιν', 'υμεις', 'υμας', 'υμων', 'υμιν', 'τις',
+      'τι', 'τινα', 'τινος', 'τινι', 'τινες', 'τινων', 'τισι', 'τισιν',
+      'εστι', 'εστιν', 'ειμι', 'ησαν', 'εσμεν', 'εστε', 'εισι', 'εισιν',
+      'βη', 'βαν', 'βας', 'βησαν', 'εβη', 'φη', 'εφη', 'φησι',
+      'ηλθε', 'ηλθον', 'νυν', 'ετι', 'ουν', 'αρα', 'τοτε', 'ποτε',
+      'πω', 'πως', 'που', 'οπου', 'οθεν', 'ενθα', 'ενθεν', 'οπως',
+      'ωστε', 'ουτω', 'ουτως'
+    ]
+  },
+  english: {
+    words: [
+      'the', 'be', 'to', 'of', 'and', 'a', 'in', 'that',
+      'have', 'i', 'it', 'for', 'not', 'on', 'with', 'he',
+      'as', 'you', 'do', 'at', 'this', 'but', 'his', 'by',
+      'from', 'they', 'we', 'say', 'her', 'she', 'or', 'an',
+      'will', 'my', 'one', 'all', 'would', 'there', 'their', 'what',
+      'so', 'up', 'out', 'if', 'about', 'who', 'get', 'which',
+      'go', 'me', 'when', 'make', 'can', 'like', 'no', 'just',
+      'him', 'know', 'take', 'into', 'your', 'some', 'could', 'them',
+      'see', 'other', 'than', 'then', 'now', 'its', 'is', 'am',
+      'are', 'was', 'were', 'been', 'being', 'has', 'had', 'having',
+      'thou', 'thee', 'thy', 'thine', 'thyself', 'ye', 'art', 'doth',
+      'dost', 'hath', 'hast', 'shalt', 'wilt', 'canst', 'wouldst', 'shouldst',
+      'couldst', 'didst', 'hadst', 'mayst', 'mightst', 'wast', 'wert', 'wherefore',
+      'wherein', 'whereon', 'thereof', 'therein', 'herein', 'hereby', 'hither', 'thither',
+      'whither', 'hence', 'thence', 'ere', 'oft', 'nay', 'yea', 'aye',
+      'prithee', 'methinks', 'forsooth', 'verily', 'tis', 'twas', 'twere', 'twill',
+      'twould', 'o', 'oh', 'ah', 'alas', 'lo', 'behold', 'nought',
+      'naught', 'upon', 'unto', 'thus', 'such', 'each', 'every', 'both',
+      'own', 'same', 'much', 'more', 'most', 'yet', 'still', 'even',
+      'also', 'too', 'very', 'here', 'how', 'why', 'where', 'whence',
+      'whether', 'while', 'whilst', 'though', 'although', 'because', 'since', 'before',
+      'after', 'until', 'till', 'shall', 'should', 'may', 'might', 'must',
+      'need', 'dare', 'let', 'lest', 'nor', 'neither', 'either', 'none',
+      'any', 'many', 'few', 'less', 'least'
+    ]
+  }
+};
+
 export const STOPLIST_INFO = {
   description: "The Default stoplist combines curated function words with automatic high-frequency detection using Zipf's law. In Fusion mode, the curated stoplist also plays a key role in scoring: it identifies function-word matches so they can be ranked below content-word matches.",
 
@@ -5,29 +81,18 @@ export const STOPLIST_INFO = {
     "Curated words: Pronouns, articles, conjunctions, prepositions, common verbs",
     "Zipf detection: Automatically identifies 10-50 additional high-frequency words from your selected texts",
     "The two lists are combined to filter out noise while preserving meaningful vocabulary",
-    "In Fusion mode: the curated list is used in the scoring layer to penalize function-word-only matches (e.g., sharing only tum + nec) while preserving content-word matches (e.g., pectore + curas)"
+    "In Fusion mode: the curated list is used in the scoring layer to penalize function-word-only matches (e.g., sharing tum + nec) while preserving content-word matches (e.g., pectore + curas)"
   ],
-  
-  latin: {
-    count: 66,
-    examples: ["et", "in", "est", "non", "ut", "cum", "qui", "quae", "que", "hic", "ille", "sum", "esse"]
-  },
-  
-  greek: {
-    count: 88,
-    examples: ["καί", "δέ", "τε", "γάρ", "μέν", "ὁ", "ἡ", "τό", "αὐτός", "οὗτος", "ἐγώ", "σύ", "εἰμί"]
-  },
-  
-  english: {
-    count: 60,
-    examples: ["the", "be", "to", "of", "and", "a", "in", "that", "have", "it", "thou", "thee", "thy", "hath"]
-  },
-  
+
+  latin: CURATED_STOPLISTS.latin,
+  greek: CURATED_STOPLISTS.greek,
+  english: CURATED_STOPLISTS.english,
+
   options: {
     default: "Uses curated stop words + Zipf elbow detection (recommended)",
     manual: "Enter a number (e.g., 50) to use only the top N most frequent words",
     disabled: "Enter -1 to disable stoplisting entirely (not recommended)"
   },
-  
+
   customStopwordsNote: "Use dictionary forms (lemmata): pietas not pietate, λόγος not λόγον, king not kings."
 };

--- a/docs/API.md
+++ b/docs/API.md
@@ -412,6 +412,22 @@ Get corpus statistics.
 
 ---
 
+### GET `/api/stoplists`
+Get the current curated stoplists used by the primary matcher and displayed on the Help page. The lists are de-duplicated for display and do not include text-specific Zipf additions.
+
+**Response:**
+```json
+{
+  "stoplists": {
+    "la": { "label": "Latin", "words": ["et", "in"], "count": 91 },
+    "grc": { "label": "Greek", "words": ["και", "δε"], "count": 195 },
+    "en": { "label": "English", "words": ["the", "be"], "count": 189 }
+  }
+}
+```
+
+---
+
 ### POST `/api/stoplist`
 Generate a stoplist for given texts.
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -94,3 +94,19 @@ def test_version_endpoint(app_instance):
         data = resp.get_json()
         assert "version" in data
         assert "last_updated" in data
+
+
+def test_curated_stoplists_endpoint(app_instance):
+    """The Help page receives the active primary matcher stoplists from the API."""
+    from backend.matcher import get_curated_stoplists
+
+    with app_instance.test_client() as client:
+        response = client.get("/api/stoplists")
+
+    assert response.status_code == 200
+    assert "no-store" in response.headers["Cache-Control"]
+    assert response.get_json() == {"stoplists": get_curated_stoplists()}
+
+    for stoplist in response.get_json()["stoplists"].values():
+        assert stoplist["count"] == len(stoplist["words"])
+        assert len(stoplist["words"]) == len(set(stoplist["words"]))


### PR DESCRIPTION
Synchronizes the Help & Support stoplist display with the backend matcher’s curated stoplists.

  - Adds GET /api/stoplists for the current Latin, Greek, and English matcher lists.
  - Updates Help & Support to load stoplists from the API instead of a duplicated frontend copy.
  - Keeps specialized rare-bigram and cross-lingual stoplists unchanged.
  - Documents the new endpoint and adds endpoint coverage.