### PR TITLE
Support Coptic in Rare Pairs (bigram) search

### DIFF
--- a/backend/bigram_frequency.py
+++ b/backend/bigram_frequency.py
@@ -109,6 +109,17 @@ def calculate_bigram_frequencies(language, text_processor, progress_callback=Non
     doc_bigrams = Counter()
     
     text_files = [f for f in os.listdir(lang_dir) if f.endswith('.tess')]
+
+    if language == 'cop':
+        # Exclude aggregate/superset corpora (whole-Bible, OT, NT, and the
+        # combined Shenoute corpus). Otherwise a bigram in an individual book is
+        # also counted in its aggregate, deflating its rarity — the same reason
+        # the Coptic search index is built without them.
+        text_files = [
+            f for f in text_files
+            if f[:-len('.tess')].split('.')[-1] not in ('bible', 'ot', 'nt', 'all')
+        ]
+
     if '.part.' in str(text_files):
         full_versions = set()
         for f in text_files:

--- a/backend/blueprints/admin.py
+++ b/backend/blueprints/admin.py
@@ -1336,7 +1336,7 @@ def bigram_cache_stats():
         return jsonify({'error': 'Unauthorized'}), 401
     
     stats = {}
-    for lang in ['la', 'grc', 'en']:
+    for lang in ['la', 'grc', 'en', 'cop']:
         if is_bigram_cache_available(lang):
             stats[lang] = get_bigram_stats(lang)
         else:
@@ -1353,7 +1353,7 @@ def build_bigram_cache():
     data = request.get_json() or {}
     language = data.get('language', 'la')
     
-    if language not in ['la', 'grc', 'en']:
+    if language not in ['la', 'grc', 'en', 'cop']:
         return jsonify({'error': 'Invalid language'}), 400
     
     try:

--- a/backend/blueprints/hapax.py
+++ b/backend/blueprints/hapax.py
@@ -41,6 +41,23 @@ from backend.services import log_search, get_user_location
 
 logger = get_logger('hapax')
 
+# Coptic lemmatization normalizes the seven Coptic-only letters into the
+# "dialect-P" Coptic block (ϣ→ⲳ, ϩ→ⲹ, ϫ→ⲻ, …). For display we reverse that so
+# results show the manuscript letterforms scholars recognize. Built from the
+# forward map, so there is no hand-typed Coptic here.
+try:
+    from backend.coptic.processor import _LEGACY_TO_COPTIC as _COPTIC_LEGACY_MAP
+    _COPTIC_TO_MANUSCRIPT = {v: k for k, v in _COPTIC_LEGACY_MAP.items()}
+except Exception:  # pragma: no cover - coptic package optional
+    _COPTIC_TO_MANUSCRIPT = {}
+
+
+def _coptic_manuscript_form(text):
+    """Restore manuscript Coptic letterforms from the normalized lemma alphabet."""
+    if not text or not _COPTIC_TO_MANUSCRIPT:
+        return text
+    return ''.join(_COPTIC_TO_MANUSCRIPT.get(ch, ch) for ch in text)
+
 # Greek display forms: normalized lemma -> accented form for display
 _greek_display_forms = None
 def get_greek_display_forms():
@@ -2235,6 +2252,11 @@ def rare_bigram_search():
                 # Get proper dictionary forms for display
                 dict_form1 = get_dictionary_form(lemma1, language)
                 dict_form2 = get_dictionary_form(lemma2, language)
+                if language == 'cop':
+                    # Show manuscript letterforms (ϣ, ϩ, ϫ …) rather than the
+                    # normalized dialect-P block used internally for matching.
+                    dict_form1 = _coptic_manuscript_form(dict_form1)
+                    dict_form2 = _coptic_manuscript_form(dict_form2)
                 
                 # Get actual matched words from all locations for highlighting
                 src_locs = source_bigram_locations[bg_key]


### PR DESCRIPTION
## Problem
Rare Pairs for Coptic errored: **"Bigram index not built for cop. Please build it in Admin → Cache Management."** Two gaps: the bigram frequency cache was never built for `cop`, and the admin build/stats endpoints were gated to `la/grc/en` (so it couldn't be built from the UI either). The search endpoint itself already accepted `cop` — it just needs the cache present.

## Changes
- **`admin.py`**: allow `cop` in `bigram-cache/build` and `bigram-cache/stats`.
- **`bigram_frequency.py`**: when building for `cop`, exclude the **7 aggregate/superset corpora** (`sahidic.bible/ot`, `sahidica.nt`, `bohairic.bible/nt/ot`, `shenoute.all`). Otherwise a bigram in an individual book is also counted in its aggregate, deflating its rarity — the same reason the Coptic search index is built without them. (Filter is on the last dotted component ∈ {bible, ot, nt, all}; individual books like `john`/`genesis` are kept — verified no collisions.)

## Data
The cache (`cache/bigrams/cop_bigrams.json`) is built as a data op and deployed to prod alongside this PR (it's not in git — large). Build: **180 texts** (7 aggregates excluded), **190,422 unique bigrams**, 0 errors, ~13s. Uses Coptic sub-word lemmatization via `process_file`.

## Verification
Matthew × Luke → **142 shared rare bigrams** (rarity ≥ 0.9), surfacing meaningful proper-noun collocations: Solomon (ⲥⲟⲗⲟⲙⲱⲛ), Nazareth (ⲛⲁⲍⲁⲣⲉⲑ), Capernaum (ⲕⲁⲫⲁⲣⲛⲁⲟⲩⲙ). `is_bigram_cache_available('cop')` → True. Latin/Greek/English builds unchanged (cop-only branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)