### PR TITLE
Fix Coptic corpus-wide search returning meaningless results

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2136,6 +2136,15 @@ def corpus_search():
 
         # Normalize lemmas for index lookup (strip Greek diacritics, Latin u/v)
         normalized_lemmas = [_normalize_lemma(l, language) for l in lemmas]
+        # Drop function words so corpus co-occurrence is driven by content words,
+        # not grammatical particles. Critical for Coptic, whose lemmatizer emits
+        # article/tense-marker morphemes (ⲡ "the", ⲁ past-marker, ...) that
+        # co-occur in nearly every clause and otherwise flood the results.
+        from backend.fusion import _STOPLISTS as _FUSION_STOPLISTS
+        _stop = _FUSION_STOPLISTS.get(language, set())
+        normalized_lemmas = [l for l in normalized_lemmas if l and l.lower() not in _stop]
+        if not normalized_lemmas:
+            return jsonify({'results': [], 'total': 0, 'lemmas': lemmas})
         matches = find_co_occurring_lemmas(normalized_lemmas, language, min_matches=min(2, len(normalized_lemmas)))
         
         results = []

--- a/backend/fusion.py
+++ b/backend/fusion.py
@@ -88,6 +88,27 @@ _STOPLISTS = {
     'cop': COPTIC_STOP_WORDS,
 }
 
+# matched_words carries scorer-internal markup as pseudo-lemmas: quotation-run
+# tokens ('[QUOT:...]'), dictionary pairs ('a≈b'), fuzzy/edit pairs ('a~b (66%)'),
+# and sound-channel trigrams ('[xyz]'). A real lemma contains none of these
+# characters. Used to derive a clean matched-lemma list for corpus-search.
+_MATCHED_LEMMA_MARKUP_RE = re.compile(r'[\[\]()~≈%:\s]')
+
+
+def _clean_matched_lemmas(lemma_keys, stoplist):
+    """Return the sorted set of real content lemmas from matched_words keys.
+
+    matched_words keys include scorer markup ('[QUOT:x]', 'a≈b', 'a~b (66%)',
+    '[xyz]') alongside genuine lemmas. Drop the markup and any function words so
+    the result is the actual words that matched, in index-normalized form —
+    what the corpus-search feature and result highlighting should consume.
+    """
+    return sorted({
+        lem for lem in lemma_keys
+        if lem and not _MATCHED_LEMMA_MARKUP_RE.search(lem)
+        and lem.lower() not in stoplist
+    })
+
 
 # ---------------------------------------------------------------------------
 # Config K channel weights (Feb 28 2026)
@@ -2366,6 +2387,8 @@ def fuse_results(channel_results, weights=None, convergence_bonus=None,
                 info["all_target_highlights"]
             )
         result["matched_words"] = list(info["all_matched_words"].values())
+        result["matched_lemmas"] = _clean_matched_lemmas(
+            info["all_matched_words"], _STOPLISTS.get(language, set()))
         result["fused_score"] = round(info["score"], 4)
         result["channels"] = info["channels"]
         result["channel_count"] = len(info["channels"])

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -472,9 +472,14 @@ function App() {
         lemmas
       };
     } else {
-      lemmas = (result.matched_words || []).map(w => 
-        typeof w === 'object' ? (w.lemma || w.word || '') : w
-      ).filter(Boolean);
+      // Prefer the clean matched_lemmas list (real content words, markup and
+      // function words removed). Fall back to parsing matched_words for older
+      // results that predate the field.
+      lemmas = (Array.isArray(result.matched_lemmas) && result.matched_lemmas.length)
+        ? result.matched_lemmas.slice()
+        : (result.matched_words || []).map(w =>
+            typeof w === 'object' ? (w.lemma || w.word || '') : w
+          ).filter(Boolean);
       queryInfo = {
         source: { ref: result.source_locus || result.source?.ref, text: result.source_text || result.source?.text },
         target: { ref: result.target_locus || result.target?.ref, text: result.target_text || result.target?.text },

--- a/tests/test_fusion_scoring.py
+++ b/tests/test_fusion_scoring.py
@@ -733,3 +733,38 @@ class TestTextPairFrequencyBaseline:
         # Non-existent words should return 0 frequency
         assert freqs.get("nonexistentword12345", 0) == 0
 
+
+
+# ── Clean matched-lemma extraction (corpus-search input) ───────────────────
+
+class TestCleanMatchedLemmas:
+    """_clean_matched_lemmas strips scorer markup and function words from
+    matched_words keys so corpus-search sees real content lemmas. Regression
+    guard for the Coptic corpus-search fix (markup + particle flood)."""
+
+    def test_strips_quotation_and_pair_markup(self):
+        from backend.fusion import _clean_matched_lemmas
+        keys = ['[QUOT:ⲛ]', 'ⲛⲟⲩⲻⲉ~ⲛⲟⲩⲧⲉ (80%)', 'ⲛⲧⲟⲥ≈ⲡⲉⲥ',
+                '[ⲏⲣⲉ]', 'ⲓⲥⲁⲁⲕ', 'ⲳⲏⲣⲉ']
+        assert _clean_matched_lemmas(keys, set()) == sorted(['ⲓⲥⲁⲁⲕ', 'ⲳⲏⲣⲉ'])
+
+    def test_drops_stopwords(self):
+        from backend.fusion import _clean_matched_lemmas
+        keys = ['ⲡ', 'ⲁ', 'ⲓⲥⲁⲁⲕ', 'ⲳⲏⲣⲉ']
+        stop = {'ⲡ', 'ⲁ'}
+        assert _clean_matched_lemmas(keys, stop) == sorted(['ⲓⲥⲁⲁⲕ', 'ⲳⲏⲣⲉ'])
+
+    def test_latin_content_words_pass_through(self):
+        from backend.fusion import _clean_matched_lemmas
+        keys = ['arma', 'virum', 'et', 'a~b (66%)']
+        assert _clean_matched_lemmas(keys, {'et'}) == ['arma', 'virum']
+
+    def test_empty_and_all_markup(self):
+        from backend.fusion import _clean_matched_lemmas
+        assert _clean_matched_lemmas([], set()) == []
+        assert _clean_matched_lemmas(['[QUOT:x]', 'a≈b'], set()) == []
+
+    def test_dedupes(self):
+        from backend.fusion import _clean_matched_lemmas
+        assert _clean_matched_lemmas(['nux', 'nux', 'castanea'], set()) == \
+            sorted(['nux', 'castanea'])


### PR DESCRIPTION
## Problem
A user reported that corpus-wide search on Coptic returns meaningless results — passages highlighting a single stray word, even when the source parallel matched several words.

**Root cause.** The "search corpus for these words" button hands a result's `matched_words` to the co-occurrence lookup. But `matched_words` is a scorer-internal structure, not a word list — it carries markup pseudo-lemmas (`[QUOT:…]` quotation-run tokens, `a≈b` dictionary pairs, `a~b (66%)` fuzzy pairs, `[xyz]` sound trigrams) in the matcher's normalized alphabet. Latin/Greek never hit this: the quotation channel is Coptic-only and their lemmatization is clean. Coptic search is *built around* the quotation channel, so its `matched_words` is mostly markup, and corpus-search matched on stray fragments + function-word particles → flood of one-word-highlight noise.

## Fix
- **`fusion.py`**: add a clean `matched_lemmas` field to every fused result — the real content lemmas that matched, markup + stopwords removed, in index-normalized form (`_clean_matched_lemmas` helper). **Additive; does not touch scoring or ranking.**
- **`app.py` `corpus_search`**: drop function words from the query defensively (protects the fallback path).
- **`App.jsx`**: corpus-search prefers `matched_lemmas`, falling back to `matched_words` for older results.

## Validation
- **Coptic** (Abraham × Genesis): `matched_lemmas` clean (no markup/stopwords); corpus-search flood eliminated — e.g. Gen 21:10 went **1142 → 0** stray matches — while genuine multi-content-word matches are preserved (creation-formula echoes still 30/29).
- **Latin** (Eclogues × Calpurnius): corpus-search counts **identical** old vs new (no regression); `matched_lemmas` clean.
- **69 fusion unit tests pass** (+5 new for `_clean_matched_lemmas`).

Latin/Greek recall is unaffected — the new field is not read by scoring. Frontend rebuild required on deploy.