### PR TITLE
Filter Coptic function words from Rare Pairs (fixes one-word-highlighted results)

### DIFF
--- a/backend/blueprints/hapax.py
+++ b/backend/blueprints/hapax.py
@@ -193,6 +193,19 @@ def is_word_in_stoplist(word, language):
             if entry_norm == normalized:
                 return True
         return False
+    elif language == 'cop':
+        # Coptic rare-pair lemmas and COPTIC_STOP_WORDS are both in the
+        # normalized (normalize_coptic) alphabet, so they compare directly.
+        # Without this, Coptic function words (articles like ⲡ, particles like
+        # ϫⲉ) were never filtered, so rare pairs came out as content-word +
+        # function-word — only one meaningful, highlightable word — rather than
+        # genuine two-word collocations.
+        try:
+            from backend.coptic.stopwords import COPTIC_STOP_WORDS
+            from backend.coptic.processor import normalize_coptic
+            return normalize_coptic(word.lower().strip()) in COPTIC_STOP_WORDS
+        except Exception:
+            return False
 
     return False
 


### PR DESCRIPTION
## Problem
In Coptic Rare Pairs, most results showed only **one highlighted word per side**. Root cause: `is_word_in_stoplist()` only handled Latin/Greek, so **Coptic function words were never filtered**. Results came out as content-word + function-word — e.g. `ⲕⲁⲩⲥⲱⲛ + ⲡ` (keauson + article), `ⲛⲁⲍⲁⲣⲉⲑ + ϫⲉ` (Nazareth + "that") — where only the content word is meaningful, and the fused 1–2 char function word can't be highlighted.

## Fix
Wire `COPTIC_STOP_WORDS` (`backend/coptic/stopwords.py`, 144 words, already in the normalized alphabet the rare-pair lemmas use) into `is_word_in_stoplist` for `cop`. A pair is dropped when *either* word is a stopword, so results become genuine **content + content** collocations where both words highlight.

## Effect (Matthew × Luke, default settings)
- Before: 142 "rare" pairs, ~137 of them content+function noise.
- After: the function-word pairs drop out, leaving real collocations — **ⲡⲉⲧⲣⲟⲥ + ⲥⲓⲙⲱⲛ** (Peter + Simon), **ⲟⲩⲇⲉ + ⲥⲟⲗⲟⲙⲱⲛ**, **ⲕⲁⲫⲁⲣⲛⲁⲟⲩⲙ …** — both words highlighted.

The search semantics are unchanged (still shared bigrams rare in the corpus); this only stops function words from forming the pair. Latin/Greek/English unaffected (cop-only branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)