### PR TITLE
Fix long work titles/loci overflowing into Line Search results

### DIFF
--- a/client/src/components/search/LineSearch.jsx
+++ b/client/src/components/search/LineSearch.jsx
@@ -783,7 +783,7 @@ export default function LineSearch({ language }) {
                       <span className="text-xs text-gray-400 min-w-[2.5rem] text-right shrink-0 leading-none" style={{paddingTop: '1px'}}>
                         {i + 1}.
                       </span>
-                      <div className="sm:w-48 flex-shrink-0">
+                      <div className="sm:w-48 flex-shrink-0 min-w-0 break-words">
                         <div className="text-sm font-medium text-gray-900">
                           {result.author}
                         </div>
@@ -796,7 +796,7 @@ export default function LineSearch({ language }) {
                           </span>
                         )}
                       </div>
-                      <div className="flex-1 text-gray-700">
+                      <div className="flex-1 min-w-0 break-words text-gray-700">
                         {highlightMatches(result.text, result.matched_words || query.split(/\s+/))}
                       </div>
                     </div>


### PR DESCRIPTION
In Line Search results, long work titles/loci ran into the result text. Each row's citation column is a fixed width (`sm:w-48`), and long unspaced identifiers — Coptic loci like `pseudo.athanasius.discourses.283` — have no break opportunities, so CSS didn't wrap them and they overflowed into the adjacent text column.

Fix: add `break-words min-w-0` to the citation column so long strings wrap within it, and `min-w-0` to the `flex-1` text column so it shrinks properly. CSS-only; helps all languages, fixes the Coptic case.