### PR TITLE
Regenerate rare-words cache when it exists but is empty

### DIFF
--- a/backend/blueprints/hapax.py
+++ b/backend/blueprints/hapax.py
@@ -1607,8 +1607,11 @@ RARE_LEMMATA_SORT_ORDERS = {'asc', 'desc'}
 def _get_rare_lemmata_matching(language, max_occ):
     """Load and filter the cached rare-word records for an Explorer request."""
     cached = load_rare_words_cache(language)
-    if not cached:
-        logger.info(f"Rare-words cache missing for {language}, regenerating lazily")
+    # Regenerate when the cache is missing OR empty. An empty cache can be left
+    # behind by an earlier run that lacked support for a language (e.g. Coptic
+    # before it was added); without the empty-check it would never self-heal.
+    if not cached or not cached.get('words'):
+        logger.info(f"Rare-words cache missing/empty for {language}, regenerating lazily")
         try:
             if regenerate_rare_words_cache(language):
                 cached = load_rare_words_cache(language)


### PR DESCRIPTION
`_get_rare_lemmata_matching` only regenerated the rare-words cache when the file was **absent**. An **empty** cache (`{"words": []}`) is valid JSON, so it blocked lazy regeneration indefinitely — leaving the Rare Words Explorer permanently empty for that language.

This bites Coptic specifically: an earlier run (before #162 added Coptic support) wrote an empty `cache/rare_words/cop.json`, owned by the web user, which now blocks the new Coptic path from ever populating. One-line fix: regenerate when the cache is missing **or** empty, so it self-heals on the next request.

No behavior change for languages whose cache is already populated.