### PR TITLE
Feature/rare words pagination

### DIFF
--- a/backend/blueprints/corpus.py
+++ b/backend/blueprints/corpus.py
@@ -23,6 +23,8 @@ from backend.frequency_cache import get_corpus_frequencies, recalculate_language
 logger = get_logger('corpus')
 
 AUTHOR_DATES_FILE = Path(__file__).parent.parent / "author_dates.json"
+TEXT_SOURCES_FILE = Path(__file__).parent.parent / "text_sources.json"
+TEXT_CREDITS_PAGE_SIZES = {25, 50, 100, 500}
 
 _author_dates_cache = None
 _author_dates_mtime = None
@@ -159,16 +161,39 @@ def get_provenance():
 
 @corpus_bp.route('/text-credits')
 def get_text_credits():
-    """Get text credits and provenance information from static JSON data file."""
-    text_sources_file = Path(__file__).parent.parent / "text_sources.json"
-    if text_sources_file.exists():
-        with open(text_sources_file, 'r', encoding='utf-8') as f:
+    """Get a filtered page of text credits from the static provenance data."""
+    try:
+        offset = int(request.args.get('offset', 0))
+        limit = int(request.args.get('limit', 50))
+    except (TypeError, ValueError):
+        return jsonify({'error': 'offset and limit must be integers'}), 400
+
+    if offset < 0:
+        return jsonify({'error': 'offset must be zero or greater'}), 400
+    if limit not in TEXT_CREDITS_PAGE_SIZES:
+        return jsonify({'error': 'limit must be one of 25, 50, 100, or 500'}), 400
+
+    query = request.args.get('query', '').strip().casefold()
+    if TEXT_SOURCES_FILE.exists():
+        with open(TEXT_SOURCES_FILE, 'r', encoding='utf-8') as f:
             sources = json.load(f)
     else:
-        import logging
-        logging.getLogger('tesserae.app').warning(f"text_sources.json not found at {text_sources_file}")
+        logger.warning("text_sources.json not found at %s", TEXT_SOURCES_FILE)
         sources = []
-    return jsonify(sources)
+
+    if query:
+        sources = [
+            entry for entry in sources
+            if query in entry.get('author', '').casefold()
+            or query in entry.get('work', '').casefold()
+        ]
+
+    return jsonify({
+        'entries': sources[offset:offset + limit],
+        'total': len(sources),
+        'offset': offset,
+        'limit': limit,
+    })
 
 
 @corpus_bp.route('/texts/hierarchy')

--- a/backend/blueprints/hapax.py
+++ b/backend/blueprints/hapax.py
@@ -24,8 +24,10 @@ Uses:
 # =============================================================================
 # IMPORTS
 # =============================================================================
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, Response, jsonify, request
 from flask_login import current_user
+import csv
+import io
 import os
 import json
 import unicodedata
@@ -1466,6 +1468,88 @@ def regenerate_rare_words_cache(language):
     return True
 
 
+RARE_LEMMATA_PAGE_SIZES = {25, 50, 100, 500}
+RARE_LEMMATA_SORT_FIELDS = {'frequency', 'lemma', 'author'}
+RARE_LEMMATA_SORT_ORDERS = {'asc', 'desc'}
+
+
+def _get_rare_lemmata_matching(language, max_occ):
+    """Load and filter the cached rare-word records for an Explorer request."""
+    cached = load_rare_words_cache(language)
+    if not cached:
+        logger.info(f"Rare-words cache missing for {language}, regenerating lazily")
+        try:
+            if regenerate_rare_words_cache(language):
+                cached = load_rare_words_cache(language)
+        except Exception as e:
+            logger.error(f"Lazy cache regeneration failed for {language}: {e}")
+
+    if not cached:
+        return None
+
+    return [word for word in cached.get('words', []) if word['count'] <= max_occ]
+
+
+def _rare_lemmata_sort_key(word, sort_by):
+    lemma = word.get('display', word.get('lemma', '')).lstrip('*').casefold()
+    if sort_by == 'frequency':
+        return (word.get('count', 0), lemma)
+    if sort_by == 'author':
+        return (word.get('first_author', '').casefold(), lemma)
+    return (lemma,)
+
+
+def _format_rare_lemma(word):
+    """Return the public Explorer representation of a cached rare word."""
+    display = word.get('display', word.get('lemma', ''))
+    if display.startswith('*'):
+        display = display[1:]
+    return {
+        'lemma': unicodedata.normalize('NFC', display),
+        'count': word['count'],
+        'first_author': word.get('first_author', ''),
+        'first_work': word.get('first_work', ''),
+        'first_locus': word.get('first_locus', ''),
+        'text_id': word.get('text_id', '')
+    }
+
+
+def _parse_rare_lemmata_params(require_paging=True):
+    """Parse and validate the shared Rare Words Explorer query parameters."""
+    language = request.args.get('language', 'la')
+    try:
+        max_occ = int(request.args.get('max_occurrences', 10))
+    except (TypeError, ValueError):
+        return None, jsonify({'error': 'max_occurrences must be an integer'}), 400
+
+    sort_by = request.args.get('sort_by', 'frequency')
+    sort_order = request.args.get('sort_order', 'asc')
+    if sort_by not in RARE_LEMMATA_SORT_FIELDS:
+        return None, jsonify({'error': 'sort_by must be frequency, lemma, or author'}), 400
+    if sort_order not in RARE_LEMMATA_SORT_ORDERS:
+        return None, jsonify({'error': 'sort_order must be asc or desc'}), 400
+
+    params = {
+        'language': language,
+        'max_occ': max_occ,
+        'sort_by': sort_by,
+        'sort_order': sort_order,
+    }
+    if require_paging:
+        try:
+            offset = int(request.args.get('offset', 0))
+            limit = int(request.args.get('limit', 50))
+        except (TypeError, ValueError):
+            return None, jsonify({'error': 'offset and limit must be integers'}), 400
+        if offset < 0:
+            return None, jsonify({'error': 'offset must be zero or greater'}), 400
+        if limit not in RARE_LEMMATA_PAGE_SIZES:
+            return None, jsonify({'error': 'limit must be one of 25, 50, 100, or 500'}), 400
+        params.update({'offset': offset, 'limit': limit})
+
+    return params, None, None
+
+
 @hapax_bp.route('/rare-lemmata-full', methods=['GET'])
 def get_rare_lemmata_full():
     """
@@ -1475,66 +1559,42 @@ def get_rare_lemmata_full():
     Query params:
         language: 'la', 'grc', or 'en' (default: 'la')
         max_occurrences: max corpus frequency (default: 10)
-        limit: max number to return (default: 50000)
+        offset: zero-based result offset (default: 0)
+        limit: page size: 25, 50, 100, or 500 (default: 50)
+        sort_by: frequency, lemma, or author (default: frequency)
+        sort_order: asc or desc (default: asc)
     """
+    params, error_response, error_status = _parse_rare_lemmata_params()
+    if error_response:
+        return error_response, error_status
+
     try:
-        language = request.args.get('language', 'la')
-        max_occ = int(request.args.get('max_occurrences', 10))
-        limit = int(request.args.get('limit', 50000))
-        
-        # Load from pre-cached file for instant response.
-        # If the cache is missing for this language, regenerate it lazily —
-        # this is the bootstrap path for languages that have frequency data
-        # but no pre-built rare-words cache yet (e.g. when a language is added
-        # without rebuilding caches first). First request pays the build cost
-        # (~30–60s for typical corpora); subsequent requests are instant.
-        cached = load_rare_words_cache(language)
-        if not cached:
-            logger.info(f"Rare-words cache missing for {language}, regenerating lazily")
-            try:
-                built = regenerate_rare_words_cache(language)
-                if built:
-                    cached = load_rare_words_cache(language)
-            except Exception as e:
-                logger.error(f"Lazy cache regeneration failed for {language}: {e}")
-        if not cached:
+        matching = _get_rare_lemmata_matching(params['language'], params['max_occ'])
+        if matching is None:
             return jsonify({
-                'language': language,
+                'language': params['language'],
                 'total': 0,
-                'max_occurrences': max_occ,
+                'max_occurrences': params['max_occ'],
+                'offset': params['offset'],
+                'limit': params['limit'],
                 'words': [],
                 'error': 'Cache not available and could not be regenerated. '
                          'Check that frequency data exists for this language.'
             })
-        
-        # Filter by max_occurrences
-        all_words = cached.get('words', [])
-        matching = [w for w in all_words if w['count'] <= max_occ]
-        filtered = matching[:limit]
-        
-        # Format response using pre-computed display forms
-        import unicodedata as _ucd
-        results = []
-        for w in filtered:
-            display = w.get('display', w.get('lemma', ''))
-            # Strip leading asterisks (denote reconstructed forms in linguistics)
-            if display.startswith('*'):
-                display = display[1:]
-            # Ensure proper NFC normalization for consistent browser rendering
-            display = _ucd.normalize('NFC', display)
-            results.append({
-                'lemma': display,
-                'count': w['count'],
-                'first_author': w.get('first_author', ''),
-                'first_work': w.get('first_work', ''),
-                'first_locus': w.get('first_locus', ''),
-                'text_id': w.get('text_id', '')
-            })
+
+        matching.sort(
+            key=lambda word: _rare_lemmata_sort_key(word, params['sort_by']),
+            reverse=params['sort_order'] == 'desc'
+        )
+        page = matching[params['offset']:params['offset'] + params['limit']]
+        results = [_format_rare_lemma(word) for word in page]
         
         response = jsonify({
-            'language': language,
-            'total': len(matching),  # Total matching, not limited
-            'max_occurrences': max_occ,
+            'language': params['language'],
+            'total': len(matching),
+            'max_occurrences': params['max_occ'],
+            'offset': params['offset'],
+            'limit': params['limit'],
             'words': results
         })
         response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
@@ -1542,6 +1602,42 @@ def get_rare_lemmata_full():
         
     except Exception as e:
         logger.error(f"Error in rare-lemmata-full: {e}")
+        return jsonify({'error': str(e)}), 500
+
+
+@hapax_bp.route('/rare-lemmata-full/export', methods=['GET'])
+def export_rare_lemmata_full():
+    """Download every matching Rare Words Explorer entry as a CSV file."""
+    params, error_response, error_status = _parse_rare_lemmata_params(require_paging=False)
+    if error_response:
+        return error_response, error_status
+
+    try:
+        matching = _get_rare_lemmata_matching(params['language'], params['max_occ'])
+        if matching is None:
+            return jsonify({'error': 'Rare words cache is not available'}), 503
+
+        matching.sort(
+            key=lambda word: _rare_lemmata_sort_key(word, params['sort_by']),
+            reverse=params['sort_order'] == 'desc'
+        )
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(['Lemma', 'Frequency', 'First Author', 'First Work', 'First Locus'])
+        for word in matching:
+            formatted = _format_rare_lemma(word)
+            writer.writerow([
+                formatted['lemma'], formatted['count'], formatted['first_author'],
+                formatted['first_work'], formatted['first_locus']
+            ])
+
+        response = Response(output.getvalue(), mimetype='text/csv')
+        response.headers['Content-Disposition'] = (
+            f"attachment; filename=rare_words_{params['language']}.csv"
+        )
+        return response
+    except Exception as e:
+        logger.error(f"Error exporting rare-lemmata-full: {e}")
         return jsonify({'error': str(e)}), 500
 
 

--- a/backend/blueprints/intertext.py
+++ b/backend/blueprints/intertext.py
@@ -2,7 +2,7 @@
 Intertext Repository Blueprint
 Handles saving, browsing, and exporting registered intertexts.
 """
-from flask import Blueprint, jsonify, request, session
+from flask import Blueprint, Response, jsonify, request, session
 from flask_login import current_user
 from datetime import datetime
 import json
@@ -16,6 +16,10 @@ logger = get_logger(__name__)
 
 intertext_bp = Blueprint('intertext', __name__, url_prefix='/intertexts')
 
+REPOSITORY_PAGE_SIZES = {25, 50, 100, 500}
+REPOSITORY_SORT_FIELDS = {'created_at', 'score', 'scholar_score'}
+REPOSITORY_SORT_ORDERS = {'asc', 'desc'}
+
 
 def _parse_json_list(raw_value):
     if not raw_value:
@@ -24,6 +28,102 @@ def _parse_json_list(raw_value):
         return json.loads(raw_value)
     except (TypeError, ValueError):
         return []
+
+
+def _parse_repository_list_params(include_visibility=False):
+    """Parse the shared pagination, filter, and sort query parameters."""
+    page = request.args.get('page', 1, type=int)
+    per_page = request.args.get('per_page', 50, type=int)
+    sort_by = request.args.get('sort_by', 'created_at')
+    sort_order = request.args.get('sort_order', 'desc')
+    source_language = request.args.get('source_language')
+
+    if not page or page < 1:
+        return None, ('page must be a positive integer', 400)
+    if per_page not in REPOSITORY_PAGE_SIZES:
+        return None, ('per_page must be one of 25, 50, 100, or 500', 400)
+    if sort_by not in REPOSITORY_SORT_FIELDS:
+        return None, ('sort_by must be created_at, score, or scholar_score', 400)
+    if sort_order not in REPOSITORY_SORT_ORDERS:
+        return None, ('sort_order must be asc or desc', 400)
+
+    params = {
+        'page': page,
+        'per_page': per_page,
+        'sort_by': sort_by,
+        'sort_order': sort_order,
+        'source_language': source_language,
+    }
+    if include_visibility:
+        visibility = request.args.get('visibility', 'all')
+        if visibility not in {'all', 'shared', 'private'}:
+            return None, ('visibility must be all, shared, or private', 400)
+        params['visibility'] = visibility
+
+    return params, None
+
+
+def _apply_repository_sort(query, model, sort_by, sort_order):
+    score_field = model.tesserae_score
+    rating_field = model.user_score if model is Intertext else model.intertext_score
+    field = {
+        'created_at': model.created_at,
+        'score': score_field,
+        'scholar_score': rating_field,
+    }[sort_by]
+    order = field.asc() if sort_order == 'asc' else field.desc()
+    return query.order_by(order, model.id.asc())
+
+
+def _apply_public_repository_filters(query, params):
+    status = request.args.get('status')
+    target_language = request.args.get('target_language')
+    tag = request.args.get('tag')
+    submitter_id = request.args.get('submitter_id')
+
+    if status:
+        query = query.filter(Intertext.status == status)
+    if params['source_language']:
+        query = query.filter(Intertext.source_language == params['source_language'])
+    if target_language:
+        query = query.filter(Intertext.target_language == target_language)
+    if tag:
+        query = query.filter(Intertext.tags.ilike(f'%{tag}%'))
+    if submitter_id:
+        query = query.filter(Intertext.submitter_id == submitter_id)
+    return query
+
+
+def _apply_saved_repository_filters(query, params):
+    if params['source_language']:
+        query = query.filter(SavedIntertext.source_language == params['source_language'])
+    if params['visibility'] == 'shared':
+        query = query.filter(SavedIntertext.shared_to_public.is_(True))
+    elif params['visibility'] == 'private':
+        query = query.filter(SavedIntertext.shared_to_public.is_(False))
+    return query
+
+
+def _repository_csv_response(items, is_public):
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(['Source', 'Target', 'Language', 'Match Score', 'Your Rating', 'Visibility', 'Notes', 'Created'])
+    for item in items:
+        writer.writerow([
+            item.source_reference or '',
+            item.target_reference or '',
+            item.source_language or '',
+            item.tesserae_score or '',
+            (item.user_score if is_public else item.intertext_score) or '',
+            'shared' if is_public or item.shared_to_public else 'private',
+            item.notes or '',
+            item.created_at.isoformat() if item.created_at else '',
+        ])
+    return Response(
+        output.getvalue(),
+        mimetype='text/csv',
+        headers={'Content-Disposition': 'attachment; filename=intertexts.csv'}
+    )
 
 
 def _serialize_public_intertext(it):
@@ -180,30 +280,17 @@ def _delete_public_copy(saved_it):
 @intertext_bp.route('', methods=['GET'])
 def list_intertexts():
     """List all intertexts with optional filtering"""
+    params, param_error = _parse_repository_list_params()
+    if param_error:
+        message, status_code = param_error
+        return jsonify({'error': message}), status_code
+
     try:
-        page = request.args.get('page', 1, type=int)
-        per_page = request.args.get('per_page', 50, type=int)
-        status = request.args.get('status', None)
-        source_language = request.args.get('source_language', None)
-        target_language = request.args.get('target_language', None)
-        tag = request.args.get('tag', None)
-        submitter_id = request.args.get('submitter_id', None)
-        
-        query = Intertext.query
-        
-        if status:
-            query = query.filter(Intertext.status == status)
-        if source_language:
-            query = query.filter(Intertext.source_language == source_language)
-        if target_language:
-            query = query.filter(Intertext.target_language == target_language)
-        if tag:
-            query = query.filter(Intertext.tags.ilike(f'%{tag}%'))
-        if submitter_id:
-            query = query.filter(Intertext.submitter_id == submitter_id)
-        
-        query = query.order_by(Intertext.created_at.desc())
-        pagination = query.paginate(page=page, per_page=per_page, error_out=False)
+        query = _apply_public_repository_filters(Intertext.query, params)
+        with_notes = query.filter(Intertext.notes.isnot(None), Intertext.notes != '').count()
+        pagination = _apply_repository_sort(
+            query, Intertext, params['sort_by'], params['sort_order']
+        ).paginate(page=params['page'], per_page=params['per_page'], error_out=False)
         
         intertexts = [_serialize_public_intertext(it) for it in pagination.items]
         
@@ -211,8 +298,12 @@ def list_intertexts():
             'intertexts': intertexts,
             'total': pagination.total,
             'pages': pagination.pages,
-            'current_page': page,
-            'per_page': per_page
+            'current_page': params['page'],
+            'per_page': params['per_page'],
+            'summary': {
+                'visible': pagination.total,
+                'with_notes': with_notes,
+            }
         })
     except Exception as e:
         logger.error(f"Failed to list intertexts: {e}")
@@ -421,41 +512,20 @@ def delete_intertext(intertext_id):
 @intertext_bp.route('/export', methods=['GET'])
 def export_intertexts():
     """Export intertexts to CSV or JSON"""
+    params, param_error = _parse_repository_list_params()
+    if param_error:
+        message, status_code = param_error
+        return jsonify({'error': message}), status_code
+
     try:
         format_type = request.args.get('format', 'json')
-        status = request.args.get('status', None)
-        
-        query = Intertext.query
-        if status:
-            query = query.filter(Intertext.status == status)
-        
-        intertexts = query.order_by(Intertext.created_at.desc()).all()
+        query = _apply_public_repository_filters(Intertext.query, params)
+        intertexts = _apply_repository_sort(
+            query, Intertext, params['sort_by'], params['sort_order']
+        ).all()
         
         if format_type == 'csv':
-            output = io.StringIO()
-            writer = csv.writer(output)
-            writer.writerow([
-                'id', 'source_text_id', 'source_author', 'source_work', 'source_reference', 'source_snippet', 'source_language',
-                'target_text_id', 'target_author', 'target_work', 'target_reference', 'target_snippet', 'target_language',
-                'matched_lemmas', 'matched_tokens', 'tesserae_score', 'user_score',
-                'notes', 'tags', 'status', 'created_at'
-            ])
-            
-            for it in intertexts:
-                writer.writerow([
-                    it.id, it.source_text_id, it.source_author, it.source_work, it.source_reference, it.source_snippet, it.source_language,
-                    it.target_text_id, it.target_author, it.target_work, it.target_reference, it.target_snippet, it.target_language,
-                    it.matched_lemmas, it.matched_tokens, it.tesserae_score, it.user_score,
-                    it.notes, it.tags, it.status, 
-                    it.created_at.isoformat() if it.created_at else ''
-                ])
-            
-            from flask import Response
-            return Response(
-                output.getvalue(),
-                mimetype='text/csv',
-                headers={'Content-Disposition': 'attachment; filename=intertexts.csv'}
-            )
+            return _repository_csv_response(intertexts, is_public=True)
         else:
             data = []
             for it in intertexts:
@@ -526,13 +596,24 @@ def list_my_intertexts():
     try:
         if not current_user.is_authenticated:
             return jsonify({'error': 'Login required'}), 401
-        
-        page = request.args.get('page', 1, type=int)
-        per_page = request.args.get('per_page', 50, type=int)
-        
-        query = SavedIntertext.query.filter(SavedIntertext.user_id == current_user.id)
-        query = query.order_by(SavedIntertext.created_at.desc())
-        pagination = query.paginate(page=page, per_page=per_page, error_out=False)
+
+        params, param_error = _parse_repository_list_params(include_visibility=True)
+        if param_error:
+            message, status_code = param_error
+            return jsonify({'error': message}), status_code
+
+        base_query = SavedIntertext.query.filter(SavedIntertext.user_id == current_user.id)
+        summary_query = base_query
+        if params['source_language']:
+            summary_query = summary_query.filter(SavedIntertext.source_language == params['source_language'])
+        summary = {
+            'saved': summary_query.count(),
+            'shared': summary_query.filter(SavedIntertext.shared_to_public.is_(True)).count(),
+        }
+        query = _apply_saved_repository_filters(base_query, params)
+        pagination = _apply_repository_sort(
+            query, SavedIntertext, params['sort_by'], params['sort_order']
+        ).paginate(page=params['page'], per_page=params['per_page'], error_out=False)
         
         intertexts = [_serialize_saved_intertext(it) for it in pagination.items]
         
@@ -540,10 +621,35 @@ def list_my_intertexts():
             'intertexts': intertexts,
             'total': pagination.total,
             'pages': pagination.pages,
-            'current_page': page
+            'current_page': params['page'],
+            'per_page': params['per_page'],
+            'summary': summary,
         })
     except Exception as e:
         logger.error(f"Failed to list personal intertexts: {e}")
+        return jsonify({'error': str(e)}), 500
+
+
+@intertext_bp.route('/my/export', methods=['GET'])
+def export_my_intertexts():
+    """Download every saved intertext matching the current Repository filters."""
+    if not current_user.is_authenticated:
+        return jsonify({'error': 'Login required'}), 401
+
+    params, param_error = _parse_repository_list_params(include_visibility=True)
+    if param_error:
+        message, status_code = param_error
+        return jsonify({'error': message}), status_code
+
+    try:
+        query = SavedIntertext.query.filter(SavedIntertext.user_id == current_user.id)
+        query = _apply_saved_repository_filters(query, params)
+        items = _apply_repository_sort(
+            query, SavedIntertext, params['sort_by'], params['sort_order']
+        ).all()
+        return _repository_csv_response(items, is_public=False)
+    except Exception as e:
+        logger.error(f"Failed to export personal intertexts: {e}")
         return jsonify({'error': str(e)}), 500
 
 

--- a/client/src/components/about/TextCredits.jsx
+++ b/client/src/components/about/TextCredits.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 const SOURCE_LINKS = {
   'The Latin Library': 'http://thelatinlibrary.com/',
@@ -18,27 +18,81 @@ function IntroLink({ name, url }) {
 }
 
 export default function TextCredits() {
-  const [data, setData] = useState(null);
+  const [entries, setEntries] = useState([]);
+  const [totalEntries, setTotalEntries] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState('');
   const [filter, setFilter] = useState('');
+  const [query, setQuery] = useState('');
+  const [pageSize, setPageSize] = useState(50);
+  const queryVersionRef = useRef(0);
 
   useEffect(() => {
-    fetch('/api/text-credits')
-      .then(res => res.json())
-      .then(d => { setData(d); setLoading(false); })
-      .catch(err => { setError(err.message); setLoading(false); });
-  }, []);
+    const timer = setTimeout(() => setQuery(filter), 250);
+    return () => clearTimeout(timer);
+  }, [filter]);
 
-  const filteredData = useMemo(() => {
-    if (!data) return [];
-    if (!filter.trim()) return data;
-    const q = filter.toLowerCase();
-    return data.filter(entry =>
-      entry.author.toLowerCase().includes(q) ||
-      entry.work.toLowerCase().includes(q)
-    );
-  }, [data, filter]);
+  useEffect(() => {
+    const controller = new AbortController();
+    const queryVersion = queryVersionRef.current + 1;
+    queryVersionRef.current = queryVersion;
+    setLoading(true);
+    setLoadingMore(false);
+    setError('');
+
+    const params = new URLSearchParams({
+      query,
+      offset: '0',
+      limit: String(pageSize),
+    });
+
+    fetch(`/api/text-credits?${params.toString()}`, { signal: controller.signal })
+      .then(async (res) => {
+        if (!res.ok) throw new Error('Failed to load sources');
+        return res.json();
+      })
+      .then((data) => {
+        if (queryVersionRef.current !== queryVersion) return;
+        setEntries(data.entries || []);
+        setTotalEntries(data.total || 0);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (err.name === 'AbortError' || queryVersionRef.current !== queryVersion) return;
+        setError('Failed to load sources. Please try again.');
+        setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [query, pageSize]);
+
+  const loadMore = async () => {
+    if (loading || loadingMore || entries.length >= totalEntries) return;
+
+    const queryVersion = queryVersionRef.current;
+    setLoadingMore(true);
+    setError('');
+    try {
+      const params = new URLSearchParams({
+        query,
+        offset: String(entries.length),
+        limit: String(pageSize),
+      });
+      const res = await fetch(`/api/text-credits?${params.toString()}`);
+      if (!res.ok) throw new Error('Failed to load more sources');
+      const data = await res.json();
+      if (queryVersionRef.current === queryVersion) {
+        setEntries(previousEntries => [...previousEntries, ...(data.entries || [])]);
+        setTotalEntries(data.total || 0);
+      }
+    } catch (err) {
+      if (queryVersionRef.current === queryVersion) {
+        setError('Failed to load more sources. Please try again.');
+      }
+    }
+    if (queryVersionRef.current === queryVersion) setLoadingMore(false);
+  };
 
   if (loading) {
     return (
@@ -49,7 +103,7 @@ export default function TextCredits() {
     );
   }
 
-  if (error) {
+  if (error && entries.length === 0) {
     return (
       <div className="bg-white rounded-lg shadow p-8">
         <p className="text-red-600">Failed to load sources: {error}</p>
@@ -75,7 +129,7 @@ export default function TextCredits() {
         original provenance of these texts, and reproduce citation where possible. This is a work in progress.
       </p>
 
-      <div className="mb-4">
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center">
         <input
           type="text"
           placeholder="Filter by author or work..."
@@ -83,10 +137,27 @@ export default function TextCredits() {
           onChange={(e) => setFilter(e.target.value)}
           className="w-full sm:w-80 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
         />
-        <span className="ml-3 text-sm text-gray-500">
-          {filteredData.length} {filteredData.length === 1 ? 'entry' : 'entries'}
+        <select
+          value={pageSize}
+          onChange={(e) => setPageSize(Number(e.target.value))}
+          aria-label="Entries at a time"
+          className="w-fit border border-gray-300 rounded-lg px-3 py-2 text-sm"
+        >
+          <option value="25">25 entries at a time</option>
+          <option value="50">50 entries at a time</option>
+          <option value="100">100 entries at a time</option>
+          <option value="500">500 entries at a time</option>
+        </select>
+        <span className="text-sm text-gray-500">
+          Showing {entries.length} of {totalEntries} {totalEntries === 1 ? 'entry' : 'entries'}
         </span>
       </div>
+
+      {error && (
+        <div className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {error}
+        </div>
+      )}
 
       <div className="overflow-x-auto border border-gray-200 rounded-lg">
         <table className="w-full text-sm min-w-[600px]">
@@ -100,7 +171,7 @@ export default function TextCredits() {
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100">
-            {filteredData.map((entry, idx) => (
+            {entries.map((entry, idx) => (
               <tr key={idx} className="hover:bg-gray-50">
                 <td className="px-2 sm:px-4 py-2 text-gray-900 font-medium whitespace-nowrap">{entry.author}</td>
                 <td className="px-2 sm:px-4 py-2 text-gray-700">{entry.work}</td>
@@ -122,7 +193,7 @@ export default function TextCredits() {
                 <td className="px-2 sm:px-4 py-2 text-gray-600 whitespace-nowrap">{entry.added_by}</td>
               </tr>
             ))}
-            {filteredData.length === 0 && (
+            {!loading && entries.length === 0 && (
               <tr>
                 <td colSpan={5} className="px-4 py-8 text-center text-gray-500">
                   No entries found matching your filter.
@@ -132,6 +203,18 @@ export default function TextCredits() {
           </tbody>
         </table>
       </div>
+      {entries.length < totalEntries && (
+        <div className="mt-4 text-center">
+          <button
+            type="button"
+            onClick={loadMore}
+            disabled={loadingMore}
+            className="rounded border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {loadingMore ? 'Loading…' : `Show More (${totalEntries - entries.length} remaining)`}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/components/corpus/RareWordsExplorer.jsx
+++ b/client/src/components/corpus/RareWordsExplorer.jsx
@@ -27,8 +27,12 @@ function extractLineNumber(ref) {
 export default function RareWordsExplorer() {
   const [language, setLanguage] = useState('la');
   const [words, setWords] = useState([]);
+  const [totalWords, setTotalWords] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [loadError, setLoadError] = useState('');
   const [maxOccurrences, setMaxOccurrences] = useState(3);
+  const [pageSize, setPageSize] = useState(50);
   const [sortBy, setSortBy] = useState('frequency');
   const [sortOrder, setSortOrder] = useState('asc');
   const [expandedWord, setExpandedWord] = useState(null);
@@ -42,6 +46,7 @@ export default function RareWordsExplorer() {
   const [viewerTitle, setViewerTitle] = useState('');
   const [viewerTargetRef, setViewerTargetRef] = useState('');
   const highlightedLineRef = useRef(null);
+  const queryVersionRef = useRef(0);
 
   const openTextViewer = async (textId, word, ref, author, work) => {
     setViewerWord(word);
@@ -82,31 +87,48 @@ export default function RareWordsExplorer() {
   ];
 
   useEffect(() => {
+    const controller = new AbortController();
     let cancelled = false;
-    const currentLang = language;  // Capture current language
-    setWords([]);  // Clear immediately when language changes
+    const queryVersion = queryVersionRef.current + 1;
+    queryVersionRef.current = queryVersion;
+
+    setWords([]);
+    setTotalWords(0);
     setLoading(true);
+    setLoadingMore(false);
+    setLoadError('');
     setExpandedWord(null);
     setExpandedDetails({});
     
     const fetchWords = async () => {
       try {
-        // Force fresh request with language in URL
-        const url = `/api/rare-lemmata-full?language=${currentLang}&max_occurrences=${maxOccurrences}&limit=50000&_t=${Date.now()}`;
+        const params = new URLSearchParams({
+          language,
+          max_occurrences: String(maxOccurrences),
+          limit: String(pageSize),
+          offset: '0',
+          sort_by: sortBy,
+          sort_order: sortOrder
+        });
+        const url = `/api/rare-lemmata-full?${params.toString()}`;
         const res = await fetch(url, {
           cache: 'no-store',
-          headers: { 'Cache-Control': 'no-cache' }
+          headers: { 'Cache-Control': 'no-cache' },
+          signal: controller.signal
         });
+        if (!res.ok) throw new Error('Failed to load rare words');
         const data = await res.json();
+        if (data.error) throw new Error(data.error);
         
-        // Only update if this request wasn't cancelled AND language still matches
-        if (!cancelled && data.language === currentLang && language === currentLang) {
+        if (!cancelled && queryVersionRef.current === queryVersion) {
           setWords(data.words || []);
+          setTotalWords(data.total || 0);
           setLoading(false);
         }
       } catch (err) {
-        console.error('Failed to load rare words:', err);
-        if (!cancelled) {
+        if (!cancelled && queryVersionRef.current === queryVersion && err.name !== 'AbortError') {
+          console.error('Failed to load rare words:', err);
+          setLoadError('Unable to load rare words. Please try again.');
           setLoading(false);
         }
       }
@@ -114,21 +136,45 @@ export default function RareWordsExplorer() {
     
     fetchWords();
     
-    return () => { cancelled = true; };
-  }, [language, maxOccurrences]);
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [language, maxOccurrences, pageSize, sortBy, sortOrder]);
 
-  const loadRareWords = async () => {
-    setLoading(true);
+  const loadMoreWords = async () => {
+    if (loadingMore || loading || words.length >= totalWords) return;
+
+    const queryVersion = queryVersionRef.current;
+    setLoadingMore(true);
+    setLoadError('');
     try {
-      const res = await fetch(`/api/rare-lemmata-full?language=${language}&max_occurrences=${maxOccurrences}&limit=10000&_t=${Date.now()}`);
+      const params = new URLSearchParams({
+        language,
+        max_occurrences: String(maxOccurrences),
+        limit: String(pageSize),
+        offset: String(words.length),
+        sort_by: sortBy,
+        sort_order: sortOrder
+      });
+      const res = await fetch(`/api/rare-lemmata-full?${params.toString()}`, {
+        cache: 'no-store',
+        headers: { 'Cache-Control': 'no-cache' }
+      });
+      if (!res.ok) throw new Error('Failed to load more rare words');
       const data = await res.json();
-      if (data.language === language) {
-        setWords(data.words || []);
+      if (data.error) throw new Error(data.error);
+      if (queryVersionRef.current === queryVersion) {
+        setWords(prev => [...prev, ...(data.words || [])]);
+        setTotalWords(data.total || 0);
       }
     } catch (err) {
-      console.error('Failed to load rare words:', err);
+      console.error('Failed to load more rare words:', err);
+      if (queryVersionRef.current === queryVersion) {
+        setLoadError('Unable to load more rare words. Please try again.');
+      }
     }
-    setLoading(false);
+    if (queryVersionRef.current === queryVersion) setLoadingMore(false);
   };
 
   const toggleWordExpand = async (lemma) => {
@@ -155,19 +201,6 @@ export default function RareWordsExplorer() {
     }
   };
 
-  const sortedWords = [...words].sort((a, b) => {
-    let cmp = 0;
-    if (sortBy === 'frequency') {
-      cmp = (a.count || 0) - (b.count || 0);
-    } else if (sortBy === 'lemma') {
-      // Case-insensitive sort for Greek/Latin
-      cmp = (a.lemma || '').toLowerCase().localeCompare((b.lemma || '').toLowerCase());
-    } else if (sortBy === 'author') {
-      cmp = (a.first_author || '').localeCompare(b.first_author || '');
-    }
-    return sortOrder === 'asc' ? cmp : -cmp;
-  });
-
   const handleSort = (field) => {
     if (sortBy === field) {
       setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
@@ -178,22 +211,16 @@ export default function RareWordsExplorer() {
   };
 
   const exportCSV = useCallback(() => {
-    const headers = ['Lemma', 'Frequency', 'First Author', 'First Work'];
-    const rows = words.map(w => [
-      w.lemma,
-      w.count,
-      w.first_author || '',
-      w.first_work || ''
-    ]);
-    const csv = [headers, ...rows].map(row => row.map(cell => `"${cell}"`).join(',')).join('\n');
-    const blob = new Blob([csv], { type: 'text/csv' });
-    const url = URL.createObjectURL(blob);
+    const params = new URLSearchParams({
+      language,
+      max_occurrences: String(maxOccurrences),
+      sort_by: sortBy,
+      sort_order: sortOrder
+    });
     const a = document.createElement('a');
-    a.href = url;
-    a.download = `rare_words_${language}.csv`;
+    a.href = `/api/rare-lemmata-full/export?${params.toString()}`;
     a.click();
-    URL.revokeObjectURL(url);
-  }, [words, language]);
+  }, [language, maxOccurrences, sortBy, sortOrder]);
 
   const getLanguageName = (lang) => {
     const names = { la: 'Latin', grc: 'Greek', en: 'English' };
@@ -211,7 +238,7 @@ export default function RareWordsExplorer() {
         {languageTabs.map(tab => (
           <button
             key={tab.code}
-            onClick={() => { setLanguage(tab.code); setWords([]); setExpandedWord(null); setExpandedDetails({}); }}
+            onClick={() => setLanguage(tab.code)}
             className={`px-4 py-2 text-sm font-medium whitespace-nowrap ${
               language === tab.code 
                 ? 'text-red-700 border-b-2 border-red-700' 
@@ -232,7 +259,7 @@ export default function RareWordsExplorer() {
             Find rare vocabulary across the corpus
           </p>
         </div>
-        <div className="flex gap-3">
+        <div className="flex flex-wrap gap-3">
           <select
             value={maxOccurrences}
             onChange={e => setMaxOccurrences(parseInt(e.target.value))}
@@ -243,6 +270,17 @@ export default function RareWordsExplorer() {
             <option value="3">Up to 3 occurrences</option>
             <option value="5">Up to 5 occurrences</option>
             <option value="10">Up to 10 occurrences</option>
+          </select>
+          <select
+            value={pageSize}
+            onChange={e => setPageSize(parseInt(e.target.value))}
+            aria-label="Words at a time"
+            className="border rounded px-3 py-2 text-sm"
+          >
+            <option value="25">25 words at a time</option>
+            <option value="50">50 words at a time</option>
+            <option value="100">100 words at a time</option>
+            <option value="500">500 words at a time</option>
           </select>
           <button
             onClick={exportCSV}
@@ -257,6 +295,11 @@ export default function RareWordsExplorer() {
         <LoadingSpinner text="Loading rare words..." />
       ) : (
         <div className="bg-white border rounded-lg">
+          {loadError && (
+            <div className="m-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              {loadError}
+            </div>
+          )}
           <div className="overflow-x-auto">
           <table className="w-full">
             <thead className="bg-gray-50">
@@ -285,7 +328,7 @@ export default function RareWordsExplorer() {
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200">
-              {sortedWords.map(word => (
+              {words.map(word => (
                 <>
                   <tr
                     key={word.lemma}
@@ -374,8 +417,19 @@ export default function RareWordsExplorer() {
           </table>
           </div>
           <div className="px-4 py-3 bg-gray-50 text-sm text-gray-500">
-            Showing {sortedWords.length} words
+            Showing {words.length} of {totalWords} words
           </div>
+          {words.length < totalWords && (
+            <div className="px-4 pb-4 bg-gray-50 text-center">
+              <button
+                onClick={loadMoreWords}
+                disabled={loadingMore}
+                className="px-3 py-2 bg-white text-amber-700 border border-amber-200 rounded hover:bg-amber-50 text-sm disabled:opacity-50"
+              >
+                {loadingMore ? 'Loading...' : `Show more (${totalWords - words.length} remaining)`}
+              </button>
+            </div>
+          )}
         </div>
       )}
 

--- a/client/src/components/repository/Repository.jsx
+++ b/client/src/components/repository/Repository.jsx
@@ -122,7 +122,13 @@ export default function Repository({ user, isAdmin = false }) {
   const [filter, setFilter] = useState({ language: 'all', status: 'all' });
   const [sortBy, setSortBy] = useState('created_at');
   const [sortOrder, setSortOrder] = useState('desc');
-  const [displayLimit, setDisplayLimit] = useState(50);
+  const [pageSize, setPageSize] = useState(50);
+  const [publicTotal, setPublicTotal] = useState(0);
+  const [myTotal, setMyTotal] = useState(0);
+  const [publicSummary, setPublicSummary] = useState({ visible: 0, with_notes: 0 });
+  const [mySummary, setMySummary] = useState({ saved: 0, shared: 0 });
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [loadError, setLoadError] = useState('');
   const [viewMode, setViewMode] = useState(user ? 'my' : 'public');
   const [publicIntertexts, setPublicIntertexts] = useState([]);
   const [myIntertexts, setMyIntertexts] = useState([]);
@@ -157,6 +163,7 @@ export default function Repository({ user, isAdmin = false }) {
   const [expandedAuthors, setExpandedAuthors] = useState({});
   const [expandedWorks, setExpandedWorks] = useState({});
   const [expandedFormsCache, setExpandedFormsCache] = useState({});
+  const expandedFormsCacheRef = useRef({});
 
   const loadExpandedFormsForItems = useCallback(async (items) => {
     const uniqueLemmaSets = new Map();
@@ -171,7 +178,7 @@ export default function Repository({ user, isAdmin = false }) {
       }
     });
     
-    const newCache = { ...expandedFormsCache };
+    const newCache = { ...expandedFormsCacheRef.current };
     const keysToFetch = [...uniqueLemmaSets.keys()].filter(k => !newCache[k]);
     
     if (keysToFetch.length === 0) return;
@@ -193,59 +200,102 @@ export default function Repository({ user, isAdmin = false }) {
       }
     }
     
+    expandedFormsCacheRef.current = newCache;
     setExpandedFormsCache(newCache);
-  }, [expandedFormsCache]);
+  }, []);
 
-  const loadPublicIntertexts = useCallback(async () => {
-    setLoading(true);
+  const buildRepositoryParams = useCallback((page) => {
+    const params = new URLSearchParams({
+      page: String(page),
+      per_page: String(pageSize),
+      sort_by: sortBy,
+      sort_order: sortOrder,
+    });
+    if (filter.language !== 'all') params.set('source_language', filter.language);
+    return params;
+  }, [filter.language, pageSize, sortBy, sortOrder]);
+
+  const loadPublicIntertexts = useCallback(async ({ page = 1, append = false } = {}) => {
+    if (append) setLoadingMore(true);
+    else {
+      setLoading(true);
+      setLoadError('');
+    }
     try {
-      const res = await fetch('/api/intertexts', { credentials: 'include' });
-      if (!res.ok) {
-        throw new Error('Failed to load public repository');
-      }
+      const params = buildRepositoryParams(page);
+      const res = await fetch(`/api/intertexts?${params.toString()}`, { credentials: 'include' });
+      if (!res.ok) throw new Error('Failed to load public repository');
       const data = await res.json();
       const items = (data.intertexts || []).map((item) => normalizeRepositoryItem(item, { publicEntry: true }));
-      setPublicIntertexts(items);
+      setPublicIntertexts(previous => append ? [...previous, ...items] : items);
+      setPublicTotal(data.total || 0);
+      setPublicSummary(data.summary || { visible: data.total || 0, with_notes: 0 });
       await loadExpandedFormsForItems(items);
     } catch (err) {
       console.error('Failed to load public intertexts:', err);
+      setLoadError('Unable to load the public repository. Please try again.');
     } finally {
-      setLoading(false);
+      if (append) setLoadingMore(false);
+      else setLoading(false);
     }
-  }, [loadExpandedFormsForItems]);
+  }, [buildRepositoryParams, loadExpandedFormsForItems]);
 
-  const loadMyIntertexts = useCallback(async () => {
-    setLoading(true);
+  const loadMyIntertexts = useCallback(async ({ page = 1, append = false } = {}) => {
+    if (!user) return;
+    if (append) setLoadingMore(true);
+    else {
+      setLoading(true);
+      setLoadError('');
+    }
     try {
-      const res = await fetch('/api/intertexts/my', { credentials: 'include' });
-      if (!res.ok) {
-        throw new Error('Failed to load repository');
-      }
+      const params = buildRepositoryParams(page);
+      params.set('visibility', filter.status);
+      const res = await fetch(`/api/intertexts/my?${params.toString()}`, { credentials: 'include' });
+      if (!res.ok) throw new Error('Failed to load repository');
       const data = await res.json();
       const items = (data.intertexts || []).map((item) => normalizeRepositoryItem(item));
-      setMyIntertexts(items);
+      setMyIntertexts(previous => append ? [...previous, ...items] : items);
+      setMyTotal(data.total || 0);
+      setMySummary(data.summary || { saved: data.total || 0, shared: 0 });
       await loadExpandedFormsForItems(items);
     } catch (err) {
       console.error('Failed to load my intertexts:', err);
+      setLoadError('Unable to load your saved intertexts. Please try again.');
     } finally {
-      setLoading(false);
+      if (append) setLoadingMore(false);
+      else setLoading(false);
     }
-  }, [loadExpandedFormsForItems]);
+  }, [buildRepositoryParams, filter.status, loadExpandedFormsForItems, user]);
 
   useEffect(() => {
-    loadPublicIntertexts();
-  }, [loadPublicIntertexts]);
+    if (viewMode === 'public') loadPublicIntertexts();
+  }, [viewMode, loadPublicIntertexts]);
 
   useEffect(() => {
-    if (user) {
+    if (user && viewMode !== 'public') {
       loadMyIntertexts();
       return;
     }
-    setMyIntertexts([]);
-    if (viewMode !== 'public') {
-      setViewMode('public');
+    if (!user) {
+      setMyIntertexts([]);
+      setMyTotal(0);
+      setMySummary({ saved: 0, shared: 0 });
+      if (viewMode !== 'public') setViewMode('public');
     }
   }, [user, viewMode, loadMyIntertexts]);
+
+  const loadMoreIntertexts = () => {
+    if (loading || loadingMore) return;
+    if (viewMode === 'public') {
+      if (publicIntertexts.length < publicTotal) {
+        loadPublicIntertexts({ page: Math.floor(publicIntertexts.length / pageSize) + 1, append: true });
+      }
+      return;
+    }
+    if (viewMode === 'my' && myIntertexts.length < myTotal) {
+      loadMyIntertexts({ page: Math.floor(myIntertexts.length / pageSize) + 1, append: true });
+    }
+  };
 
   const getFormsForItem = (item) => {
     const lemmas = item.matched_lemmas || [];
@@ -451,13 +501,13 @@ export default function Repository({ user, isAdmin = false }) {
     return sortOrder === 'desc' ? -cmp : cmp;
   });
   const personalStats = {
-    total: myIntertexts.length,
-    shared: myIntertexts.filter((item) => item.is_public).length,
+    total: mySummary.saved,
+    shared: mySummary.shared,
   };
 
   const publicStats = {
-    total: publicIntertexts.length,
-    withNotes: publicIntertexts.filter((item) => item.notes).length,
+    total: publicSummary.visible,
+    withNotes: publicSummary.with_notes,
   };
 
   const groupedByWork = (() => {
@@ -488,26 +538,14 @@ export default function Repository({ user, isAdmin = false }) {
   const langNames = { la: 'Latin', grc: 'Greek', en: 'English', cross: 'Greek-Latin' };
 
   const exportCSV = useCallback(() => {
-    const headers = ['Source', 'Target', 'Language', 'Match Score', 'Your Rating', 'Visibility', 'Notes', 'Created'];
-    const rows = sortedIntertexts.map(item => [
-      item.source_locus || '',
-      item.target_locus || '',
-      item.language || '',
-      item.score || '',
-      item.scholar_score || '',
-      item.is_public ? 'shared' : 'private',
-      (item.notes || '').replace(/"/g, '""'),
-      item.created_at || ''
-    ]);
-    const csv = [headers, ...rows].map(row => row.map(cell => `"${cell}"`).join(',')).join('\n');
-    const blob = new Blob([csv], { type: 'text/csv' });
-    const url = URL.createObjectURL(blob);
+    const params = buildRepositoryParams(1);
+    const isPersonalExport = !isPublicView;
+    if (isPersonalExport) params.set('visibility', filter.status);
+    else params.set('format', 'csv');
     const a = document.createElement('a');
-    a.href = url;
-    a.download = 'intertexts.csv';
+    a.href = `${isPersonalExport ? '/api/intertexts/my/export' : '/api/intertexts/export'}?${params.toString()}`;
     a.click();
-    URL.revokeObjectURL(url);
-  }, [sortedIntertexts]);
+  }, [buildRepositoryParams, filter.status, isPublicView]);
 
   const StarRating = ({ value, onChange, readOnly }) => (
     <div className="flex gap-0.5">
@@ -625,6 +663,19 @@ export default function Repository({ user, isAdmin = false }) {
               <option value="score">Match Score</option>
               <option value="scholar_score">Your Rating</option>
             </select>
+            {viewMode !== 'byWork' && (
+              <select
+                value={pageSize}
+                onChange={e => setPageSize(parseInt(e.target.value))}
+                aria-label="Intertexts at a time"
+                className="border rounded px-3 py-2 text-sm"
+              >
+                <option value="25">25 at a time</option>
+                <option value="50">50 at a time</option>
+                <option value="100">100 at a time</option>
+                <option value="500">500 at a time</option>
+              </select>
+            )}
             <button
               onClick={exportCSV}
               className="px-3 py-2 bg-gray-100 text-gray-700 border rounded hover:bg-gray-200 text-sm"
@@ -650,6 +701,12 @@ export default function Repository({ user, isAdmin = false }) {
           </div>
         </div>
       </div>
+
+      {loadError && (
+        <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {loadError}
+        </div>
+      )}
 
       {filteredIntertexts.length === 0 ? (
         <div className="bg-white rounded-lg shadow p-8 text-center text-gray-500">
@@ -767,7 +824,7 @@ export default function Repository({ user, isAdmin = false }) {
       ) : (
         <div className="bg-white rounded-lg shadow overflow-hidden">
           <div className="divide-y divide-gray-200">
-            {sortedIntertexts.slice(0, displayLimit).map((item, i) => (
+            {sortedIntertexts.map((item, i) => (
               <div key={item.id || i} className="p-4 hover:bg-gray-50">
                 {(() => {
                   const canDeletePublicItem = isPublicView && user && (isAdmin || (item.submitter_id && String(item.submitter_id) === String(user.id)));
@@ -923,16 +980,22 @@ export default function Repository({ user, isAdmin = false }) {
               </div>
             ))}
           </div>
-          {sortedIntertexts.length > displayLimit && (
+          {sortedIntertexts.length < (isPublicView ? publicTotal : myTotal) && (
             <div className="px-4 py-3 bg-gray-50 text-center">
               <button
-                onClick={() => setDisplayLimit(displayLimit + 50)}
-                className="text-amber-600 hover:text-amber-800 text-sm"
+                onClick={loadMoreIntertexts}
+                disabled={loadingMore}
+                className="text-amber-600 hover:text-amber-800 text-sm disabled:opacity-50"
               >
-                Show more ({displayLimit} of {sortedIntertexts.length})
+                {loadingMore
+                  ? 'Loading...'
+                  : `Show more (${(isPublicView ? publicTotal : myTotal) - sortedIntertexts.length} remaining)`}
               </button>
             </div>
           )}
+          <div className="px-4 py-3 bg-gray-50 text-sm text-gray-500">
+            Showing {sortedIntertexts.length} of {isPublicView ? publicTotal : myTotal} intertexts
+          </div>
         </div>
       )}
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -146,14 +146,23 @@ Find unique word pairs shared between texts.
 
 ---
 
-### GET `/api/rare-lemmata`
-Get rare vocabulary for a specific text.
+### GET `/api/rare-lemmata-full`
+Browse rare vocabulary across a corpus language in pages.
 
 **Query Parameters:**
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| text_id | string | Text ID to analyze |
-| max_frequency | int | Maximum corpus frequency (default: 10) |
+| language | string | `la`, `grc`, or `en` (default: `la`) |
+| max_occurrences | int | Maximum corpus frequency (default: 10) |
+| offset | int | Zero-based result offset (default: 0) |
+| limit | int | Page size: `25`, `50`, `100`, or `500` (default: 50) |
+| sort_by | string | `frequency`, `lemma`, or `author` (default: `frequency`) |
+| sort_order | string | `asc` or `desc` (default: `asc`) |
+
+The response includes the requested `words` page and the total number of matching words.
+
+### GET `/api/rare-lemmata-full/export`
+Download all rare words matching the language, frequency, and sorting parameters as a CSV file. It accepts `language`, `max_occurrences`, `sort_by`, and `sort_order`; pagination parameters do not apply.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -241,8 +241,12 @@ List public intertexts from the repository.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | page | int | Page number (default: 1) |
-| per_page | int | Results per page (default: 20) |
-| language | string | Filter by language |
+| per_page | int | Results per page: `25`, `50`, `100`, or `500` (default: 50) |
+| source_language | string | Filter by source language |
+| sort_by | string | `created_at`, `score`, or `scholar_score` (default: `created_at`) |
+| sort_order | string | `asc` or `desc` (default: `desc`) |
+
+The response includes `total`, page metadata, and a `summary` for repository counts.
 
 ---
 
@@ -267,7 +271,7 @@ Create a new intertext entry.
 ---
 
 ### GET `/api/intertexts/my`
-Get current user's saved intertexts. Requires authentication.
+Get current user's saved intertexts. Requires authentication. It accepts the same paging, source-language, and sorting parameters as the public list, plus `visibility` (`all`, `shared`, or `private`).
 
 ---
 
@@ -278,7 +282,12 @@ Export intertexts as CSV.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | format | string | Export format: csv |
-| user_id | string | Filter by user (optional) |
+| source_language | string | Filter by source language |
+| sort_by | string | `created_at`, `score`, or `scholar_score` |
+| sort_order | string | `asc` or `desc` |
+
+### GET `/api/intertexts/my/export`
+Export all of the current user's matching saved intertexts as CSV. Requires authentication and accepts `source_language`, `visibility`, `sort_by`, and `sort_order`.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -191,6 +191,18 @@ List all texts in the corpus.
 }
 ```
 
+### GET `/api/text-credits`
+Browse the source credits for corpus texts in pages.
+
+**Query Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| query | string | Case-insensitive author or work filter (default: empty) |
+| offset | int | Zero-based result offset (default: 0) |
+| limit | int | Page size: `25`, `50`, `100`, or `500` (default: `50`) |
+
+The response contains the requested `entries` page plus `total`, `offset`, and `limit` metadata.
+
 ---
 
 ### GET `/api/authors`

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -367,6 +367,44 @@ def test_rare_lemmata(client):
     assert 'total_rare_words' in res
 
 
+def test_rare_lemmata_full_pagination_and_export(client, monkeypatch):
+    from backend.blueprints import hapax
+
+    cached_words = [
+        {'lemma': 'zeta', 'display': 'zeta', 'count': 3, 'first_author': 'Virgil', 'first_work': 'Aeneid'},
+        {'lemma': 'alpha', 'display': 'alpha', 'count': 1, 'first_author': 'Homer', 'first_work': 'Iliad'},
+        {'lemma': 'beta', 'display': 'beta', 'count': 2, 'first_author': 'Cicero', 'first_work': 'Orations'},
+    ]
+    monkeypatch.setattr(hapax, 'load_rare_words_cache', lambda _language: {'words': cached_words})
+
+    first_page = check_json(client.get(
+        '/api/rare-lemmata-full?language=la&max_occurrences=3&limit=25&sort_by=frequency&sort_order=asc'
+    ))
+    assert first_page['total'] == 3
+    assert first_page['offset'] == 0
+    assert first_page['limit'] == 25
+    assert [word['lemma'] for word in first_page['words']] == ['alpha', 'beta', 'zeta']
+
+    offset_page = check_json(client.get(
+        '/api/rare-lemmata-full?language=la&max_occurrences=3&offset=1&limit=25&sort_by=frequency&sort_order=asc'
+    ))
+    assert [word['lemma'] for word in offset_page['words']] == ['beta', 'zeta']
+
+    author_sorted = check_json(client.get(
+        '/api/rare-lemmata-full?language=la&max_occurrences=3&limit=25&sort_by=author&sort_order=desc'
+    ))
+    assert [word['first_author'] for word in author_sorted['words']] == ['Virgil', 'Homer', 'Cicero']
+
+    invalid_limit = client.get('/api/rare-lemmata-full?limit=10')
+    assert invalid_limit.status_code == 400
+
+    export = client.get('/api/rare-lemmata-full/export?language=la&max_occurrences=3&sort_by=lemma')
+    assert export.status_code == 200
+    assert export.mimetype == 'text/csv'
+    assert 'attachment;' in export.headers['Content-Disposition']
+    assert export.get_data(as_text=True).splitlines()[1].startswith('alpha,1,Homer,Iliad')
+
+
 def test_rare_bigrams(client):
     resp = client.get("/api/rare-bigrams?language=la&max_occurrences=10")
     assert resp.status_code == 200

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -405,6 +405,31 @@ def test_rare_lemmata_full_pagination_and_export(client, monkeypatch):
     assert export.get_data(as_text=True).splitlines()[1].startswith('alpha,1,Homer,Iliad')
 
 
+def test_text_credits_pagination_and_filtering(client, monkeypatch, tmp_path):
+    from backend.blueprints import corpus
+
+    sources_file = tmp_path / 'text_sources.json'
+    sources_file.write_text(json.dumps([
+        {'author': 'Virgil', 'work': 'Aeneid'},
+        {'author': 'Homer', 'work': 'Iliad'},
+        {'author': 'Virgil', 'work': 'Eclogues'},
+    ]), encoding='utf-8')
+    monkeypatch.setattr(corpus, 'TEXT_SOURCES_FILE', sources_file)
+
+    first_page = check_json(client.get('/api/text-credits?limit=25'))
+    assert first_page['total'] == 3
+    assert first_page['offset'] == 0
+    assert first_page['limit'] == 25
+    assert [entry['work'] for entry in first_page['entries']] == ['Aeneid', 'Iliad', 'Eclogues']
+
+    filtered_page = check_json(client.get('/api/text-credits?query=virgil&offset=1&limit=25'))
+    assert filtered_page['total'] == 2
+    assert [entry['work'] for entry in filtered_page['entries']] == ['Eclogues']
+
+    assert client.get('/api/text-credits?limit=10').status_code == 400
+    assert client.get('/api/text-credits?offset=-1').status_code == 400
+
+
 def test_rare_bigrams(client):
     resp = client.get("/api/rare-bigrams?language=la&max_occurrences=10")
     assert resp.status_code == 200

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -566,7 +566,24 @@ def test_auth_user(client):
 
 @pytest.mark.skipif(db_unavailable, reason="Database connection not available")
 def test_intertexts_list(client):
-    check_json(client.get("/api/intertexts"), min_keys=['intertexts'])
+    res = check_json(client.get(
+        "/api/intertexts?per_page=25&source_language=la&sort_by=score&sort_order=desc"
+    ), min_keys=['intertexts', 'total', 'pages', 'current_page', 'per_page', 'summary'])
+    assert res['per_page'] == 25
+    assert 'visible' in res['summary']
+    assert 'with_notes' in res['summary']
+
+
+@pytest.mark.skipif(db_unavailable, reason="Database connection not available")
+def test_intertexts_export(client):
+    resp = client.get("/api/intertexts/export?format=csv&per_page=50&sort_by=created_at")
+    assert resp.status_code == 200
+    assert resp.mimetype == 'text/csv'
+
+
+def test_intertexts_reject_invalid_page_size(client):
+    resp = client.get("/api/intertexts?per_page=20")
+    assert resp.status_code == 400
 
 
 @pytest.mark.skipif(db_unavailable, reason="Database connection not available")


### PR DESCRIPTION
Adds server-side pagination to the application’s largest data-heavy pages:

  - Rare Words Explorer
  - Repository lists (Public and My Saved)
  - Text Credits

  Each page now supports 25, 50, 100, or 500 results at a time, incremental “Show More” loading,
  accurate total counts, and server-side filtering/sorting where applicable.

  ## API changes

  - /api/rare-lemmata-full now supports paginated and sortable results; CSV export downloads all
    matching rows.

  - /api/intertexts and /api/intertexts/my now support paginated lists, filters, sorting, summaries,
    and filtered CSV export.

  - /api/text-credits now supports server-side author/work filtering plus offset and limit.

  ## Verification

  - Focused pagination endpoint tests passed: 5 passed.
  - Production build passed.
  - Live checks confirmed:
      - Rare Words: 25 of 1,582 results
      - Repository: paginated public response and CSV export
      - Text Credits: 25 of 1,956 entries

  - Verified Vite routes for Rare Words, Repository, and Text Credits return successfully.