### PR TITLE
Clean Coptic line-search locus (fix citation overflow into results text)

### DIFF
--- a/client/src/components/search/LineSearch.jsx
+++ b/client/src/components/search/LineSearch.jsx
@@ -777,7 +777,14 @@ export default function LineSearch({ language }) {
               )}
 
               <div className="divide-y divide-gray-200">
-                {filteredResults.slice(0, displayLimit).map((result, i) => (
+                {filteredResults.slice(0, displayLimit).map((result, i) => {
+                  // Coptic loci embed the full text id (e.g. "pseudo.athanasius.discourses.24");
+                  // strip that redundant filename stem so the citation reads "Discourses, 24".
+                  const stem = (result.text_id || '').replace(/\.tess$/, '');
+                  const displayLocus = stem && (result.locus || '').startsWith(stem + '.')
+                    ? result.locus.slice(stem.length + 1)
+                    : (result.locus || '');
+                  return (
                   <div key={i} className="p-4 hover:bg-gray-50">
                     <div className="flex flex-col sm:flex-row sm:items-start gap-2">
                       <span className="text-xs text-gray-400 min-w-[2.5rem] text-right shrink-0 leading-none" style={{paddingTop: '1px'}}>
@@ -788,7 +795,7 @@ export default function LineSearch({ language }) {
                           {result.author}
                         </div>
                         <div className="text-xs text-gray-500">
-                          {result.work}, {result.locus}
+                          {result.work}, {displayLocus}
                         </div>
                         {result.era && (
                           <span className="text-xs px-1.5 py-0.5 bg-gray-100 text-gray-600 rounded mt-1 inline-block">
@@ -801,7 +808,8 @@ export default function LineSearch({ language }) {
                       </div>
                     </div>
                   </div>
-                ))}
+                  );
+                })}
               </div>
               {filteredResults.length > displayLimit && (
                 <div className="px-4 py-3 bg-gray-50 text-center">


### PR DESCRIPTION
## Problem
In Coptic line search, the citation column ran into the results text — e.g. for Pseudo-Athanasius it showed:

> **Pseudo-Athanasius**
> Discourses, `pseudo.athanasius.discourses.24`

Coptic `.tess` loci embed the full internal text id, so `result.locus` is a long dot-joined token (`pseudo.athanasius.discourses.24`) with no spaces/break opportunities. It overflowed the fixed `w-48` citation column into the adjacent results text.

## Fix
Display-only: strip the redundant filename stem from the locus using `result.text_id`, so the citation reads **"Discourses, 24"** (or "Judith, 4.12" for the Bible). 

- Keyed on `result.text_id`; only strips when the locus actually starts with the text-id stem.
- Latin/Greek loci are already short (`1.469`) and don't carry the stem, so they're **unchanged**.
- No change to `result.locus` itself — corpus-search `exclude_locus` and CSV export are unaffected.
- Complements the existing `break-words` wrapping on the column (belt-and-suspenders).

Verified strip logic on real cases (Pseudo-Athanasius/Celestinus, Sahidic Judith, Book of Bartholomew, Vergil).

🤖 Generated with [Claude Code](https://claude.com/claude-code)