### PR TITLE
Group search-mode description with the toggle + reword Lines/String

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -678,10 +678,12 @@ function App() {
                     </button>
                   )}
                 </div>
-                <SearchModeToggle searchMode={searchMode} setSearchMode={setSearchMode} />
               </div>
 
-              <SearchDescription mode={searchMode} className="mb-6 -mt-2" />
+              <div className="mb-6">
+                <SearchModeToggle searchMode={searchMode} setSearchMode={setSearchMode} />
+                <SearchDescription mode={searchMode} className="mt-2 px-1" />
+              </div>
 
               {searchMode === 'line' ? (
                 <LineSearch key={activeTab} language={activeTab} />

--- a/client/src/components/search/SearchDescription.jsx
+++ b/client/src/components/search/SearchDescription.jsx
@@ -7,9 +7,9 @@ export const SEARCH_DESCRIPTIONS = {
   parallel:
     'You set only the texts to compare; the search finds the most similar phrases between them, based on a variety of similarity types.',
   line:
-    'You enter a line to find other lines like it.',
+    'Enter a line to find other lines like it. Choose an existing line to search or write your own.',
   string:
-    'You enter specific terms, and can use wildcards (am*), phrases, and AND/OR operators.',
+    'Enter specific terms, optionally with wildcards (am*), phrases, or AND/OR operators.',
   bigram:
     'Finds uncommon two-word combinations that appear in both of two chosen texts but are rare across the corpus — it can catch rare combinations of otherwise ordinary words.',
   hapax:


### PR DESCRIPTION
Follow-up to #182. The mode toggle was right-justified while its description was left-justified, so they didn't read as connected. Now the toggle and its description sit together in one left-aligned block. Also reworded per NC: Lines → "Enter a line to find other lines like it. Choose an existing line to search or write your own."; String → "Enter specific terms, optionally with wildcards (am*), phrases, or AND/OR operators."

🤖 Generated with [Claude Code](https://claude.com/claude-code)