### PR TITLE
Hide the empty Rare Words Settings box for Coptic

### DIFF
--- a/client/src/components/search/RarePairsSettings.jsx
+++ b/client/src/components/search/RarePairsSettings.jsx
@@ -9,6 +9,13 @@ const RarePairsSettings = ({ settings, setSettings, searchMode, language }) => {
 
   const isHapax = searchMode === 'hapax';
 
+  // In rare-word (hapax) mode the only control is the proper-noun exclusion, which
+  // is hidden for Coptic (it relies on capitalization). That would leave an empty
+  // "Rare Words Settings" box, so don't render the panel at all in that case.
+  if (isHapax && language === 'cop') {
+    return null;
+  }
+
   return (
     <div className="bg-gray-50 rounded-lg p-4">
       <div className="mb-3">


### PR DESCRIPTION
Follow-up to #168: in rare-word (hapax) mode the settings panel's only control is the proper-noun exclusion checkbox, which #168 correctly hid for Coptic (it relies on capitalization, which Coptic script lacks). That left an **empty "Rare Words Settings" box** on the Coptic search page. Return `null` from `RarePairsSettings` for Coptic rare-word mode so no empty box renders. Latin/Greek/English and rare-pairs mode are unchanged.