### PR TITLE
Coptic rare-word search: highlight matches, hide non-working proper-noun filter

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -738,6 +738,7 @@ function App() {
                       settings={settings}
                       setSettings={setSettings}
                       searchMode={searchMode}
+                      language={activeTab}
                     />
                   )}
 

--- a/client/src/components/search/RarePairsSettings.jsx
+++ b/client/src/components/search/RarePairsSettings.jsx
@@ -2,7 +2,7 @@
  * RarePairsSettings — Settings panel for rare word (hapax) and rare pair search modes.
  * Controls rarity threshold, proper noun exclusion, minimum frequency, and bigram options.
  */
-const RarePairsSettings = ({ settings, setSettings, searchMode }) => {
+const RarePairsSettings = ({ settings, setSettings, searchMode, language }) => {
   const handleChange = (key, value) => {
     setSettings(prev => ({ ...prev, [key]: value }));
   };
@@ -18,7 +18,7 @@ const RarePairsSettings = ({ settings, setSettings, searchMode }) => {
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        {isHapax && (
+        {isHapax && language !== 'cop' && (
           <div className="sm:col-span-2">
             <label className="flex items-center gap-2 cursor-pointer">
               <input
@@ -31,9 +31,6 @@ const RarePairsSettings = ({ settings, setSettings, searchMode }) => {
                 Exclude proper nouns (names, places)
               </span>
             </label>
-            <p className="text-xs text-gray-400 mt-1 ml-6">
-              Filter out proper nouns (names and places)
-            </p>
           </div>
         )}
 

--- a/client/src/components/search/RareResultsDisplay.jsx
+++ b/client/src/components/search/RareResultsDisplay.jsx
@@ -8,12 +8,41 @@ import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Toolti
 import { Bar } from 'react-chartjs-2';
 import { formatElapsedTime } from '../../utils/formatting';
 import { displayGreekWithFinalSigma } from '../../utils/greekUtils';
+import { normalizeCoptic } from '../../utils/copticUtils';
 import { getDictionaryUrl } from '../../utils/linkUtils';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 
-const highlightMatchedWords = (text, matchedWords, lemma1, lemma2, positions) => {
+const highlightMatchedWords = (text, matchedWords, lemma1, lemma2, positions, language) => {
   if (!text) return text;
+
+  // Coptic: the search uses sub-word lemma forms (in a normalized alphabet) that
+  // don't align with the surface words — and \w doesn't match Coptic script — so
+  // match by normalized form with a substring fallback for bound groups (a surface
+  // word that contains the sub-word lemma, e.g. ⲣⲱⲙⲉ inside ⲛⲉⲩⲛⲟⲩⲣⲱⲙⲉ).
+  if (language === 'cop') {
+    const strip = (s) => String(s)
+      .replace(/^[\s.,;:!?'"()—–·‧-]+/, '')
+      .replace(/[\s.,;:!?'"()—–·‧-]+$/, '');
+    const norm = (s) => normalizeCoptic(strip(s));
+    const targets = new Set();
+    [lemma1, lemma2].forEach(l => { if (l) targets.add(norm(l)); });
+    (matchedWords || []).forEach(w => {
+      const word = typeof w === 'object' ? (w.lemma || w.word) : w;
+      if (word && !/[~[]/.test(String(word))) targets.add(norm(word));
+    });
+    targets.delete('');
+    if (targets.size === 0) return text;
+    return text.split(/(\s+)/).map((part, i) => {
+      if (/^\s+$/.test(part) || part === '') return part;
+      const cmp = norm(part);
+      let hit = targets.has(cmp);
+      if (!hit) { for (const t of targets) { if (t.length >= 3 && cmp.includes(t)) { hit = true; break; } } }
+      return hit
+        ? <span key={i}><span className="bg-yellow-200 px-0.5 rounded font-medium">{part}</span></span>
+        : part;
+    });
+  }
 
   // Split text into tokens while preserving whitespace
   const parts = text.split(/(\s+)/);
@@ -592,7 +621,7 @@ const RareResultsDisplay = ({
                         <div key={j} className="text-sm">
                           <div className="font-medium text-red-700">{formatLocationRef(loc.ref, formatTextName(sourceText))}</div>
                           {loc.text && <div className="text-gray-700">
-                            {highlightMatchedWords(displayGreekWithFinalSigma(loc.text), r.matched_words, r.word1 || r.lemma, r.word2, loc.positions)}
+                            {highlightMatchedWords(displayGreekWithFinalSigma(loc.text), r.matched_words, r.word1 || r.lemma, r.word2, loc.positions, language)}
                           </div>}
                         </div>
                       ))}
@@ -612,7 +641,7 @@ const RareResultsDisplay = ({
                         <div key={j} className="text-sm">
                           <div className="font-medium text-amber-700">{formatLocationRef(loc.ref, formatTextName(targetText))}</div>
                           {loc.text && <div className="text-gray-700">
-                            {highlightMatchedWords(displayGreekWithFinalSigma(loc.text), r.matched_words, r.word1 || r.lemma, r.word2, loc.positions)}
+                            {highlightMatchedWords(displayGreekWithFinalSigma(loc.text), r.matched_words, r.word1 || r.lemma, r.word2, loc.positions, language)}
                           </div>}
                         </div>
                       ))}


### PR DESCRIPTION
Three fixes to the Coptic rare-word (hapax) search UI (all reported by Neil):

1. **Highlighting was broken for Coptic.** The highlighter matched on ASCII `\w` (which never matches Coptic script) and on sub-word lemma positions that don't align with the surface words. Added a Coptic branch to `highlightMatchedWords` that normalizes with `normalizeCoptic` and matches by normalized form with a **substring fallback for bound groups** (ⲣⲱⲙⲉ inside ⲛⲉⲩⲛⲟⲩⲣⲱⲙⲉ) — the same approach the main results view already uses.
2. **Hide the "Exclude proper nouns" checkbox for Coptic.** It detects proper nouns by capitalization, which Coptic script doesn't have, so it did nothing (0 excluded, verified). Per Neil's call, hide it for Coptic.
3. **Removed the redundant sub-paragraph** under the checkbox (it just restated the label).

Frontend-only; all files parse. Latin/Greek/English highlighting and the checkbox are unchanged. Rebuild required on deploy.