### PR TITLE
Fix Coptic-language UI leaks (Latin defaults/examples in the Coptic space)

### DIFF
--- a/client/src/components/corpus/CorpusBrowser.jsx
+++ b/client/src/components/corpus/CorpusBrowser.jsx
@@ -16,7 +16,8 @@ export default function CorpusBrowser() {
   const languageTabs = [
     { code: 'la', label: 'Latin' },
     { code: 'grc', label: 'Greek' },
-    { code: 'en', label: 'English' }
+    { code: 'en', label: 'English' },
+    { code: 'cop', label: 'Coptic' }
   ];
 
   const erasByLanguage = {
@@ -207,7 +208,7 @@ export default function CorpusBrowser() {
   };
 
   const getLanguageName = (lang) => {
-    const names = { la: 'Latin', grc: 'Greek', en: 'English' };
+    const names = { la: 'Latin', grc: 'Greek', en: 'English', cop: 'Coptic' };
     return names[lang] || lang;
   };
 

--- a/client/src/components/search/LineSearch.jsx
+++ b/client/src/components/search/LineSearch.jsx
@@ -432,7 +432,7 @@ export default function LineSearch({ language }) {
   };
 
   const getLanguageName = (lang) => {
-    const names = { la: 'Latin', grc: 'Greek', en: 'English' };
+    const names = { la: 'Latin', grc: 'Greek', en: 'English', cop: 'Coptic' };
     return names[lang] || lang;
   };
 

--- a/client/src/components/search/RarePairsSettings.jsx
+++ b/client/src/components/search/RarePairsSettings.jsx
@@ -32,7 +32,7 @@ const RarePairsSettings = ({ settings, setSettings, searchMode }) => {
               </span>
             </label>
             <p className="text-xs text-gray-400 mt-1 ml-6">
-              Filter out words like Roma, Aeneas, Troia that are always capitalized
+              Filter out proper nouns (names and places)
             </p>
           </div>
         )}

--- a/client/src/components/search/RareResultsDisplay.jsx
+++ b/client/src/components/search/RareResultsDisplay.jsx
@@ -172,6 +172,12 @@ const RareResultsDisplay = ({
   const isHapax = searchMode === 'hapax';
   const title = isHapax ? 'Shared Rare Words' : 'Shared Rare Pairs';
 
+  const getDictionaryName = (lang) => {
+    if (lang === 'en') return 'Wiktionary';
+    if (lang === 'cop') return 'Coptic Dictionary';
+    return 'Logeion';
+  };
+
   const extractRefNumbers = (ref) => {
     if (!ref) return [Infinity, Infinity];
     const nums = ref.match(/\d+/g);
@@ -513,7 +519,7 @@ const RareResultsDisplay = ({
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-gray-400 hover:text-amber-600 text-xs"
-                      title={`Look up "${r.lemma}" in ${language === 'en' ? 'Wiktionary' : 'Logeion'}`}
+                      title={`Look up "${r.lemma}" in ${getDictionaryName(language)}`}
                     >
                       📖
                     </a>
@@ -526,7 +532,7 @@ const RareResultsDisplay = ({
                           target="_blank"
                           rel="noopener noreferrer"
                           className="text-gray-400 hover:text-amber-600 text-xs"
-                          title={`Look up "${r.word1}" in ${language === 'en' ? 'Wiktionary' : 'Logeion'}`}
+                          title={`Look up "${r.word1}" in ${getDictionaryName(language)}`}
                         >
                           📖
                         </a>
@@ -537,7 +543,7 @@ const RareResultsDisplay = ({
                           target="_blank"
                           rel="noopener noreferrer"
                           className="text-gray-400 hover:text-amber-600 text-xs"
-                          title={`Look up "${r.word2}" in ${language === 'en' ? 'Wiktionary' : 'Logeion'}`}
+                          title={`Look up "${r.word2}" in ${getDictionaryName(language)}`}
                         >
                           📖
                         </a>

--- a/client/src/components/search/SavedSearches.jsx
+++ b/client/src/components/search/SavedSearches.jsx
@@ -96,8 +96,9 @@ const SavedSearches = ({
                       <div className="font-medium text-gray-900 truncate">{search.name}</div>
                       <div className="text-xs text-gray-500">
                         {search.sourceAuthor} vs {search.targetAuthor} | {
-                          search.language === 'la' ? 'Latin' : 
-                          search.language === 'grc' ? 'Greek' : 'English'
+                          search.language === 'la' ? 'Latin' :
+                          search.language === 'grc' ? 'Greek' :
+                          search.language === 'cop' ? 'Coptic' : 'English'
                         }
                       </div>
                       <div className="text-xs text-gray-400">

--- a/client/src/components/search/SearchSettings.jsx
+++ b/client/src/components/search/SearchSettings.jsx
@@ -4,7 +4,8 @@ const SearchSettings = ({ settings, setSettings, showAdvanced, setShowAdvanced, 
   const stopwordExamples = {
     la: 'pietas not pietate, bellum not bello',
     grc: 'λόγος not λόγον, θεός not θεῷ',
-    en: 'king not kings, speak not speaking'
+    en: 'king not kings, speak not speaking',
+    cop: 'use lemmatized (sub-word) dictionary forms, not inflected forms'
   };
   const handleChange = (key, value) => {
     const updates = { [key]: value };
@@ -61,7 +62,7 @@ const SearchSettings = ({ settings, setSettings, showAdvanced, setShowAdvanced, 
           {settings.match_type === 'fusion' && (
             <p className="text-xs text-gray-500 mt-1">
               Runs 9 channels with weighted scoring. Best recall but slower.
-              Large text comparisons (e.g., {language === 'grc' ? 'full Odyssey vs. Argonautica' : language === 'en' ? 'full Paradise Lost vs. Faerie Queene' : 'full Aeneid vs. Metamorphoses'}) may take up to 15 minutes on first run; subsequent searches are cached.
+              Large text comparisons (e.g., {language === 'grc' ? 'full Odyssey vs. Argonautica' : language === 'en' ? 'full Paradise Lost vs. Faerie Queene' : language === 'cop' ? 'Sahidic Bible vs. Shenoute' : 'full Aeneid vs. Metamorphoses'}) may take up to 15 minutes on first run; subsequent searches are cached.
             </p>
           )}
         </div>
@@ -272,12 +273,14 @@ const SearchSettings = ({ settings, setSettings, showAdvanced, setShowAdvanced, 
                 Part-of-speech filtering
               </label>
               )}
+              {language === 'la' && (
               <label className="flex items-center gap-2 text-sm text-gray-700">
                 <input type="checkbox" checked={settings.use_meter || false}
                   onChange={(e) => handleChange('use_meter', e.target.checked)}
                   className="rounded border-gray-300" />
                 Metrical patterns
               </label>
+              )}
               {settings.match_type !== 'fusion' && (
               <label className="flex items-center gap-2 text-sm text-gray-700 group relative">
                 <input type="checkbox" checked={settings.use_syntax || false}

--- a/client/src/components/search/WildcardSearch.jsx
+++ b/client/src/components/search/WildcardSearch.jsx
@@ -227,7 +227,7 @@ const WildcardSearch = ({ language }) => {
     scales: { y: { beginAtZero: true, ticks: { precision: 0 } } }
   };
 
-  const languageLabel = language === 'la' ? 'Latin' : language === 'grc' ? 'Greek' : 'English';
+  const languageLabel = language === 'la' ? 'Latin' : language === 'grc' ? 'Greek' : language === 'cop' ? 'Coptic' : 'English';
 
   return (
     <div className="space-y-4">
@@ -238,6 +238,8 @@ const WildcardSearch = ({ language }) => {
         </p>
       </div>
 
+      {/* Syntax examples below (am*, "arma virumque", rex OR regina) use Latin words to
+          illustrate wildcard/boolean SYNTAX regardless of the active corpus language. */}
       <div className="bg-gray-50 rounded-lg p-4 text-sm">
         <h4 className="font-medium mb-2">Search Syntax</h4>
         <ul className="space-y-1 text-gray-600">


### PR DESCRIPTION
Fixes the reported "Latin all over the Coptic space" — Latin defaults, examples, and labels leaking into the Coptic experience. From an audit of the frontend.

## Changes (7 files)
- **CorpusBrowser.jsx** — add a **Coptic tab** + `cop: 'Coptic'` name (it had none, so it opened on Latin — the Roma/Aeneas leak). *(RareWordsExplorer already had its Coptic tab from an earlier PR.)*
- **WildcardSearch.jsx** — `cop → 'Coptic'` (was falling through to "English corpus").
- **LineSearch.jsx** — `cop: 'Coptic'` in the language-name map (was showing the raw code "cop").
- **SavedSearches.jsx** — `cop → 'Coptic'` (Coptic saved searches were labeled "English").
- **SearchSettings.jsx** — Coptic branch for the fusion example ("Sahidic Bible vs. Shenoute"), a `cop` stopword-examples entry, and **gate the "Metrical patterns" checkbox to Latin** (Coptic has no quantitative meter).
- **RarePairsSettings.jsx** — proper-noun example made language-neutral (was Latin-only "Roma, Aeneas, Troia").
- **RareResultsDisplay.jsx** — dictionary link label is language-aware (Coptic → "Coptic Dictionary"); it already used `getDictionaryUrl` so Coptic URLs point to the Coptic Dictionary Online.

Frontend-only; all touched files parse cleanly. Frontend rebuild required on deploy.

**Follow-up noted:** `CorpusBrowser`'s `erasByLanguage` map has no `cop` key (era filter falls back to Latin eras) — left for later since it needs Coptic era metadata.