### PR TITLE
Fix CSV export and distribution chart to use fused_score (not the saturating pre-fusion score)

### DIFF
--- a/client/src/components/search/SearchResults.jsx
+++ b/client/src/components/search/SearchResults.jsx
@@ -103,7 +103,7 @@ const SearchResults = ({
         highlightMatchedWords(sourceText, mw, 'source'),
         r.target_locus || r.target?.ref || '',
         highlightMatchedWords(targetText, mw, 'target'),
-        (r.score ?? r.overall_score)?.toFixed(3) || '',
+        (r.fused_score ?? r.score ?? r.overall_score)?.toFixed(3) || '',
         mw.map(w => typeof w === 'object' ? (w.lemma || w.word || '') : w).join('; '),
         (r.channels || []).join('; ')
       ];
@@ -156,7 +156,7 @@ const SearchResults = ({
         bookData[bookLabel] = { count: 0, totalScore: 0 };
       }
       bookData[bookLabel].count++;
-      bookData[bookLabel].totalScore += (r.score ?? r.overall_score ?? 0);
+      bookData[bookLabel].totalScore += (r.fused_score ?? r.score ?? r.overall_score ?? 0);
     });
 
     const sortedBooks = Object.keys(bookData).sort((a, b) => {


### PR DESCRIPTION
## Problem
A user (running Thebaid 11 × Psychomachia) reported that a result showing **27.93** on the site exported to CSV as **1.427**, and that the **top 60 results all exported as 1.427** — so the exported scores neither match the website nor distinguish the top hits.

## Cause
The on-screen results rank and display `fused_score` (`SearchResults.jsx:610`) — the full fusion score with IDF rarity, channel weights, and the convergence bonus. But the **CSV export** (`:106`) and the **score-distribution chart** (`:159`) used `r.score ?? r.overall_score`, the *pre-fusion* per-pair score. That field is bounded and saturates near its max for strong matches, which is why 60 top results all read 1.427.

## Fix
Both spots now prefer `fused_score` (`r.fused_score ?? r.score ?? r.overall_score`), matching the on-screen ranking. Two one-line changes; frontend builds clean. Source-only, so deploy rebuilds `dist/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)