### PR TITLE
Coptic-specific search-syntax examples + clearer input wording

### DIFF
--- a/client/src/components/search/CopticSearchInput.jsx
+++ b/client/src/components/search/CopticSearchInput.jsx
@@ -55,6 +55,12 @@ export default function CopticSearchInput({ value, onChange, onEnter, placeholde
   const coptic = transliterateToCoptic(buffer);
   const showPreview = buffer && coptic !== buffer;
 
+  // Computed default: shows the transliteration idea with its Coptic result,
+  // and the other two input paths. "Transliteration", not "Latin" — the user
+  // types Latin letters but is entering Coptic, not a Latin word.
+  const effectivePlaceholder =
+    placeholder || `Transliteration (rOme = ${transliterateToCoptic('rOme')}), paste Coptic, or click Insert letters`;
+
   return (
     <div className={className}>
       <input
@@ -63,7 +69,7 @@ export default function CopticSearchInput({ value, onChange, onEnter, placeholde
         value={buffer}
         onChange={handleChange}
         onKeyDown={(e) => e.key === 'Enter' && onEnter && onEnter()}
-        placeholder={placeholder}
+        placeholder={effectivePlaceholder}
         className="w-full border rounded px-4 py-2"
       />
 
@@ -98,7 +104,7 @@ export default function CopticSearchInput({ value, onChange, onEnter, placeholde
           {paletteOpen ? 'Hide letters' : 'Insert letters'}
         </button>
         <span className="text-gray-400">
-          Type in Latin (Leipzig-Jerusalem):{' '}
+          Transliteration (Leipzig-Jerusalem):{' '}
           {HINT_KEYS.map((k) => `${k}→${transliterateToCoptic(k)}`).join('  ')}
         </span>
       </div>

--- a/client/src/components/search/LineSearch.jsx
+++ b/client/src/components/search/LineSearch.jsx
@@ -557,7 +557,6 @@ export default function LineSearch({ language }) {
                     value={query}
                     onChange={setQuery}
                     onEnter={handleSearch}
-                    placeholder="Type in Latin: rOme, shEre..."
                   />
                 ) : (
                   <input

--- a/client/src/components/search/WildcardSearch.jsx
+++ b/client/src/components/search/WildcardSearch.jsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useMemo, useEffect } from 'react';
 import { wildcardSearch } from '../../utils/api';
 import CopticSearchInput from './CopticSearchInput';
+import { transliterateToCoptic } from '../../utils/copticUtils';
 import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
 
@@ -239,18 +240,30 @@ const WildcardSearch = ({ language }) => {
         </p>
       </div>
 
-      {/* Syntax examples below (am*, "arma virumque", rex OR regina) use Latin words to
-          illustrate wildcard/boolean SYNTAX regardless of the active corpus language. */}
+      {/* Syntax examples are language-aware: Latin words for la/grc/en, real
+          Coptic words (codepoint-generated via the transliterator) for cop. */}
       <div className="bg-gray-50 rounded-lg p-4 text-sm">
         <h4 className="font-medium mb-2">Search Syntax</h4>
-        <ul className="space-y-1 text-gray-600">
-          <li><code className="bg-gray-200 px-1 rounded">*</code> matches any characters (e.g., <code>am*</code> finds amor, amicus, etc.)</li>
-          <li><code className="bg-gray-200 px-1 rounded">?</code> matches single character (e.g., <code>am?r</code> finds amor, amer)</li>
-          <li><code className="bg-gray-200 px-1 rounded">AND</code> both terms required (e.g., <code>amor AND bellum</code>)</li>
-          <li><code className="bg-gray-200 px-1 rounded">OR</code> either term (e.g., <code>rex OR regina</code>)</li>
-          <li><code className="bg-gray-200 px-1 rounded">~</code> proximity search (e.g., <code>amor ~ dolor</code> finds words within ~100 characters)</li>
-          <li><code className="bg-gray-200 px-1 rounded">"..."</code> exact phrase (e.g., <code>"arma virumque"</code>)</li>
-        </ul>
+        {language === 'cop' ? (
+          <ul className="space-y-1 text-gray-600">
+            <li><code className="bg-gray-200 px-1 rounded">*</code> matches any characters (e.g., <code>{transliterateToCoptic('noute')}*</code> finds words beginning {transliterateToCoptic('noute')})</li>
+            <li><code className="bg-gray-200 px-1 rounded">?</code> matches a single character (e.g., <code>{transliterateToCoptic('rOm')}?</code>)</li>
+            <li><code className="bg-gray-200 px-1 rounded">AND</code> both terms required (e.g., <code>{transliterateToCoptic('noute')} AND {transliterateToCoptic('rOme')}</code>)</li>
+            <li><code className="bg-gray-200 px-1 rounded">OR</code> either term (e.g., <code>{transliterateToCoptic('noute')} OR {transliterateToCoptic('joeis')}</code>)</li>
+            <li><code className="bg-gray-200 px-1 rounded">~</code> proximity search (e.g., <code>{transliterateToCoptic('noute')} ~ {transliterateToCoptic('rOme')}</code>, within ~100 characters)</li>
+            <li><code className="bg-gray-200 px-1 rounded">"..."</code> exact phrase (e.g., <code>"{transliterateToCoptic('shEre')} {transliterateToCoptic('noute')}"</code>)</li>
+            <li className="text-gray-500 pt-1">Enter Coptic by typing the transliteration (e.g. <code>noute</code> → {transliterateToCoptic('noute')}), clicking <em>Insert letters</em>, or pasting. Coptic joins words into groups, so use <code className="bg-gray-200 px-1 rounded">*</code> to find a word inside a group.</li>
+          </ul>
+        ) : (
+          <ul className="space-y-1 text-gray-600">
+            <li><code className="bg-gray-200 px-1 rounded">*</code> matches any characters (e.g., <code>am*</code> finds amor, amicus, etc.)</li>
+            <li><code className="bg-gray-200 px-1 rounded">?</code> matches single character (e.g., <code>am?r</code> finds amor, amer)</li>
+            <li><code className="bg-gray-200 px-1 rounded">AND</code> both terms required (e.g., <code>amor AND bellum</code>)</li>
+            <li><code className="bg-gray-200 px-1 rounded">OR</code> either term (e.g., <code>rex OR regina</code>)</li>
+            <li><code className="bg-gray-200 px-1 rounded">~</code> proximity search (e.g., <code>amor ~ dolor</code> finds words within ~100 characters)</li>
+            <li><code className="bg-gray-200 px-1 rounded">"..."</code> exact phrase (e.g., <code>"arma virumque"</code>)</li>
+          </ul>
+        )}
       </div>
 
       <div className="space-y-3">
@@ -261,7 +274,6 @@ const WildcardSearch = ({ language }) => {
               value={query}
               onChange={setQuery}
               onEnter={() => query.trim() && handleSearch()}
-              placeholder="Type in Latin: rOme, shEre, am* AND shEre..."
             />
           ) : (
             <input


### PR DESCRIPTION
Addresses two Coptologist-facing rough edges on the Coptic search boxes (follow-up to #174/#175).

## 1. Search-syntax examples were all Latin
String Search's **Search Syntax** legend illustrated `*`, `?`, `AND`, `OR`, `~`, `"..."` with Latin words (`amor`, `bellum`, `rex OR regina`, `"arma virumque"`) for *every* language. Now language-aware: for Coptic it uses real Coptic words generated via the transliterator —
- `ⲛⲟⲩⲧⲉ*`, `ⲣⲱⲙ?`, `ⲛⲟⲩⲧⲉ AND ⲣⲱⲙⲉ`, `ⲛⲟⲩⲧⲉ OR ϫⲟⲉⲓⲥ`, `ⲛⲟⲩⲧⲉ ~ ⲣⲱⲙⲉ`, `"ϣⲏⲣⲉ ⲛⲟⲩⲧⲉ"`
- plus a note: enter Coptic by transliteration (`noute` → ⲛⲟⲩⲧⲉ), the palette, or pasting, and use `*` to reach a word fused inside a bound group.

Latin/Greek/English keep their existing examples.

## 2. "Type in Latin" placeholder was misleading
The ghost text read `Type in Latin: rOme, shEre, am* AND shEre` — a Coptologist enters *Coptic*, not a Latin word, and the fragment was cluttered. Now:
- Placeholder (computed): **`Transliteration (rOme = ⲣⲱⲙⲉ), paste Coptic, or click Insert letters`** — names the term "transliteration" and shows the actual Coptic result.
- Hint label: **"Type in Latin"** → **"Transliteration (Leipzig-Jerusalem)"**.

All Coptic glyphs are codepoint-generated (no hand-typed Coptic); Coptic-gated, other languages unaffected; full build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)