### PR TITLE
Fix Line Search Load Lines for non-Latin languages

### DIFF
--- a/client/src/components/search/LineSearch.jsx
+++ b/client/src/components/search/LineSearch.jsx
@@ -201,7 +201,7 @@ export default function LineSearch({ language }) {
     setBrowseLoading(true);
     setBrowseLines([]);
     try {
-      const res = await fetch(`/api/text/${selectedWork}/lines`);
+      const res = await fetch(`/api/text/${selectedWork}/lines?language=${language}`);
       const data = await res.json();
       if (data.lines) {
         setBrowseLines(data.lines);


### PR DESCRIPTION
Line Search's "Load Lines" (browse a text's lines) did nothing for Coptic. `handleBrowseLines` fetched `/api/text/<id>/lines` **without the language param**, so the endpoint defaulted to Latin, looked for the Coptic text in the Latin corpus, returned `{"error":"Text not found"}`, and rendered nothing. (Confirmed: the same URL with `?language=cop` returns the 56 lines of acts.pilate.)

One-line fix: pass the active language. Also fixes the same latent bug for Greek/English browse.