### PR TITLE
Fix CSV exports mangling Coptic/Greek in Excel (add UTF-8 BOM)

### DIFF
--- a/backend/blueprints/hapax.py
+++ b/backend/blueprints/hapax.py
@@ -1647,7 +1647,8 @@ def export_rare_lemmata_full():
                 formatted['first_work'], formatted['first_locus']
             ])
 
-        response = Response(output.getvalue(), mimetype='text/csv')
+        # Prepend UTF-8 BOM so Excel reads non-Latin scripts (Coptic, Greek) as Unicode, not Windows-1252.
+        response = Response('﻿' + output.getvalue(), mimetype='text/csv; charset=utf-8')
         response.headers['Content-Disposition'] = (
             f"attachment; filename=rare_words_{params['language']}.csv"
         )

--- a/backend/blueprints/intertext.py
+++ b/backend/blueprints/intertext.py
@@ -119,9 +119,10 @@ def _repository_csv_response(items, is_public):
             item.notes or '',
             item.created_at.isoformat() if item.created_at else '',
         ])
+    # Prepend UTF-8 BOM so Excel reads non-Latin scripts (Coptic, Greek) as Unicode, not Windows-1252.
     return Response(
-        output.getvalue(),
-        mimetype='text/csv',
+        '﻿' + output.getvalue(),
+        mimetype='text/csv; charset=utf-8',
         headers={'Content-Disposition': 'attachment; filename=intertexts.csv'}
     )
 

--- a/client/src/components/search/LineSearch.jsx
+++ b/client/src/components/search/LineSearch.jsx
@@ -286,7 +286,8 @@ export default function LineSearch({ language }) {
       r.era || ''
     ]);
     const csv = [headers, ...rows].map(row => row.map(cell => `"${cell}"`).join(',')).join('\n');
-    const blob = new Blob([csv], { type: 'text/csv' });
+    // Prepend UTF-8 BOM so Excel reads non-Latin scripts (Coptic, Greek) as Unicode, not Windows-1252.
+    const blob = new Blob(['﻿', csv], { type: 'text/csv;charset=utf-8' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;

--- a/client/src/components/search/SearchResults.jsx
+++ b/client/src/components/search/SearchResults.jsx
@@ -119,7 +119,8 @@ const SearchResults = ({
     });
 
     const csv = [headers.join(','), ...rows.map(r => r.map(c => `"${c}"`).join(','))].join('\n');
-    const blob = new Blob([csv], { type: 'text/csv' });
+    // Prepend UTF-8 BOM so Excel reads non-Latin scripts (Coptic, Greek) as Unicode, not Windows-1252.
+    const blob = new Blob(['﻿', csv], { type: 'text/csv;charset=utf-8' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;


### PR DESCRIPTION
**Problem.** A user reported that the Coptic CSV export opens as gibberish. Four CSV exporters write UTF-8 without a byte-order mark, so Excel reads them as Windows-1252 and turns Coptic (and polytonic Greek) into mojibake.

**Fix.** Prepend a UTF-8 BOM and set `charset=utf-8`, matching `exportResults.js` which already did this correctly.

- **client:** `SearchResults.jsx` (main results Export CSV), `LineSearch.jsx`
- **backend:** `hapax.py` rare-words export, `intertext.py` repository export

Latin/English exports are unaffected (a leading BOM is invisible to them). No logic or data changes.

**Not included:** the admin dictionary-review CSV export (`admin.py`) has the same pattern but is admin-only and in a high-risk path; left for a separate change.