### PR TITLE
Greek/English syntax examples + fix broken Greek accent matching

### DIFF
--- a/backend/wildcard_search.py
+++ b/backend/wildcard_search.py
@@ -40,33 +40,22 @@ def get_author_dates():
     except ImportError:
         return {}
 
-GREEK_DIACRITICAL_MAP = {
-    'ά': 'α', 'ὰ': 'α', 'ᾶ': 'α', 'ἀ': 'α', 'ἁ': 'α', 'ἂ': 'α', 'ἃ': 'α', 'ἄ': 'α', 'ἅ': 'α', 'ἆ': 'α', 'ἇ': 'α',
-    'ᾀ': 'α', 'ᾁ': 'α', 'ᾂ': 'α', 'ᾃ': 'α', 'ᾄ': 'α', 'ᾅ': 'α', 'ᾆ': 'α', 'ᾇ': 'α', 'ᾲ': 'α', 'ᾳ': 'α', 'ᾴ': 'α', 'ᾷ': 'α',
-    'έ': 'ε', 'ὲ': 'ε', 'ἐ': 'ε', 'ἑ': 'ε', 'ἒ': 'ε', 'ἓ': 'ε', 'ἔ': 'ε', 'ἕ': 'ε',
-    'ή': 'η', 'ὴ': 'η', 'ῆ': 'η', 'ἠ': 'η', 'ἡ': 'η', 'ἢ': 'η', 'ἣ': 'η', 'ἤ': 'η', 'ἥ': 'η', 'ἦ': 'η', 'ἧ': 'η',
-    'ᾐ': 'η', 'ᾑ': 'η', 'ᾒ': 'η', 'ᾓ': 'η', 'ᾔ': 'η', 'ᾕ': 'η', 'ᾖ': 'η', 'ᾗ': 'η', 'ῂ': 'η', 'ῃ': 'η', 'ῄ': 'η', 'ῇ': 'η',
-    'ί': 'ι', 'ὶ': 'ι', 'ῖ': 'ι', 'ἰ': 'ι', 'ἱ': 'ι', 'ἲ': 'ι', 'ἳ': 'ι', 'ἴ': 'ι', 'ἵ': 'ι', 'ἶ': 'ι', 'ἷ': 'ι', 'ϊ': 'ι', 'ΐ': 'ι', 'ῒ': 'ι', 'ῗ': 'ι',
-    'ό': 'ο', 'ὸ': 'ο', 'ὀ': 'ο', 'ὁ': 'ο', 'ὂ': 'ο', 'ὃ': 'ο', 'ὄ': 'ο', 'ὅ': 'ο',
-    'ύ': 'υ', 'ὺ': 'υ', 'ῦ': 'υ', 'ὐ': 'υ', 'ὑ': 'υ', 'ὒ': 'υ', 'ὓ': 'υ', 'ὔ': 'υ', 'ὕ': 'υ', 'ὖ': 'υ', 'ὗ': 'υ', 'ϋ': 'υ', 'ΰ': 'υ', 'ῢ': 'υ', 'ῧ': 'υ',
-    'ώ': 'ω', 'ὼ': 'ω', 'ῶ': 'ω', 'ὠ': 'ω', 'ὡ': 'ω', 'ὢ': 'ω', 'ὣ': 'ω', 'ὤ': 'ω', 'ὥ': 'ω', 'ὦ': 'ω', 'ὧ': 'ω',
-    'ᾠ': 'ω', 'ᾡ': 'ω', 'ᾢ': 'ω', 'ᾣ': 'ω', 'ᾤ': 'ω', 'ᾥ': 'ω', 'ᾦ': 'ω', 'ᾧ': 'ω', 'ῲ': 'ω', 'ῳ': 'ω', 'ῴ': 'ω', 'ῷ': 'ω',
-    'ῤ': 'ρ', 'ῥ': 'ρ',
-}
-
-
 def normalize_greek(text: str) -> str:
     """
-    Normalize Greek text by removing diacriticals (accents, breathings, iota subscripts).
-    This allows searches like 'λογος' to match 'λόγος'.
+    Remove Greek diacritics (accents, breathings, iota subscripts) so an
+    accented query matches accentless text and vice versa -- e.g. both 'λογος'
+    and 'λόγος' match the corpus.
+
+    Works regardless of Unicode normalization form: the text is decomposed
+    (NFD) so every diacritic becomes a combining mark, then all combining marks
+    are stripped. The Greek corpus is stored in NFD while typed/pasted queries
+    are usually NFC; the previous precomposed-only character map reduced NFC
+    queries to base letters but left the NFD corpus untouched, so accented
+    queries matched nothing. Case is preserved -- the caller controls
+    case-sensitivity via regex flags.
     """
-    result = []
-    for char in text:
-        if char in GREEK_DIACRITICAL_MAP:
-            result.append(GREEK_DIACRITICAL_MAP[char])
-        else:
-            result.append(char)
-    return ''.join(result)
+    decomposed = unicodedata.normalize('NFD', text)
+    return ''.join(ch for ch in decomposed if not unicodedata.combining(ch))
 
 def normalize_latin(text: str) -> str:
     """
@@ -222,11 +211,13 @@ def search_file(filepath: str, parsed_query: Dict, case_sensitive: bool = False,
             search_text = text
 
         if matches_query(search_text, parsed_query, flags, is_greek, is_latin, is_coptic):
-            # Coptic normalization changes string length (strokes are stripped),
-            # so match positions on normalized text don't map back to the raw
-            # display text. Highlight whole bound groups instead of exact spans.
-            if is_coptic:
-                highlight_indices = get_coptic_highlight_indices(text, parsed_query, flags)
+            # Coptic and Greek normalizers change string length (strokes /
+            # combining accents are stripped), so match positions on the
+            # normalized text don't map back to the raw display text. Highlight
+            # whole tokens for those; Latin/English keep exact-span highlights.
+            token_normalizer = normalize_coptic if is_coptic else (normalize_greek if is_greek else None)
+            if token_normalizer:
+                highlight_indices = get_token_highlight_indices(text, parsed_query, flags, token_normalizer)
             else:
                 highlight_indices = get_highlight_indices(text, parsed_query, flags, is_greek, is_latin)
 
@@ -234,8 +225,8 @@ def search_file(filepath: str, parsed_query: Dict, case_sensitive: bool = False,
             display_text = text
             if is_prose and len(text) > 150:
                 display_text = extract_sentences_with_matches(text, highlight_indices)
-                if is_coptic:
-                    highlight_indices = get_coptic_highlight_indices(display_text, parsed_query, flags)
+                if token_normalizer:
+                    highlight_indices = get_token_highlight_indices(display_text, parsed_query, flags, token_normalizer)
                 else:
                     highlight_indices = get_highlight_indices(display_text, parsed_query, flags, is_greek, is_latin)
             
@@ -376,15 +367,16 @@ def get_highlight_indices(text: str, parsed_query: Dict, flags: int, is_greek: b
     return indices
 
 
-def get_coptic_highlight_indices(text: str, parsed_query: Dict, flags: int) -> List[List[int]]:
-    """Highlight indices for Coptic, at whole bound-group granularity.
+def get_token_highlight_indices(text: str, parsed_query: Dict, flags: int, normalizer) -> List[List[int]]:
+    """Highlight indices at whole-token (whitespace-delimited) granularity.
 
-    normalize_coptic() removes characters (supralinear strokes), so exact
-    match offsets computed on the normalized string don't line up with the
-    raw display text. Instead, walk the raw text group by group (whitespace-
-    delimited bound groups), normalize each group, and mark the whole raw
-    group when a query term matches inside it. Spans are on the raw text, so
-    they align with apply_highlighting().
+    Used for languages whose normalizer changes string length, so exact match
+    offsets on the normalized string don't line up with the raw display text:
+    normalize_coptic() strips supralinear strokes, and normalize_greek() strips
+    combining accents. Walk the raw text token by token, normalize each token,
+    and mark the whole raw token when a query term matches inside it. Spans are
+    on the raw text, so they align with apply_highlighting(). For Greek this is
+    exactly word-level highlighting; for Coptic it highlights the bound group.
     """
     terms = []
     query_type = parsed_query.get('type', 'simple')
@@ -395,14 +387,14 @@ def get_coptic_highlight_indices(text: str, parsed_query: Dict, flags: int) -> L
     elif query_type == 'proximity':
         terms = [parsed_query['term1'], parsed_query['term2']]
 
-    patterns = [r'\b' + normalize_coptic(t['pattern']) + r'\b' for t in terms]
+    patterns = [r'\b' + normalizer(t['pattern']) + r'\b' for t in terms]
     if not patterns:
         return []
 
     indices = []
     for m in re.finditer(r'\S+', text):
-        group_norm = normalize_coptic(m.group(0))
-        if any(re.search(p, group_norm, flags) for p in patterns):
+        token_norm = normalizer(m.group(0))
+        if any(re.search(p, token_norm, flags) for p in patterns):
             indices.append([m.start(), m.end()])
     return indices
 

--- a/client/src/components/search/WildcardSearch.jsx
+++ b/client/src/components/search/WildcardSearch.jsx
@@ -2,6 +2,19 @@ import { useState, useCallback, useRef, useMemo, useEffect } from 'react';
 import { wildcardSearch } from '../../utils/api';
 import CopticSearchInput from './CopticSearchInput';
 import { transliterateToCoptic } from '../../utils/copticUtils';
+import { GREEK_SYNTAX_EXAMPLES } from '../../utils/greekUtils';
+
+// Search-syntax example words per language. Latin/English are plain ASCII;
+// Greek is imported (extracted verbatim from the corpus, never hand-typed);
+// Coptic is generated inline via the transliterator below.
+const LA_SYNTAX_EXAMPLES = {
+  wild: 'am*', wildFind: 'amor, amicus, etc.', single: 'am?r',
+  and: 'amor AND bellum', or: 'rex OR regina', prox: 'amor ~ dolor', phrase: '"arma virumque"',
+};
+const EN_SYNTAX_EXAMPLES = {
+  wild: 'lov*', wildFind: 'love, lover, etc.', single: 'w?r',
+  and: 'love AND war', or: 'king OR queen', prox: 'love ~ death', phrase: '"the quality of mercy"',
+};
 import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
 
@@ -230,6 +243,7 @@ const WildcardSearch = ({ language }) => {
   };
 
   const languageLabel = language === 'la' ? 'Latin' : language === 'grc' ? 'Greek' : language === 'cop' ? 'Coptic' : 'English';
+  const syntaxEx = language === 'grc' ? GREEK_SYNTAX_EXAMPLES : language === 'en' ? EN_SYNTAX_EXAMPLES : LA_SYNTAX_EXAMPLES;
 
   return (
     <div className="space-y-4">
@@ -256,12 +270,12 @@ const WildcardSearch = ({ language }) => {
           </ul>
         ) : (
           <ul className="space-y-1 text-gray-600">
-            <li><code className="bg-gray-200 px-1 rounded">*</code> matches any characters (e.g., <code>am*</code> finds amor, amicus, etc.)</li>
-            <li><code className="bg-gray-200 px-1 rounded">?</code> matches single character (e.g., <code>am?r</code> finds amor, amer)</li>
-            <li><code className="bg-gray-200 px-1 rounded">AND</code> both terms required (e.g., <code>amor AND bellum</code>)</li>
-            <li><code className="bg-gray-200 px-1 rounded">OR</code> either term (e.g., <code>rex OR regina</code>)</li>
-            <li><code className="bg-gray-200 px-1 rounded">~</code> proximity search (e.g., <code>amor ~ dolor</code> finds words within ~100 characters)</li>
-            <li><code className="bg-gray-200 px-1 rounded">"..."</code> exact phrase (e.g., <code>"arma virumque"</code>)</li>
+            <li><code className="bg-gray-200 px-1 rounded">*</code> matches any characters (e.g., <code>{syntaxEx.wild}</code> finds {syntaxEx.wildFind})</li>
+            <li><code className="bg-gray-200 px-1 rounded">?</code> matches a single character (e.g., <code>{syntaxEx.single}</code>)</li>
+            <li><code className="bg-gray-200 px-1 rounded">AND</code> both terms required (e.g., <code>{syntaxEx.and}</code>)</li>
+            <li><code className="bg-gray-200 px-1 rounded">OR</code> either term (e.g., <code>{syntaxEx.or}</code>)</li>
+            <li><code className="bg-gray-200 px-1 rounded">~</code> proximity search (e.g., <code>{syntaxEx.prox}</code>, within ~100 characters)</li>
+            <li><code className="bg-gray-200 px-1 rounded">"..."</code> exact phrase (e.g., <code>{syntaxEx.phrase}</code>)</li>
           </ul>
         )}
       </div>

--- a/client/src/utils/greekUtils.js
+++ b/client/src/utils/greekUtils.js
@@ -15,3 +15,16 @@ export const normalizeGreek = (text) => {
     .toLowerCase()
     .replace(/ς/g, 'σ');
 };
+
+// Search-syntax example strings for the String Search legend. The Greek
+// words are extracted verbatim from Iliad 1.1 in the corpus (never typed),
+// so the accents/encoding are exactly what the corpus uses.
+export const GREEK_SYNTAX_EXAMPLES = {
+  wild: "μῆν*",
+  wildFind: "μῆνιν",
+  single: "θε?",
+  and: "μῆνιν AND θεὰ",
+  or: "θεὰ OR ἄειδε",
+  prox: "μῆνιν ~ ἄειδε",
+  phrase: "\"μῆνιν ἄειδε\"",
+};


### PR DESCRIPTION
Follow-up to #176 (which made the String Search syntax legend Coptic-aware). Extends language-aware examples to **Greek and English** — and in doing so uncovered and fixed a real bug in Greek search.

## Bug found & fixed: Greek accent matching
Adding Greek examples revealed that **Greek String Search only matched the exact NFD form the corpus stores**. The corpus is NFD (base letters + separate combining accents), but `normalize_greek` only mapped *precomposed* (NFC) accented characters to base letters — it never touched the NFD corpus. So a normal keyboard query (NFC) for an accented word returned **0 results**.

**Fix** (`backend/wildcard_search.py`): `normalize_greek` now decomposes to NFD and strips all combining marks. Accent-insensitive matching works regardless of input normalization. Verified — queries for μῆνιν against Iliad 1.1:

| query form | before | after |
|---|---|---|
| NFC (keyboard) | 0 | ✅ 2 |
| accentless | 0 | ✅ 2 |
| NFD (corpus) | 2 | ✅ 2 |

Because the normalizer now changes string length, Greek highlighting uses the same whole-token approach introduced for Coptic (`get_coptic_highlight_indices` generalized to `get_token_highlight_indices(…, normalizer)`); for Greek that's exactly word-level highlighting. **Latin/English unaffected** (arma→145, uirum→51, exact-span highlights preserved).

## Language-aware examples
The Search Syntax legend now uses per-language words:
- **Greek**: `μῆν*`, `θε?`, `μῆνιν AND θεὰ`, `θεὰ OR ἄειδε`, `μῆνιν ~ ἄειδε`, `"μῆνιν ἄειδε"` — extracted **verbatim from Iliad 1.1 in the corpus** (never hand-typed), stored in a generated constant in `greekUtils.js`, so the component has no Greek literals.
- **English**: `lov*`, `love AND war`, `king OR queen`, `"the quality of mercy"`, etc.
- Latin and Coptic unchanged.

All generated Greek examples verified to return real matches. Full build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)