### PR TITLE
Coptic rare-words: Coptic Dictionary link + proper Coptic sort

### DIFF
--- a/backend/blueprints/hapax.py
+++ b/backend/blueprints/hapax.py
@@ -1624,8 +1624,16 @@ def _get_rare_lemmata_matching(language, max_occ):
     return [word for word in cached.get('words', []) if word['count'] <= max_occ]
 
 
-def _rare_lemmata_sort_key(word, sort_by):
-    lemma = word.get('display', word.get('lemma', '')).lstrip('*').casefold()
+def _rare_lemmata_sort_key(word, sort_by, language='la'):
+    if language == 'cop':
+        # Collate Coptic by the normalized lemma: the Coptic Unicode block orders
+        # the Greek-derived letters first and the Demotic-derived letters
+        # (ϣ ϥ ϩ ϫ ϭ …) last — traditional Coptic alphabetical order. The
+        # manuscript display puts those letters in the legacy block, which would
+        # (wrongly) sort them first.
+        lemma = word.get('lemma', word.get('display', '')).lstrip('*')
+    else:
+        lemma = word.get('display', word.get('lemma', '')).lstrip('*').casefold()
     if sort_by == 'frequency':
         return (word.get('count', 0), lemma)
     if sort_by == 'author':
@@ -1717,7 +1725,7 @@ def get_rare_lemmata_full():
             })
 
         matching.sort(
-            key=lambda word: _rare_lemmata_sort_key(word, params['sort_by']),
+            key=lambda word: _rare_lemmata_sort_key(word, params['sort_by'], params['language']),
             reverse=params['sort_order'] == 'desc'
         )
         page = matching[params['offset']:params['offset'] + params['limit']]
@@ -1752,7 +1760,7 @@ def export_rare_lemmata_full():
             return jsonify({'error': 'Rare words cache is not available'}), 503
 
         matching.sort(
-            key=lambda word: _rare_lemmata_sort_key(word, params['sort_by']),
+            key=lambda word: _rare_lemmata_sort_key(word, params['sort_by'], params['language']),
             reverse=params['sort_order'] == 'desc'
         )
         output = io.StringIO()

--- a/client/src/components/corpus/RareWordsExplorer.jsx
+++ b/client/src/components/corpus/RareWordsExplorer.jsx
@@ -228,6 +228,12 @@ export default function RareWordsExplorer() {
     return names[lang] || lang;
   };
 
+  const getDictionaryName = (lang) => {
+    if (lang === 'en') return 'Wiktionary';
+    if (lang === 'cop') return 'Coptic Dictionary';
+    return 'Logeion';
+  };
+
   const SortIcon = ({ field }) => {
     if (sortBy !== field) return <span className="text-gray-300 ml-1">↕</span>;
     return <span className="text-red-600 ml-1">{sortOrder === 'asc' ? '↑' : '↓'}</span>;
@@ -346,7 +352,7 @@ export default function RareWordsExplorer() {
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-gray-400 hover:text-amber-600 text-xs ml-1"
-                            title={`Look up "${word.lemma}" in ${language === 'en' ? 'Wiktionary' : 'Logeion'}`}
+                            title={`Look up "${word.lemma}" in ${getDictionaryName(language)}`}
                             onClick={(e) => e.stopPropagation()}
                           >
                             📖
@@ -375,9 +381,9 @@ export default function RareWordsExplorer() {
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 className="text-gray-400 hover:text-amber-600 text-sm"
-                                title={`Look up "${word.lemma}" in ${language === 'en' ? 'Wiktionary' : 'Logeion'}`}
+                                title={`Look up "${word.lemma}" in ${getDictionaryName(language)}`}
                               >
-                                📖 {language === 'en' ? 'Wiktionary' : 'Logeion'}
+                                📖 {getDictionaryName(language)}
                               </a>
                             )}
                           </div>

--- a/client/src/utils/linkUtils.js
+++ b/client/src/utils/linkUtils.js
@@ -7,11 +7,10 @@ export function getDictionaryUrl(word, language) {
   if (language === 'en') {
     return `https://en.wiktionary.org/wiki/${encodeURIComponent(word)}`;
   }
-  // Coptic: no external lookup wired yet (Logeion has no Coptic; the Coptic
-  // Dictionary Online needs the manuscript form, not the matcher's normalized
-  // lemma), so omit the link rather than show a broken one.
+  // Coptic uses the Coptic Dictionary Online (KELLIA). The Rare Words Explorer
+  // passes the manuscript-spelled lemma, which matches CDO's Sahidic entries.
   if (language === 'cop') {
-    return null;
+    return `https://coptic-dictionary.org/results.cgi?quick_search=${encodeURIComponent(word)}`;
   }
   // Latin and Greek both use Logeion
   return `https://logeion.uchicago.edu/${encodeURIComponent(word)}`;

--- a/tests/test_coptic_rare_words.py
+++ b/tests/test_coptic_rare_words.py
@@ -63,3 +63,26 @@ class TestCleanCopticLemma:
         from backend.blueprints.hapax import _clean_coptic_lemma
         assert _clean_coptic_lemma('') == ''
         assert _clean_coptic_lemma('[...]') == ''
+
+
+class TestCopticCollation:
+    """_rare_lemmata_sort_key collates Coptic by the normalized lemma so the
+    Demotic-derived letters (ϣ ϥ ϩ ϫ ϭ) sort last, as in traditional Coptic
+    order — not first, as they would by the manuscript display's legacy block."""
+
+    def _order(self, language):
+        from backend.blueprints.hapax import _rare_lemmata_sort_key
+        recs = [
+            {'lemma': 'ⲳⲏⲣⲉ', 'display': 'ϣⲏⲣⲉ', 'count': 1},   # shai
+            {'lemma': 'ⲁⲣⲭⲏ', 'display': 'ⲁⲣⲭⲏ', 'count': 1},   # alfa
+            {'lemma': 'ⲹⲛ', 'display': 'ϩⲛ', 'count': 1},        # hori
+            {'lemma': 'ⲣⲱⲙⲉ', 'display': 'ⲣⲱⲙⲉ', 'count': 1},   # ro
+        ]
+        return [r['display'] for r in sorted(recs, key=lambda w: _rare_lemmata_sort_key(w, 'lemma', language))]
+
+    def test_coptic_demotic_letters_sort_last(self):
+        assert self._order('cop') == ['ⲁⲣⲭⲏ', 'ⲣⲱⲙⲉ', 'ϣⲏⲣⲉ', 'ϩⲛ']
+
+    def test_non_coptic_unchanged_uses_display(self):
+        # For non-cop the key is the display (legacy block), so ϣ/ϩ sort first
+        assert self._order('la')[0] in ('ϣⲏⲣⲉ', 'ϩⲛ')


### PR DESCRIPTION
Two polish items on the Coptic Rare Words Explorer (both requested by Neil).

## 1. Coptic Dictionary Online link
Wires the [Coptic Dictionary Online](https://coptic-dictionary.org) (KELLIA) as the external lookup for Coptic rare words: `results.cgi?quick_search=<word>`. The Explorer already passes the **manuscript-spelled** lemma, which matches CDO's Sahidic entries (SCRIPTORIUM and CDO share KELLIA lemmatization — verified ϣⲏⲣⲉ resolves). The link label now reads **"Coptic Dictionary"** for Coptic instead of the mislabeled "Logeion".

## 2. Proper Coptic alphabetical sort
`_rare_lemmata_sort_key` now collates Coptic by the **normalized lemma**. The Coptic Unicode block orders the Greek-derived letters first and the Demotic-derived letters (ϣ ϥ ϩ ϫ ϭ) **last** — traditional Coptic order. The manuscript display keeps those letters in the legacy Unicode block, which sorted them *first* (the clustering you saw). Endpoint-side change — **no cache rebuild needed**. Latin/Greek/English sorting is untouched.

## Safety
Language-gated; non-Coptic paths unchanged. 2 new collation unit tests (10 total). JSX validated. Frontend rebuild required on deploy; no cache regeneration.