### PR TITLE
Add a one-line description of what each search mode does

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { Header, Navigation } from './components/layout';
 import { SearchModeToggle, TextSelector, SearchSettings, SearchResults, LineSearch, CrossLingualSearch, WildcardSearch, SavedSearches, CorpusSearchResults, RarePairsSettings } from './components/search';
 import RareResultsDisplay from './components/search/RareResultsDisplay';
+import SearchDescription from './components/search/SearchDescription';
 import { Modal, LoadingSpinner } from './components/common';
 import { CorpusBrowser, RareWordsExplorer } from './components/corpus';
 import { Repository } from './components/repository';
@@ -680,6 +681,8 @@ function App() {
                 <SearchModeToggle searchMode={searchMode} setSearchMode={setSearchMode} />
               </div>
 
+              <SearchDescription mode={searchMode} className="mb-6 -mt-2" />
+
               {searchMode === 'line' ? (
                 <LineSearch key={activeTab} language={activeTab} />
               ) : searchMode === 'string' ? (
@@ -827,7 +830,10 @@ function App() {
         )}
 
         {pageType === 'search' && activeTab === 'cross' && (
-          <CrossLingualSearch />
+          <div className="space-y-3">
+            <SearchDescription mode="cross" className="px-1" />
+            <CrossLingualSearch />
+          </div>
         )}
 
         {pageType === 'browse' && (
@@ -862,12 +868,14 @@ function App() {
 
         {pageType === 'line-search' && (
           <div className="bg-white rounded-lg shadow p-4 sm:p-6">
+            <SearchDescription mode="line" className="mb-4" />
             <LineSearch key={activeTab} language={activeTab} />
           </div>
         )}
 
         {pageType === 'string-search' && (
           <div className="bg-white rounded-lg shadow p-4 sm:p-6">
+            <SearchDescription mode="string" className="mb-4" />
             <WildcardSearch language={activeTab} />
           </div>
         )}

--- a/client/src/components/search/SearchDescription.jsx
+++ b/client/src/components/search/SearchDescription.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+// One-line, plain-language explanation of what each search mode does, shown
+// under the mode toggle (and on the standalone Line/String and Cross-Language
+// pages). Language-agnostic — the same description applies to every language.
+export const SEARCH_DESCRIPTIONS = {
+  parallel:
+    'You set only the texts to compare; the search finds the most similar phrases between them, based on a variety of similarity types.',
+  line:
+    'You enter a line to find other lines like it.',
+  string:
+    'You enter specific terms, and can use wildcards (am*), phrases, and AND/OR operators.',
+  bigram:
+    'Finds uncommon two-word combinations that appear in both of two chosen texts but are rare across the corpus — it can catch rare combinations of otherwise ordinary words.',
+  hapax:
+    'Finds rare words that two chosen texts share.',
+  cross:
+    'Finds parallels across languages — e.g. the Greek source behind a Latin, Coptic, or English text.',
+};
+
+export default function SearchDescription({ mode, className = '' }) {
+  const text = SEARCH_DESCRIPTIONS[mode];
+  if (!text) return null;
+  return <p className={`text-sm text-gray-600 ${className}`}>{text}</p>;
+}


### PR DESCRIPTION
Adds a short, always-visible explanation of each search mode so users (and we) don't have to remember what each one does.

- Appears under the mode toggle on the main search page (updates with the selected mode: Phrases / Lines / String Search / Rare Pairs / Rare Words), on the standalone Line-Search and String-Search pages, and on Cross-Language.
- Plain one-liners, **language-agnostic** (same for all languages).
- All copy lives in one shared component (`SearchDescription`) so it's consistent and trivial to reword.

Wording (approved by NC):
- **Phrases** — You set only the texts to compare; the search finds the most similar phrases between them, based on a variety of similarity types.
- **Lines** — You enter a line to find other lines like it.
- **String Search** — You enter specific terms, and can use wildcards (am*), phrases, and AND/OR operators.
- **Rare Pairs** — Finds uncommon two-word combinations that appear in both of two chosen texts but are rare across the corpus — it can catch rare combinations of otherwise ordinary words.
- **Rare Words** — Finds rare words that two chosen texts share.
- **Cross-Language** — Finds parallels across languages — e.g. the Greek source behind a Latin, Coptic, or English text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)