### PR TITLE
Reword Rare Words description to "rare individual words"

### DIFF
--- a/client/src/components/search/SearchDescription.jsx
+++ b/client/src/components/search/SearchDescription.jsx
@@ -13,7 +13,7 @@ export const SEARCH_DESCRIPTIONS = {
   bigram:
     'Finds uncommon two-word combinations that appear in both of two chosen texts but are rare across the corpus — it can catch rare combinations of otherwise ordinary words.',
   hapax:
-    'Finds rare words that two chosen texts share.',
+    'Finds rare individual words that two chosen texts share.',
   cross:
     'Finds parallels across languages — e.g. the Greek source behind a Latin, Coptic, or English text.',
 };


### PR DESCRIPTION
One-word clarification so Rare Words (single shared rare words) reads as distinct from Rare Pairs (two-word combinations). Per NC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)