### PR TITLE
Fix Greek Line Search crash under ASCII filesystem locale

### DIFF
--- a/backend/frequency_cache.py
+++ b/backend/frequency_cache.py
@@ -40,19 +40,31 @@ def deduplicate_text_files(text_files):
     return deduplicated
 
 def get_corpus_checksum(language):
-    """Get a checksum of all .tess files in a language directory"""
+    """Get a checksum of all .tess files in a language directory.
+
+    Iterates the directory using *bytes* paths so it works regardless of the
+    process filesystem encoding. Under an ASCII/C locale (as on some WSGI
+    deployments) os.stat() on a str path containing non-ASCII characters — e.g.
+    Greek filenames like "aeschylus.ἀγαμέμνων.tess" — raises UnicodeEncodeError;
+    bytes paths sidestep that entirely.
+    """
     lang_dir = os.path.join(TEXTS_DIR, language)
     if not os.path.exists(lang_dir):
         return None
-    
-    files = sorted([f for f in safe_listdir(lang_dir) if f.endswith('.tess')])
+
+    lang_dir_bytes = os.fsencode(lang_dir)  # lang_dir is ASCII, so this is safe
+    names = sorted(n for n in os.listdir(lang_dir_bytes) if n.endswith(b'.tess'))
     file_info = []
-    for f in files:
-        path = os.path.join(lang_dir, f)
-        stat = os.stat(path)
+    for name_bytes in names:
+        stat = os.stat(os.path.join(lang_dir_bytes, name_bytes))
+        f = os.fsdecode(name_bytes)
         file_info.append(f"{f}:{stat.st_size}:{stat.st_mtime}")
-    
-    checksum = hashlib.md5('\n'.join(file_info).encode()).hexdigest()  # nosec B324
+
+    # surrogatepass preserves surrogate-escaped names produced under an ASCII
+    # locale; for ASCII/UTF-8 names this yields the exact same bytes (and thus
+    # the same checksum) as the previous implementation, so existing frequency
+    # caches for Latin/English/Coptic are not needlessly invalidated.
+    checksum = hashlib.md5('\n'.join(file_info).encode('utf-8', 'surrogatepass')).hexdigest()  # nosec B324
     return checksum
 
 def get_cache_path(language):


### PR DESCRIPTION
## Problem
Greek **Line Search** returned 0 results for every query on production — it was **crashing**, not just empty. The live error:
> `'ascii' codec can't encode characters … ordinal not in range(128)`

**Root cause** (from the prod traceback): `line_search` → `get_corpus_frequencies` → `get_corpus_checksum`, which does `os.stat()` on each corpus file via a **str** path. **55 of the Greek texts have non-ASCII (Greek) filenames** (`aeschylus.ἀγαμέμνων.tess`, `nicomachus_of_gerasa.ἀριθμητικὴ_εἰσαγωγή.tess`, …). The production WSGI process runs under an **ASCII/C filesystem locale**, so encoding those paths raises `UnicodeEncodeError`, which propagates out and kills the whole request before any search runs.

This is **not** the NFC/NFD accent issue (that was fixed for String Search in #177; Line Search lemmatizes accent-insensitively). It's a filesystem-encoding crash specific to the ASCII-locale prod environment.

## Fix
Iterate the directory with **bytes paths** (`os.listdir(os.fsencode(dir))` + `os.stat` on bytes joins), which is locale-independent. The checksum string is rebuilt from `os.fsdecode(name)` with `surrogatepass`, so ASCII/UTF-8 names produce the **exact same bytes → same checksum** as before — Latin/English/Coptic frequency caches are **not** invalidated (verified byte-identical).

## Verification (simulated ASCII locale, `LC_ALL=C`, `fsencoding=ascii`)
- `get_corpus_checksum('grc')` no longer crashes.
- Greek line search runs **end to end**: 4111 results for "θεός ἄνθρωπος", processing all 52 Greek-filename candidates.
- Greek-named texts display correctly (no surrogate garbling): *Nicomachus of Gerasa — Ἀριθμητικὴ Εἰσαγωγή*, *Pseudolucian — Λούκιος Ἢ Ὄνος*, etc.
- Latin checksum byte-identical to the previous implementation.

## Scope
Targeted stopgap for the line-search crash. The **root cause is the ASCII filesystem locale**; the complete fix is to run the WSGI process in UTF-8 (`PYTHONUTF8=1`), handled separately as a server-config change. Other paths that touch the 55 Greek-named files can still degrade under the ASCII locale until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)