### PR TITLE
Prototype: user-adjustable channel weights (Advanced)

### DIFF
--- a/backend/blueprints/fusion.py
+++ b/backend/blueprints/fusion.py
@@ -92,6 +92,13 @@ def search_fusion_stream():
             if max_results <= 0:
                 max_results = 5000  # enforce cap for browser payload size
 
+            # Optional user-supplied per-channel weight overrides (Advanced UI).
+            # Sanitized here (numbers only, known channels only, clamped) so the
+            # rest of the pipeline can trust it. Empty dict => no overrides =>
+            # default weight profile (behavior unchanged).
+            from backend.fusion import sanitize_channel_weights
+            channel_weights = sanitize_channel_weights(data.get('channel_weights'))
+
             if not source_id or not target_id:
                 yield f"data: {json.dumps({'type': 'error', 'message': 'Please select both source and target texts'})}\n\n"
                 return
@@ -116,6 +123,11 @@ def search_fusion_stream():
                 'use_meter': use_meter,
                 'freq_basis': freq_basis,
             }
+            # Only add to the cache key when the user actually supplied custom
+            # weights, so default-weight searches keep their existing cache
+            # entries (and never read/write a custom-weight result by mistake).
+            if channel_weights:
+                cache_settings['channel_weights'] = channel_weights
             cached_results, cached_meta = (None, None) if skip_cache else \
                 get_cached_results(source_id, target_id, language, cache_settings)
             if cached_results is not None:
@@ -186,6 +198,7 @@ def search_fusion_stream():
                 target_path=target_path,
                 user_settings={'use_meter': use_meter},
                 freq_basis=freq_basis,
+                channel_weights=channel_weights,
             ):
                 if event_type == "channel_start":
                     phase = evt_data['phase']
@@ -276,3 +289,29 @@ def search_fusion_stream():
         'Connection': 'keep-alive',
         'X-Accel-Buffering': 'no',
     })
+
+
+@fusion_bp.route('/fusion-default-weights', methods=['GET'])
+def fusion_default_weights():
+    """Return the default per-channel fusion weights for a language.
+
+    Used by the Advanced "Channel weights" UI to pre-fill its inputs with the
+    optimized defaults, and to know what "Reset to defaults" restores. Read-only
+    and side-effect-free; does not affect any search.
+
+    Query params:
+        language — la (default) | grc | en | cop | ...
+
+    Response: {"language": "la", "weights": {"lemma": 2.0, ...},
+               "min": 0.0, "max": 20.0}
+    """
+    from backend.fusion import (get_weight_profile, USER_WEIGHT_MIN,
+                                USER_WEIGHT_MAX)
+    language = request.args.get('language', 'la')
+    weights = get_weight_profile(language=language)
+    return {
+        'language': language,
+        'weights': weights,
+        'min': USER_WEIGHT_MIN,
+        'max': USER_WEIGHT_MAX,
+    }

--- a/backend/blueprints/fusion.py
+++ b/backend/blueprints/fusion.py
@@ -96,8 +96,33 @@ def search_fusion_stream():
             # Sanitized here (numbers only, known channels only, clamped) so the
             # rest of the pipeline can trust it. Empty dict => no overrides =>
             # default weight profile (behavior unchanged).
-            from backend.fusion import sanitize_channel_weights
+            from backend.fusion import (sanitize_channel_weights,
+                                        sanitize_channel_keys,
+                                        get_channels_for_language)
             channel_weights = sanitize_channel_weights(data.get('channel_weights'))
+
+            # Optional per-channel ON/OFF switches (Advanced UI). The request
+            # carries disabled_channels — the channels the user turned OFF. A
+            # disabled channel is excluded from running entirely (a true off,
+            # unlike weight=0 which still runs and can pull pairs in via
+            # convergence). We turn that into enabled_channels, the KEEP-set
+            # passed downstream: (channels available for this language) minus
+            # (the ones the user disabled). Sending the OFF list (rather than
+            # the keep list) means channels the UI never exposes — e.g.
+            # `quotation` — stay on unless explicitly disabled, and a search
+            # with nothing turned off is byte-identical to today.
+            disabled_channels = sanitize_channel_keys(data.get('disabled_channels'))
+            available_for_lang = set(get_channels_for_language(language))
+            enabled_channels = None  # None => no restriction (default behavior)
+            if disabled_channels:
+                effective_disabled = disabled_channels & available_for_lang
+                keep = available_for_lang - effective_disabled
+                # Only a real restriction if it actually drops a channel that
+                # would otherwise run AND leaves at least one running. If the
+                # user turned everything off, fall back to the full set (guard
+                # rail) rather than running an empty search.
+                if effective_disabled and keep:
+                    enabled_channels = keep
 
             if not source_id or not target_id:
                 yield f"data: {json.dumps({'type': 'error', 'message': 'Please select both source and target texts'})}\n\n"
@@ -128,6 +153,11 @@ def search_fusion_stream():
             # entries (and never read/write a custom-weight result by mistake).
             if channel_weights:
                 cache_settings['channel_weights'] = channel_weights
+            # Same for the on/off filter: only key on it when it meaningfully
+            # restricts the channel set (enabled_channels is None otherwise).
+            # Sorted list => stable, JSON-serializable, order-independent key.
+            if enabled_channels:
+                cache_settings['enabled_channels'] = sorted(enabled_channels)
             cached_results, cached_meta = (None, None) if skip_cache else \
                 get_cached_results(source_id, target_id, language, cache_settings)
             if cached_results is not None:
@@ -199,6 +229,7 @@ def search_fusion_stream():
                 user_settings={'use_meter': use_meter},
                 freq_basis=freq_basis,
                 channel_weights=channel_weights,
+                enabled_channels=enabled_channels,
             ):
                 if event_type == "channel_start":
                     phase = evt_data['phase']

--- a/backend/cache.py
+++ b/backend/cache.py
@@ -40,6 +40,15 @@ def get_cache_key(source_id, target_id, language, settings):
         'custom_stopwords': settings.get('custom_stopwords', ''),
         'freq_basis': settings.get('freq_basis', 'corpus'),
     }
+    # Advanced fusion knobs (channel weight overrides + on/off switches) are
+    # only added to the key when actually supplied, so a default search keeps a
+    # byte-identical key (and reuses existing cache entries), while each custom
+    # configuration gets its own distinct cache entry instead of colliding with
+    # the default or with a differently-configured custom search.
+    if settings.get('channel_weights'):
+        key_parts['channel_weights'] = settings['channel_weights']
+    if settings.get('enabled_channels'):
+        key_parts['enabled_channels'] = settings['enabled_channels']
     key_str = json.dumps(key_parts, sort_keys=True)
     return hashlib.md5(key_str.encode()).hexdigest()  # nosec B324
 

--- a/backend/fusion.py
+++ b/backend/fusion.py
@@ -342,6 +342,30 @@ def merge_channel_weights(channel_weights, language=None, corpus_type=None,
     return merged
 
 
+def sanitize_channel_keys(raw):
+    """Validate a user-supplied list of fusion channel keys.
+
+    Returns a set of recognized channel keys, or None when the input is
+    unusable, empty, or contains no known channels. Unknown keys are dropped.
+    Returning None (never an empty set) lets callers treat "nothing usable"
+    the same as "not supplied" — which keeps default behavior byte-identical
+    when the user has not touched the on/off switches.
+
+    Used for the Advanced on/off switches: the request carries the list of
+    channels the user turned OFF (disabled_channels); channels not in it stay
+    on. Unlike a weight of 0 (which still runs and can pull pairs in via the
+    convergence bonus), a disabled channel is excluded from running entirely.
+    """
+    if not raw:
+        return None
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple, set, frozenset)):
+        return None
+    keys = {ch for ch in raw if ch in CHANNEL_WEIGHTS}
+    return keys or None
+
+
 # Bonus added for each additional channel beyond the first that confirms
 # a pair, rewarding cross-channel convergence as evidence of a true allusion.
 # The raw bonus per extra channel is 0.75 * idf_weight, where idf_weight
@@ -2815,7 +2839,8 @@ def iter_fusion_search(source_units, target_units, matcher, scorer,
                        source_path=None, target_path=None,
                        user_settings=None,
                        source_language=None, target_language=None,
-                       freq_basis='corpus', channel_weights=None):
+                       freq_basis='corpus', channel_weights=None,
+                       enabled_channels=None):
     """Generator version of run_fusion_search for progressive SSE streaming.
 
     Yields (event_type, data) tuples as the search progresses:
@@ -2832,6 +2857,14 @@ def iter_fusion_search(source_units, target_units, matcher, scorer,
     language-default profile and behavior is unchanged. When provided, the
     overrides are merged over the language-default profile (so a user need
     only override a subset of channels) and passed to every fuse_results call.
+
+    enabled_channels: optional iterable of channel keys the user has left ON
+    (Advanced UI on/off switches). When None or empty, every language-available
+    channel runs (behavior unchanged). When provided, only channels in this set
+    run at all — unchecked channels are excluded entirely, so they cannot pull
+    pairs in through the convergence bonus. As a guard rail, if the filter would
+    exclude every available channel (e.g. the user turned everything off), the
+    full available set runs instead of returning nothing.
     """
     user_settings = user_settings or {}
     if source_language is None:
@@ -2859,6 +2892,21 @@ def iter_fusion_search(source_units, target_units, matcher, scorer,
     # --- Pass 1: Line-level (language-appropriate channels, fast-first order) ---
     line_channel_results = {}
     available_channels = get_channels_for_language(language)
+    # Apply the optional user on/off filter. enabled_channels is the set of
+    # channels to KEEP; unchecked channels are dropped so they never run (and
+    # thus can't contribute convergence). Guard rail: if the filter would leave
+    # no channels (user turned everything off, or only unsupported ones on), we
+    # fall back to the full available set rather than running an empty search.
+    if enabled_channels:
+        enabled_set = set(enabled_channels)
+        restricted = [ch for ch in available_channels if ch in enabled_set]
+        if restricted:
+            available_channels = restricted
+        else:
+            logger.warning(
+                "[FUSION] enabled_channels %s excluded every available channel "
+                "for language '%s'; falling back to full channel set",
+                enabled_set, language)
     line_channels = [ch for ch in available_channels if ch in configs]
     total_line = len(line_channels)
 

--- a/backend/fusion.py
+++ b/backend/fusion.py
@@ -292,6 +292,56 @@ def get_weight_profile(language=None, corpus_type=None, profile_name=None):
     return dict(WEIGHT_PROFILES["latin_epic"])
 
 
+# Clamp range for user-supplied channel weights (Advanced UI). Weights are
+# non-negative multipliers; the tuned defaults sit well inside this range, so
+# 0–20 gives users room to experiment without letting a single channel swamp
+# the fused score to a degree that would just be noise.
+USER_WEIGHT_MIN = 0.0
+USER_WEIGHT_MAX = 20.0
+
+
+def sanitize_channel_weights(raw):
+    """Validate/sanitize a user-supplied channel_weights dict.
+
+    Returns a clean dict containing only known channel keys mapped to finite
+    numbers clamped to [USER_WEIGHT_MIN, USER_WEIGHT_MAX]. Unknown keys and
+    non-numeric values are dropped. Returns {} for anything unusable, so an
+    empty result reliably means "no overrides" (default behavior preserved).
+    """
+    if not isinstance(raw, dict):
+        return {}
+    clean = {}
+    for key, val in raw.items():
+        if key not in CHANNEL_WEIGHTS:
+            continue
+        # Reject bools (isinstance(True, int) is True) and non-numbers.
+        if isinstance(val, bool) or not isinstance(val, (int, float)):
+            continue
+        num = float(val)
+        if num != num or num in (float("inf"), float("-inf")):  # NaN / inf
+            continue
+        clean[key] = max(USER_WEIGHT_MIN, min(USER_WEIGHT_MAX, num))
+    return clean
+
+
+def merge_channel_weights(channel_weights, language=None, corpus_type=None,
+                          profile_name=None):
+    """Merge sanitized user weight overrides over the default weight profile.
+
+    Returns None when there are no usable overrides (so callers can pass the
+    result straight to fuse_results(weights=...) and get the unchanged
+    language-default behavior). Otherwise returns a full weight dict: the
+    language/profile default with the user's overrides applied on top.
+    """
+    overrides = sanitize_channel_weights(channel_weights)
+    if not overrides:
+        return None
+    merged = get_weight_profile(language=language, corpus_type=corpus_type,
+                                profile_name=profile_name)
+    merged.update(overrides)
+    return merged
+
+
 # Bonus added for each additional channel beyond the first that confirms
 # a pair, rewarding cross-channel convergence as evidence of a true allusion.
 # The raw bonus per extra channel is 0.75 * idf_weight, where idf_weight
@@ -2765,7 +2815,7 @@ def iter_fusion_search(source_units, target_units, matcher, scorer,
                        source_path=None, target_path=None,
                        user_settings=None,
                        source_language=None, target_language=None,
-                       freq_basis='corpus'):
+                       freq_basis='corpus', channel_weights=None):
     """Generator version of run_fusion_search for progressive SSE streaming.
 
     Yields (event_type, data) tuples as the search progresses:
@@ -2776,12 +2826,23 @@ def iter_fusion_search(source_units, target_units, matcher, scorer,
 
     Uses CHANNEL_ORDER (fast channels first) so intermediate results
     appear within seconds of starting the search.
+
+    channel_weights: optional dict of per-channel weight overrides supplied by
+    the user (Advanced UI). When None or empty, weights fall through to the
+    language-default profile and behavior is unchanged. When provided, the
+    overrides are merged over the language-default profile (so a user need
+    only override a subset of channels) and passed to every fuse_results call.
     """
     user_settings = user_settings or {}
     if source_language is None:
         source_language = language
     if target_language is None:
         target_language = language
+
+    # Merge any user weight overrides over the language-default profile. When
+    # no overrides are given, effective_weights stays None so fuse_results()
+    # uses get_weight_profile() exactly as before (byte-identical default).
+    effective_weights = merge_channel_weights(channel_weights, language)
 
     # Build per-channel configs with language override and user settings
     configs = {}
@@ -2845,7 +2906,8 @@ def iter_fusion_search(source_units, target_units, matcher, scorer,
         # Cap intermediates at 500 (preview only) to avoid huge JSON payloads;
         # the full max_results set is sent in the final "complete" event.
         if count > 0 and line_channel_results:
-            fused = fuse_results(line_channel_results, language=language,
+            fused = fuse_results(line_channel_results, weights=effective_weights,
+                                 language=language,
                                  freq_basis=freq_basis,
                                  source_id=source_id, target_id=target_id)
             preview_cap = min(max_results, 500) if max_results > 0 else 500
@@ -2916,7 +2978,8 @@ def iter_fusion_search(source_units, target_units, matcher, scorer,
             logger.info(f"[STRUCTURAL GATE] Kept {after}/{before} structural pairs "
                         f"(dictionary or cosine >= {MIN_COSINE_NO_DICT})")
 
-    line_fused = fuse_results(line_channel_results, language=language,
+    line_fused = fuse_results(line_channel_results, weights=effective_weights,
+                               language=language,
                                freq_basis=freq_basis,
                                source_id=source_id, target_id=target_id)
 
@@ -2990,7 +3053,8 @@ def iter_fusion_search(source_units, target_units, matcher, scorer,
             "phase": "window",
         })
 
-    window_fused = fuse_results(window_channel_results, language=language,
+    window_fused = fuse_results(window_channel_results, weights=effective_weights,
+                                 language=language,
                                  freq_basis=freq_basis,
                                  source_id=source_id, target_id=target_id)
     window_fused = penalize_single_line_windows(window_fused)

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -129,7 +129,11 @@ function App() {
     freq_basis: 'corpus',
     // Advanced: user-overridden fusion channel weights. Contains only the
     // channels the user has explicitly changed; empty => use tuned defaults.
-    channel_weights: {}
+    channel_weights: {},
+    // Advanced: fusion channels the user has turned OFF via the on/off
+    // switches. Empty => every channel runs (default). Only sent to the
+    // backend when non-empty (see request-building below).
+    disabled_channels: []
   });
   const [showAdvancedSettings, setShowAdvancedSettings] = useState(false);
   
@@ -424,6 +428,11 @@ function App() {
       language: activeTab,
       ...settings
     };
+    // Only send disabled_channels when the user has actually turned a channel
+    // off, so a default search's request body is unchanged from today.
+    if (!params.disabled_channels || params.disabled_channels.length === 0) {
+      delete params.disabled_channels;
+    }
 
     if (searchMode === 'parallel') {
       await search(params);
@@ -443,6 +452,9 @@ function App() {
       ...settings,
       skip_cache: true,
     };
+    if (!params.disabled_channels || params.disabled_channels.length === 0) {
+      delete params.disabled_channels;
+    }
     if (searchMode === 'parallel') {
       await search(params);
     }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -126,7 +126,10 @@ function App() {
     stoplist: false,
     use_meter: true,
     exclude_proper_nouns: false,
-    freq_basis: 'corpus'
+    freq_basis: 'corpus',
+    // Advanced: user-overridden fusion channel weights. Contains only the
+    // channels the user has explicitly changed; empty => use tuned defaults.
+    channel_weights: {}
   });
   const [showAdvancedSettings, setShowAdvancedSettings] = useState(false);
   

--- a/client/src/components/pages/HelpPage.jsx
+++ b/client/src/components/pages/HelpPage.jsx
@@ -231,6 +231,7 @@ export default function HelpPage() {
     { id: 'coptic', label: 'Coptic (in depth)', group: 'Languages' },
     { id: 'cross-lingual', label: 'Cross-Language Search', group: 'Languages' },
 
+    { id: 'ai-guide', label: 'Use with your AI', group: 'Reference & tools' },
     { id: 'syntax-texts', label: 'Syntax', group: 'Reference & tools' },
     { id: 'best-practices', label: 'Search Tips', group: 'Reference & tools' },
     { id: 'repository', label: 'Repository', group: 'Reference & tools' },
@@ -1255,6 +1256,41 @@ export default function HelpPage() {
                   Latin syntactic annotations are produced by <strong>LatinPipe</strong> (Straka & Straková, Charles University),
                   a neural dependency parser trained on Universal Dependencies treebanks. The parser processes raw Latin text
                   into full dependency trees with part-of-speech tags and grammatical relations.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {activeSection === 'ai-guide' && (
+            <div className="prose max-w-none">
+              <h3 className="text-xl font-semibold text-gray-900 mb-4">Use Tesserae with your AI assistant</h3>
+              <p className="text-gray-700 mb-4">
+                You can let your own AI assistant (such as ChatGPT or Claude) run Tesserae searches for you — comparing
+                texts, testing parallels for uniqueness across the corpus, and helping you interpret the results.
+                Tesserae does the searching, free, on its open API; your assistant orchestrates the steps and interprets.
+              </p>
+              <div className="bg-blue-50 p-4 rounded border border-blue-200 mb-4">
+                <p className="text-gray-700 text-sm mb-3">
+                  We've written a guide you can paste into your assistant as its first message. It teaches the assistant
+                  Tesserae's full toolbox, a step-by-step research workflow, and — importantly — to keep a clear line
+                  between Tesserae's reproducible results and the AI's own interpretation.
+                </p>
+                <a
+                  href="/tesserae-data/ai-guide.html"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-medium px-4 py-2 rounded no-underline"
+                >
+                  Open the full guide →
+                </a>
+              </div>
+              <div className="bg-amber-50 p-4 rounded border border-amber-200">
+                <h4 className="font-medium text-amber-900 mb-2">A note on scholarly use</h4>
+                <p className="text-gray-700 text-sm">
+                  Tesserae's results are transparent and reproducible — anyone can re-run a search and inspect why a
+                  parallel ranked where it did. Whatever your AI concludes from there is its own product. When you
+                  publish, cite Tesserae for the parallels it found, and present the surrounding analysis as
+                  AI-assisted interpretation you have checked.
                 </p>
               </div>
             </div>

--- a/client/src/components/search/SearchSettings.jsx
+++ b/client/src/components/search/SearchSettings.jsx
@@ -48,6 +48,27 @@ const SearchSettings = ({ settings, setSettings, showAdvanced, setShowAdvanced, 
   const channelWeights = settings.channel_weights || {};
   const overrideCount = Object.keys(channelWeights).length;
 
+  // On/off switches. settings.disabled_channels holds the channels the user
+  // turned OFF (empty => every channel runs, the default). We store the OFF
+  // list rather than the ON list so a search with nothing disabled sends no
+  // restriction and behaves byte-identically to today.
+  const disabledChannels = settings.disabled_channels || [];
+  const disabledSet = new Set(disabledChannels);
+  const disabledCount = disabledChannels.length;
+  const isChannelOn = (ch) => !disabledSet.has(ch);
+
+  const toggleChannel = (ch) => {
+    setSettings((prev) => {
+      const current = new Set(prev.disabled_channels || []);
+      if (current.has(ch)) {
+        current.delete(ch);  // turn back ON
+      } else {
+        current.add(ch);     // turn OFF
+      }
+      return { ...prev, disabled_channels: Array.from(current) };
+    });
+  };
+
   // Displayed value: user override if set, otherwise the language default.
   const weightValue = (ch) => {
     if (channelWeights[ch] !== undefined) return channelWeights[ch];
@@ -71,9 +92,12 @@ const SearchSettings = ({ settings, setSettings, showAdvanced, setShowAdvanced, 
     });
   };
 
+  // Reset restores BOTH the weights (back to tuned defaults) and the on/off
+  // state (all channels on).
   const resetChannelWeights = () => {
-    setSettings((prev) => ({ ...prev, channel_weights: {} }));
+    setSettings((prev) => ({ ...prev, channel_weights: {}, disabled_channels: [] }));
   };
+  const isDirty = overrideCount > 0 || disabledCount > 0;
   const handleChange = (key, value) => {
     const updates = { [key]: value };
     
@@ -373,7 +397,10 @@ const SearchSettings = ({ settings, setSettings, showAdvanced, setShowAdvanced, 
               className="flex items-center gap-1 text-sm font-medium text-gray-700 hover:text-gray-900"
             >
               <span className="text-xs">{showChannelWeights ? '▼' : '▶'}</span>
-              Advanced — Channel weights
+              Advanced — Channels &amp; weights
+              {disabledCount > 0 && (
+                <span className="ml-1 text-xs text-red-600">({disabledCount} off)</span>
+              )}
               {overrideCount > 0 && (
                 <span className="ml-1 text-xs text-red-600">({overrideCount} custom)</span>
               )}
@@ -382,16 +409,29 @@ const SearchSettings = ({ settings, setSettings, showAdvanced, setShowAdvanced, 
             {showChannelWeights && (
             <div className="mt-3">
               <p className="text-xs text-gray-500 mb-3">
-                Advanced — the defaults are optimized; custom weights can reduce recall.
-                Each channel contributes to a match's score in proportion to its weight
-                (range {weightRange.min}–{weightRange.max}). Leave a field at its default to keep it unchanged.
+                Advanced — the defaults are optimized; custom settings can reduce recall.
+                Uncheck a channel to turn it off (it won't run at all); each channel that
+                stays on contributes to a match's score in proportion to its weight
+                (range {weightRange.min}–{weightRange.max}). Leave a weight at its default to keep it unchanged.
               </p>
-              <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-3">
-                {CHANNEL_LABELS.map(([ch, label]) => (
-                  <div key={ch}>
-                    <label className="block text-xs font-medium text-gray-700 mb-1">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3">
+                {CHANNEL_LABELS.map(([ch, label]) => {
+                  const on = isChannelOn(ch);
+                  return (
+                  <div key={ch} className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={on}
+                      onChange={() => toggleChannel(ch)}
+                      aria-label={`Enable ${label} channel`}
+                      className="h-4 w-4 flex-shrink-0"
+                    />
+                    <label
+                      className={`text-xs font-medium flex-1 min-w-0 truncate ${on ? 'text-gray-700' : 'text-gray-400 line-through'}`}
+                      title={label}
+                    >
                       {label}
-                      {channelWeights[ch] !== undefined && (
+                      {on && channelWeights[ch] !== undefined && (
                         <span className="text-red-600"> *</span>
                       )}
                     </label>
@@ -402,23 +442,28 @@ const SearchSettings = ({ settings, setSettings, showAdvanced, setShowAdvanced, 
                       step="0.1"
                       value={weightValue(ch)}
                       onChange={(e) => setChannelWeight(ch, e.target.value)}
-                      className="w-full border rounded px-2 py-1.5 text-sm"
+                      disabled={!on}
+                      title={on ? undefined : 'Turn this channel on to set its weight'}
+                      className={`w-20 border rounded px-2 py-1.5 text-sm ${on ? '' : 'bg-gray-100 text-gray-400 cursor-not-allowed'}`}
                     />
                   </div>
-                ))}
+                  );
+                })}
               </div>
               <div className="mt-3 flex items-center gap-3">
                 <button
                   type="button"
                   onClick={resetChannelWeights}
-                  disabled={overrideCount === 0}
+                  disabled={!isDirty}
                   className="text-sm text-red-600 hover:text-red-800 disabled:text-gray-300 disabled:cursor-not-allowed"
                 >
                   Reset to defaults
                 </button>
-                {overrideCount > 0 && (
+                {isDirty && (
                   <span className="text-xs text-gray-400">
-                    {overrideCount} channel{overrideCount === 1 ? '' : 's'} overridden
+                    {disabledCount > 0 && `${disabledCount} off`}
+                    {disabledCount > 0 && overrideCount > 0 && ', '}
+                    {overrideCount > 0 && `${overrideCount} reweighted`}
                   </span>
                 )}
               </div>

--- a/client/src/components/search/SearchSettings.jsx
+++ b/client/src/components/search/SearchSettings.jsx
@@ -1,4 +1,21 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
+import { fetchFusionDefaultWeights } from '../../utils/api';
+
+// Fusion channels shown in the Advanced weights panel, with plain-English
+// labels. `quotation` is intentionally omitted — it is 0 for Latin/Greek/
+// English and is managed by the Coptic biblical profile, not a user knob.
+const CHANNEL_LABELS = [
+  ['lemma', 'Shared words'],
+  ['lemma_min1', 'Single word'],
+  ['exact', 'Exact'],
+  ['sound', 'Sound'],
+  ['edit_distance', 'Spelling'],
+  ['semantic', 'Meaning'],
+  ['dictionary', 'Synonyms'],
+  ['syntax', 'Syntax'],
+  ['syntax_structural', 'Structure'],
+  ['rare_word', 'Rare words'],
+];
 
 const SearchSettings = ({ settings, setSettings, showAdvanced, setShowAdvanced, language = 'la' }) => {
   const stopwordExamples = {
@@ -6,6 +23,56 @@ const SearchSettings = ({ settings, setSettings, showAdvanced, setShowAdvanced, 
     grc: 'λόγος not λόγον, θεός not θεῷ',
     en: 'king not kings, speak not speaking',
     cop: 'use lemmatized (sub-word) dictionary forms, not inflected forms'
+  };
+
+  // Advanced channel-weights panel state.
+  const [showChannelWeights, setShowChannelWeights] = useState(false);
+  const [defaultWeights, setDefaultWeights] = useState(null);
+  const [weightRange, setWeightRange] = useState({ min: 0, max: 20 });
+
+  // Fetch the tuned defaults for the active language so the inputs pre-fill
+  // with them (and so "Reset to defaults" knows what to restore).
+  useEffect(() => {
+    if (settings.match_type !== 'fusion') return;
+    let cancelled = false;
+    fetchFusionDefaultWeights(language)
+      .then((d) => {
+        if (cancelled) return;
+        setDefaultWeights(d.weights || {});
+        setWeightRange({ min: d.min ?? 0, max: d.max ?? 20 });
+      })
+      .catch(() => { /* non-fatal: panel just won't pre-fill */ });
+    return () => { cancelled = true; };
+  }, [language, settings.match_type]);
+
+  const channelWeights = settings.channel_weights || {};
+  const overrideCount = Object.keys(channelWeights).length;
+
+  // Displayed value: user override if set, otherwise the language default.
+  const weightValue = (ch) => {
+    if (channelWeights[ch] !== undefined) return channelWeights[ch];
+    if (defaultWeights && defaultWeights[ch] !== undefined) return defaultWeights[ch];
+    return '';
+  };
+
+  const setChannelWeight = (ch, raw) => {
+    setSettings((prev) => {
+      const next = { ...(prev.channel_weights || {}) };
+      if (raw === '' || raw === null || raw === undefined) {
+        // Empty input clears the override for this channel (back to default).
+        delete next[ch];
+      } else {
+        let num = parseFloat(raw);
+        if (Number.isNaN(num)) return prev;
+        num = Math.max(weightRange.min, Math.min(weightRange.max, num));
+        next[ch] = num;
+      }
+      return { ...prev, channel_weights: next };
+    });
+  };
+
+  const resetChannelWeights = () => {
+    setSettings((prev) => ({ ...prev, channel_weights: {} }));
   };
   const handleChange = (key, value) => {
     const updates = { [key]: value };
@@ -297,6 +364,68 @@ const SearchSettings = ({ settings, setSettings, showAdvanced, setShowAdvanced, 
             <p className="text-xs text-gray-400 mt-1">Note: Some features require pre-computed linguistic annotations for selected texts.</p>
             )}
           </div>
+
+          {settings.match_type === 'fusion' && (
+          <div className="sm:col-span-2 pt-2 border-t">
+            <button
+              type="button"
+              onClick={() => setShowChannelWeights((v) => !v)}
+              className="flex items-center gap-1 text-sm font-medium text-gray-700 hover:text-gray-900"
+            >
+              <span className="text-xs">{showChannelWeights ? '▼' : '▶'}</span>
+              Advanced — Channel weights
+              {overrideCount > 0 && (
+                <span className="ml-1 text-xs text-red-600">({overrideCount} custom)</span>
+              )}
+            </button>
+
+            {showChannelWeights && (
+            <div className="mt-3">
+              <p className="text-xs text-gray-500 mb-3">
+                Advanced — the defaults are optimized; custom weights can reduce recall.
+                Each channel contributes to a match's score in proportion to its weight
+                (range {weightRange.min}–{weightRange.max}). Leave a field at its default to keep it unchanged.
+              </p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-3">
+                {CHANNEL_LABELS.map(([ch, label]) => (
+                  <div key={ch}>
+                    <label className="block text-xs font-medium text-gray-700 mb-1">
+                      {label}
+                      {channelWeights[ch] !== undefined && (
+                        <span className="text-red-600"> *</span>
+                      )}
+                    </label>
+                    <input
+                      type="number"
+                      min={weightRange.min}
+                      max={weightRange.max}
+                      step="0.1"
+                      value={weightValue(ch)}
+                      onChange={(e) => setChannelWeight(ch, e.target.value)}
+                      className="w-full border rounded px-2 py-1.5 text-sm"
+                    />
+                  </div>
+                ))}
+              </div>
+              <div className="mt-3 flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={resetChannelWeights}
+                  disabled={overrideCount === 0}
+                  className="text-sm text-red-600 hover:text-red-800 disabled:text-gray-300 disabled:cursor-not-allowed"
+                >
+                  Reset to defaults
+                </button>
+                {overrideCount > 0 && (
+                  <span className="text-xs text-gray-400">
+                    {overrideCount} channel{overrideCount === 1 ? '' : 's'} overridden
+                  </span>
+                )}
+              </div>
+            </div>
+            )}
+          </div>
+          )}
         </div>
       )}
     </div>

--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -28,6 +28,11 @@ export const fetchAuthors = async (language) => {
   return jsonFetch(`${API_BASE}/authors?language=${language}`);
 };
 
+// Default per-channel fusion weights for a language (Advanced UI pre-fill).
+export const fetchFusionDefaultWeights = async (language) => {
+  return jsonFetch(`${API_BASE}/fusion-default-weights?language=${language}`);
+};
+
 export const fetchTexts = async (author) => {
   return jsonFetch(`${API_BASE}/texts?author=${author}`);
 };

--- a/research/threads/2026-08-10_adjustable-channel-weights_PR187.md
+++ b/research/threads/2026-08-10_adjustable-channel-weights_PR187.md
@@ -1,0 +1,74 @@
+# Thread dossier — User-adjustable channel weights & channel on/off (PR #187)
+
+**Status:** DRAFT PR, not deployed. Verified default-equivalent. Awaiting NC's decision to preview.
+**Last updated:** 2026-08-10
+**Owner:** Neil Coffee / Claude
+**One-line:** Let users tune each fusion channel's weight and switch channels fully on/off from the search UI (and via the API), without changing default behavior for anyone who doesn't touch the controls.
+
+---
+
+## 1. Genealogy — how this arose and the reasoning
+
+**Origin (user desiderata, surfaced during the Help-page revision, early Aug 2026).**
+While rewriting the Help page, NC recalled that users had asked to *adjust the search* — and, specifically, that **one user wanted results from just (some form of) sound + syntax**, i.e. the ability to turn channels *off*, not merely reweight them. NC asked how complicated user-adjustable weights would be, and whether we'd also need on/off switches.
+
+**Feasibility finding.** The core scorer was already parameterized: `fuse_results(channel_results, weights=None, …)` in `backend/fusion.py` falls back to `get_weight_profile(language=…)` only when `weights is None`. So *passing* a weights dict already overrides the profile — the hard part (threading a per-request weight set through scoring) was effectively free. This made the feature "moderate effort," mostly plumbing + UI, which is why we prototyped it.
+
+**Two distinct controls — and why they are not the same thing.**
+- **Weight** tunes how much a channel *contributes* to the fused score.
+- **On/off** *excludes a channel from running at all.*
+- Key insight that shaped the design: **weight = 0 is not the same as "off."** A channel at weight 0 still *runs*, and can still pull a pair into the results via the convergence bonus (multi-channel agreement). A user who says "I only want sound + syntax" needs the other channels to *not run*, not to run at zero. Hence a true on/off is a separate mechanism from a 0 weight.
+
+**Why send the OFF list, not the ON list.** The request carries `disabled_channels` (what the user turned off), which the backend converts into an `enabled_channels` keep-set (`available_for_lang − disabled`). Sending the *off* list means any channel the user never touched — and, importantly, **any channel we add later** (e.g. Coptic's `quotation`) — stays ON by default. An ON-list would silently freeze the channel set at whatever existed when the UI was written.
+
+**Cache-correctness insight.** User weights/enabled-set must be part of the results cache key, or a tuned search could return a cached *default* result (or vice-versa). But we only fold them into the cache key **when they are non-default** — so the large existing default-search cache stays valid and default searches are byte-for-byte unchanged.
+
+**Open design question NC raised (unresolved).** If users can turn channels off, *do we still need the separate single-channel search modes* (lemma, exact, sound, …) as their own UI entries? Tentative answer: keep them as convenient "main alternatives," but this is a product decision to revisit once adjustable weights ship.
+
+**Provenance note for future write-ups.** This is a good example of the V6 design philosophy that the AI-API guide also leans on: the pipeline is *transparent and adjustable*. Adjustable weights make that adjustability user-facing, which strengthens the "Tesserae results are auditable" claim.
+
+---
+
+## 2. Current state — everything needed to rebuild
+
+**PR:** #187 "Prototype: user-adjustable channel weights (Advanced)" — https://github.com/tesserae/tesserae-v6/pull/187
+**Branch:** `feature/adjustable-channel-weights` @ `de26387a` · base `main` · **DRAFT/OPEN** · created 2026-08-09 · **+391 / −6 across 6 files.**
+(Branch is behind current `main` `76cd7ef`; a preview/merge should rebase or merge main first.)
+
+**Files changed and what each does:**
+| File | +/− | Role |
+|---|---|---|
+| `backend/blueprints/fusion.py` | +70 | `/search-fusion` reads optional `channel_weights` + `disabled_channels`; converts disabled→`enabled_channels` keep-set; folds non-default settings into the cache key; passes both into the search. Adds `GET /api/fusion-default-weights`. |
+| `backend/fusion.py` | +116/−4 | New helpers: `sanitize_channel_weights(raw)`, `sanitize_channel_keys(raw)`, `merge_channel_weights(channel_weights, language, corpus_type, …)` (overlays user weights on the default profile). Threads `channel_weights` + `enabled_channels` through the search into `fuse_results`. |
+| `backend/cache.py` | +9 | Includes `channel_weights` / `enabled_channels` in the cache settings **only when present**, so default searches keep their existing cache keys. |
+| `client/src/utils/api.js` | +5 | `getFusionDefaultWeights(language)` → `GET /api/fusion-default-weights?language=…`. |
+| `client/src/components/search/SearchSettings.jsx` | +175/−1 | New collapsible **"Advanced — Channels & weights"**: per-channel weight inputs/sliders + per-channel ON/OFF checkboxes, pre-filled from the default-weights endpoint. |
+| `client/src/App.jsx` | +16/−1 | Passes `channel_weights` + `disabled_channels` into the search request. |
+
+**New / changed API surface:**
+- `POST /api/search-fusion` — now also accepts optional:
+  - `channel_weights`: `{ "<channel>": <number>, … }` (overlaid on the language default profile)
+  - `disabled_channels`: `[ "<channel>", … ]` (true off — those channels don't run)
+- `GET /api/fusion-default-weights?language=la` → `{ "language":"la", "weights": {"lemma":2.0, …}, … }` (to pre-fill the UI).
+- Channel keys are the 10 fusion channels (+ `quotation` for cop): `lemma, lemma_min1, exact, sound, edit_distance, semantic, dictionary, syntax, syntax_structural, rare_word` (see `CHANNEL_WEIGHTS` in `backend/fusion.py`).
+
+**Verification already done:** default path is unchanged — with no `channel_weights`/`disabled_channels` in the request, weights fall back to `get_weight_profile()` and the cache key is unchanged, so results are byte-identical to production. Built via two background agents; one esbuild parse-check failed only because the worktree had no `node_modules` (CI validated the build).
+
+---
+
+## 3. How to resume / preview / ship
+
+**To preview on production (NC's pending decision):** temporary deploy of the branch, exactly like the Marvin concurrency-gate branch deploy pattern —
+1. On prod: `git checkout -- dist/`, `git fetch`, `git checkout -B feature/adjustable-channel-weights origin/feature/adjustable-channel-weights` (rebase/merge `main` first so it includes `76cd7ef`), `npm run build`, `touch tesseraev6_flask.wsgi`.
+2. Verify arma-virum regression + a weighted/disabled search actually differs from default.
+3. **Rollback (one block):** `git checkout -- dist/; git checkout main; npm run build; touch tesseraev6_flask.wsgi` → back to `76cd7ef`.
+
+**To ship for real:** rebase branch onto `main`, take it out of draft, let CI run, merge, then standard prod deploy (**`npm run build` is mandatory** — this PR touches `client/`).
+
+**Before shipping, decide:** (a) keep or retire the standalone single-channel search modes; (b) whether the API's `channel_weights`/`disabled_channels` should be documented in the AI-API guide (they should — see the sibling AI-API thread).
+
+---
+
+## 4. Related
+- Sibling thread: `2026-08-10_ai-api-access.md` (the API guide should document these two new params once #187 ships).
+- Scoring context: `CHANNEL_WEIGHTS` / `get_weight_profile()` in `backend/fusion.py`; current default profile in project memory / CLAUDE.md.

--- a/research/threads/2026-08-10_ai-api-access.md
+++ b/research/threads/2026-08-10_ai-api-access.md
@@ -1,0 +1,95 @@
+# Thread dossier — Tesserae-through-your-AI (open API access + AI orchestration)
+
+**Status:** Guide LIVE. Proof-of-concept done. Crash-risk assessed. Feature-request-via-AI endpoint APPROVED to build (gated PR), pending a GitHub token.
+**Last updated:** 2026-08-10
+**Owner:** Neil Coffee / Claude · **Prompted by:** Neil Bernstein (Neil B.)
+**One-line:** Let a user's *own* AI assistant drive Tesserae's open API through a full find-and-interpret research pipeline — so Tesserae supplies free, auditable search and the user's AI supplies the (bring-your-own-cost) interpretation.
+
+---
+
+## 1. Genealogy — how this arose and the reasoning
+
+**Origin (Neil B.'s question, relayed by NC).**
+> "Could an AI agent go through multiple steps — compare one text against another, select high-ranked parallels, then compare them across the poetic corpus for uniqueness and serve up an interpretation? Tesserae is already better than MQDQ in serving up the good stuff first, but MQDQ has the benefit of displaying the poetic corpus in its results."
+
+NC's hard constraint: **he cannot pay for AI/Claude tokens for every user.** That rules out Tesserae hosting the AI itself and points to **bring-your-own-AI**: the user brings their own assistant, Tesserae exposes the search.
+
+**Two candidate routes, one dropped.**
+1. *(Dropped)* A manual "research dossier / paste-brief" the user copies into an AI by hand. Superseded by route 2 and explicitly retired by NC.
+2. *(Pursued)* Give the user's AI the **API** plus a **context prompt** so it can operate Tesserae knowledgeably and autonomously.
+
+**Feasibility findings that made route 2 viable.**
+- Tesserae's search endpoints are **open — no key, no login.** A server-side AI agent can call them directly.
+- **CORS is irrelevant here:** it only governs browser-origin requests; a server-side agent isn't affected.
+- Apache routes **only `/api` to Flask**; everything else is static. So the API is a clean, self-contained surface to document.
+- Therefore: a well-written context prompt can turn any web-capable AI into a competent Tesserae operator at **zero cost to Tesserae.**
+
+**Design principles NC set for the guide (these are the intellectual core, worth quoting in any write-up).**
+1. **Teach the whole toolbox, not just Neil B.'s route.** Neil B. knows Latin epic; he does *not* know Tesserae's full feature set. The guide documents all six search types + per-language coverage, so the AI can recommend the right tool.
+2. **Educate the user non-intrusively.** Follow the user's lead; surface a relevant capability briefly, then defer. One suggestion, not a sales pitch.
+3. **Hold a hard line between Tesserae's results and the AI's own products.** This is the ethical spine: *Tesserae output is auditable* (transparent, reproducible, adjustable — we can inspect and modify the whole process), whereas *the AI's downstream interpretation is a black box unless the user makes it auditable.* The guide instructs the AI to label the two, never let inference masquerade as a Tesserae finding, and gently encourage the user to preserve that distinction in publication (cite Tesserae for the parallels/rarity; present analysis as AI-assisted-and-author-checked). It also recommends the user keep their own side auditable — log the exact queries/results, and keep a repository of the secondary material the AI drew on.
+
+**Why the provenance principle matters (for articles/talks).** It reframes Tesserae's transparency as a *methodological advantage in the age of AI*: the search layer is examinable and reproducible; the interpretive layer, if left to a black-box model, is not — so the responsible workflow keeps them distinct and makes both auditable. This is a defensible scholarly stance and a selling point.
+
+**The feature-request sub-thread (how a user's AI asks us for more).**
+NC asked: if a user's AI hits a wall (wants a feature/language/text we don't have), can the *protocol itself* let the AI file that request in the most actionable form for us?
+- Decided the AI captures a **fixed schema** (type, title, problem, desired, example, tried, **auto-captured search context**, optional contact) and **requires explicit user sign-off before sending anything** (NC, 2026-08-10: the AI must *not* auto-send — the user confirms every submission). The auto-captured context is the differentiator — the request arrives with its own reproduction case.
+- Submission channel: users mostly **won't have GitHub accounts**, so a prefilled-GitHub-issue-URL route was rejected. NC chose **auto-file to GitHub Issues** (server-side) so requests land in the **dev team's** actual triage workflow.
+- **Discovery that reshaped the build:** Tesserae *already has* a private feedback system — `POST /api/feedback` (stores to a `feedback` table, emails the team via local Postfix, reviewable in the Admin panel) and a structured `text_requests` corpus-addition pipeline with an approval workflow. So intake is not built from scratch.
+- **Refined, approved design:** reuse the existing intake; for actionable types (`feature`/`language`/`bug`) also **auto-file a labeled GitHub issue** (`from-ai-protocol` + type), **with the user's email stripped from the public issue** (kept only in the DB + the private notification email); route corpus-addition requests to the existing `text_requests` pipeline; gate GitHub behind a token + kill-switch so that, absent the token, it degrades to the existing private path. NC's instruction: *"build it as a gated PR — strip the email."*
+
+---
+
+## 2. Current state — everything needed to rebuild
+
+### 2a. The guide (DONE, live)
+- **Source (Markdown):** `scratchpad/tesserae_api_guide.md` (working copy; regenerate the HTML from this).
+- **Repo copy (committed):** `static/downloads/ai-guide.html` — committed to `main` as **`76cd7ef`** ("Add AI-assistant API guide page").
+- **Served copy (live):** `/var/www/tesseraev6_flask/public_data/ai-guide.html`.
+- **Live URL:** **https://tesserae.caset.buffalo.edu/tesserae-data/ai-guide.html**
+- **claude.ai artifact (review view):** https://claude.ai/code/artifact/edfb170e-e019-4fc8-8c8d-84fbcde3b42e
+- **Design:** self-contained HTML, site identity (amber/gold, Crimson Pro serif, Noto Sans), one-click "Copy the full guide" (copies a plain-text version embedded in a `<script type="text/plain" id="guide-src">`). Sections: how-to-behave · what Tesserae is · the API · full toolbox table · request shapes · flagship workflow · **Provenance** · keep-your-side-auditable · caveats.
+
+### 2b. Hosting architecture (learned the hard way — see also memory `feedback_production_deploy_frontend.md`)
+- Prod Apache vhost `vhost-tess-new.conf` (ServerName `tesserae.caset.buffalo.edu`) routes **only `/api` → Flask** (`WSGIScriptAlias /api …/tesseraev6_flask.wsgi`). Everything else served by Apache from `DocumentRoot /var/www/tess-new` → symlink → `…/tesseraev6_flask/dist`, with an SPA rewrite (non-`/api/`,`/tesserae-data/`,`/blog/` and not-a-real-file → `/index.html`).
+- Consequences: (1) the Flask `/static/downloads/` `before_request` hook is **dead for web traffic** (those URLs never reach Flask → SPA fallback); (2) a raw file in `dist/` would serve but gets wiped by the `git checkout -- dist/` + `npm run build` deploy step.
+- **Durable static hosting = the Apache alias `/tesserae-data` → `/var/www/tesseraev6_flask/public_data`** (writable by ncoffee:tessdev, correct content-types, outside `dist/`, not git-tracked — like the index tarballs there). That's why the guide lives at `/tesserae-data/ai-guide.html`.
+- A prettier URL (e.g. `/ai-guide`) or fixing `/static/downloads/*` needs an Apache Alias/RewriteRule change (Chris/root).
+
+### 2c. Proof-of-concept (DONE — full pipeline run live against the API)
+- **Comparison:** `POST /api/search-fusion` `source=vergil.aeneid.part.1.tess`, `target=lucan.bellum_civile.part.1.tess`, `language=la` → SSE stream (raw saved at `scratchpad/poc_fusion.sse`), 500 ranked pairs.
+- **Top parallels (sorted by `fused_score`):** #1 Aen 1.146 *syrtis…aequor* × BC 1.499 *Syrtibus…aequor* (score 17.5, 4 ch); #2 *Hesperiam…arva* × *Hesperia…arvis* (16.5, 4 ch); #3 Aen 1.103 ***fluctusque ad sidera** tollit* × BC 1.416 ***fluctusque ad sidera** ducat* (9.6, **7 ch** incl. quotation).
+- **Corpus-uniqueness step** (`POST /api/line-search`, whole corpus): `aequor+syrtis` ≈ 9 lines; `arvum+hesperia` ≈ 8; `fluctusque ad sidera` ≈ **0 elsewhere** (near-unique Vergilian phrase Lucan reuses almost verbatim). ⇒ the entire search→select→uniqueness pipeline works end-to-end via the open API, at zero AI cost — a publishable observation produced autonomously.
+
+### 2d. Crash / OOM / wait-time assessment (DONE)
+- **Usage (search_logs, ~190 days):** 2,203 searches, ≈11.6/day avg; last 30 days ≈8/day. Busiest human hour = 66. The access-log "228 search-POSTs/minute" spike is an automated midnight benchmark, not concurrent users.
+- **Capacity:** 62 GB RAM (≈54 free) + 23 GB swap. Concurrency gate (PR #141): **max 8 concurrent, queue when free RAM < 25 GB, 300 s queue timeout.**
+- **Verdict — OOM/crash risk LOW:** the API path uses the *same* endpoints → the *same* gate → **cannot bypass** the OOM protection; excess load **queues, not crashes**. Neil B.'s pipeline is **1 heavy fusion + many *light* index lookups**; the light lookups barely touch the gate. Realistic failure mode under heavy concurrent use = **wait/queue time**, which degrades gracefully. If API/AI usage grows: add an API-specific rate-limit or lane; not needed now.
+
+### 2e. Feature-request-via-AI endpoint (APPROVED — NOT YET BUILT)
+- **Existing infra to reuse:** `POST /api/feedback` `{name,email,type,message}` → `feedback` table (id/status/created_at/admin_notes/responded_by) + `notify_feedback` email (SMTP `localhost:25`, recipients from the `settings` table) + Admin-panel review (`/api/admin/feedback` GET/PUT). Separate `text_requests` table + approval pipeline for corpus additions.
+- **To build (gated PR):**
+  1. On feedback of type `feature`/`language`/`bug`: after the existing DB insert + email, **create a GitHub issue** in `tesserae/tesserae-v6` via a bot token — labeled `from-ai-protocol` + the type — **omitting the user's email** (email stays in DB + notification only).
+  2. Accept the richer AI schema (problem/desired/example/tried/**context**) — pack it into the issue body; keep contact private.
+  3. Route corpus/text-addition requests to the existing `text_requests` flow (curatorial approval), not GitHub.
+  4. **Gate:** `GITHUB_FEEDBACK_TOKEN` + `GITHUB_FEEDBACK_REPO=tesserae/tesserae-v6` + a kill-switch env. **If token absent → behave exactly as the existing private path** (safe to merge before provisioning).
+  5. Anti-spam: rate-limit, payload caps, required fields, `from-ai-protocol` label for bulk filtering.
+  6. Update the guide with a "Requesting a feature/language/text" section: the AI drafts the schema, **warns the user the description becomes a public GitHub issue**, confirms, then submits; email optional and kept private.
+- **The one external dependency (NC/Chris):** a **fine-grained GitHub PAT** (ideally from a shared/bot account, not NC's personal account), scoped to **only `tesserae/tesserae-v6`, Issues: read/write**, placed in prod `.env` as `GITHUB_FEEDBACK_TOKEN` (+ `GITHUB_FEEDBACK_REPO`).
+
+### 2f. Open API reference (as used by the guide)
+`GET /api/languages` · `GET /api/texts?language=` · `POST /api/search-fusion` (SSE) · `POST /api/line-search` · `POST /api/wildcard-search` · `POST /api/hapax-search` · `POST /api/rare-bigram-search`. All open, no auth.
+
+---
+
+## 3. How to resume / next steps
+1. **Build the gated feature-request PR** (2e) — approved; strip email; degrade-safe without the token.
+2. **Provision the GitHub token** (NC/Chris) — the only blocker to activating GitHub auto-file.
+3. **Add the guide to the Help page** (NC flagged this first, before the feature-request work): a "Guide for AI assistants →" link/section in Help or About — a minor `client/` change → build → deploy.
+4. **Native connector — WANTED (NC, 2026-08-10), not optional:** make it native/easy for Claude and ChatGPT — an **OpenAPI spec → a ChatGPT Custom GPT / GPT Action**, and/or an **MCP server for Claude**, so users don't paste a prompt at all. Scope TBD; the pasteable guide is the interim.
+5. **Corpus-uniqueness + corpus display on results** (the MQDQ gap Neil B. named) — separate build; the PoC shows the uniqueness half already works via `line-search`.
+
+## 4. Related
+- Sibling thread: `2026-08-10_adjustable-channel-weights_PR187.md` (the API's forthcoming `channel_weights`/`disabled_channels` params should be documented in the guide once #187 ships).
+- Concurrency gate: PR #141 (`backend/concurrency_gate.py`), prod config `data/concurrency_config.json` (max 8 / 25 GB).
+- Deploy/hosting gotchas: memory `feedback_production_deploy_frontend.md`.

--- a/research/threads/README.md
+++ b/research/threads/README.md
@@ -1,0 +1,30 @@
+# Research threads — living workstream dossiers
+
+Each file here is a **living record of one workstream**, written so that (a) the current work state can be rebuilt from it, and (b) it doubles as a **genealogical record** — the origin, reasoning, decisions, and rejected alternatives — for future presentations and articles. Update the relevant dossier as a thread progresses; don't let detail live only in chat.
+
+Each dossier has the same two-part spine: **§1 Genealogy** (why this exists, the thinking, the forks) and **§2 Current state** (exact commits/branches/PRs, files, endpoints, env, what's deployed vs. gated, how to resume).
+
+## Active threads
+| Thread | File | Status |
+|---|---|---|
+| User-adjustable channel weights & on/off (PR #187) | [2026-08-10_adjustable-channel-weights_PR187.md](2026-08-10_adjustable-channel-weights_PR187.md) | Draft PR, verified default-equivalent, awaiting preview decision |
+| Tesserae-through-your-AI (open API + AI orchestration) | [2026-08-10_ai-api-access.md](2026-08-10_ai-api-access.md) | Guide live; PoC done; feature-request endpoint approved to build (needs GitHub token) |
+
+## Consolidated work plan (as of 2026-08-10)
+
+Four workstreams. Three active, one recommended for parking.
+
+**1 — Adjustable weights & channel on/off (PR #187).** Draft PR, proven not to change anyone's default results. To finish: decide whether to preview on the live site, then rebase onto `main`, un-draft, merge, deploy. Open product question: keep the standalone single-channel search modes or retire them.
+
+**2 — "Tesserae through your AI" guide.** Live at `/tesserae-data/ai-guide.html`. Remaining: (a) surface it with a link/section on the Help page (NC wanted this first); (b) once #187 ships, document its two new knobs in the guide; (c) **native connector (NC wants this):** OpenAPI → ChatGPT Custom GPT/Action and/or an MCP server for Claude, so users don't paste a prompt at all.
+
+**3 — Feature/language requests via the AI channel (new gated PR).** Designed + approved, not built. To finish: build the gated PR (reuse the existing `/api/feedback` system + mirror actionable requests to GitHub Issues, user email stripped from the public issue); add a "how to request" section to the guide; NC/Chris provision one GitHub token to switch the GitHub half on.
+
+**4 — MQDQ-style corpus display. RECOMMEND PARK.** The "show the poetic corpus in results" gap Neil B. named is largely already closed: the **corpus-wide search button** already runs a result's shared words across the whole corpus, and the AI guide uses the same capability (`line-search`) for its uniqueness step — the PoC did exactly this. The only thing MQDQ does that we don't is display those corpus hits *inline automatically* instead of on a click. That's a small optional polish, not a real gap. Park unless NC wants the inline auto-display.
+
+**Recommended sequence:** (1) commit these dossiers → (2) build #3's gated PR (approved, self-contained, merges safely even before the token) → (3) add the guide link to the Help page (#2a) → (4) decide #187 preview and ship, then update the guide (#2b) → park #4.
+
+## Conventions
+- Filename: `YYYY-MM-DD_short-slug.md` (date the thread was first captured here).
+- Keep the status line at the top current.
+- Cross-link sibling threads at the bottom.


### PR DESCRIPTION
## Prototype (draft — do not merge/deploy)

Two related Advanced controls for fusion search: **per-channel weight inputs** (original prototype) and **per-channel ON/OFF switches** (added in this update). Both are fully gated so a default search is byte-identical to today.

A weight of 0 is **not** a true off — a zeroed channel still runs and can pull pairs in through the convergence bonus. The new on/off switches actually **exclude** unchecked channels from running.

---

## Part 1 — Per-channel weights (original)

Lets users override the fusion search's per-channel weights from an **Advanced** UI panel. The scoring layer (`fuse_results(..., weights=...)`) already supported custom weights; this wires a UI + request path to it.

**Gating (default byte-identical):** request accepts optional `channel_weights`; when absent/empty, `iter_fusion_search` passes `weights=None` and `fuse_results` falls through to `get_weight_profile(language=...)`. When present, weights are sanitized (numbers only, unknown keys dropped, clamped 0–20) and merged over the language-default profile. Added to the cache key only when non-empty.

**Endpoint:** `GET /api/fusion-default-weights?language=xx` → `{language, weights, min, max}` for UI pre-fill / reset.

---

## Part 2 — Per-channel ON/OFF switches (this update)

A user can now run a fusion search with only *some* channels (e.g. just Sound + Syntax). Unchecked channels are excluded from running entirely, so they cannot contribute convergence.

### How it's gated (default behavior is byte-identical)
- The request carries an optional **`disabled_channels`** list — the channels the user turned OFF. When **absent or empty**, nothing changes: no restriction is applied and every language-available channel runs exactly as before.
- The wire format is the **OFF list** (not the keep list) on purpose: channels the UI never exposes — e.g. `quotation` — stay on unless explicitly disabled, and a search with nothing off is byte-identical to today.
- The blueprint sanitizes `disabled_channels` to known channel keys, intersects with the channels available for the language, and converts to an **enabled keep-set** = `available − disabled`. It is treated as a real restriction **only when** it actually drops a running channel **and** leaves at least one channel running.
- **Guard rail:** if the user turns everything off (or only disables channels that wouldn't run anyway), the search falls back to the full available set rather than returning nothing.
- The keep-set is added to the results **cache key only when it meaningfully restricts** the set, so restricted searches get their own cache entries and never collide with the default or with a differently-configured search.

### Changes
**Backend `backend/fusion.py`**
- `sanitize_channel_keys(raw)` — validate a list of channel keys → set of known keys, or `None` when empty/unusable.
- `iter_fusion_search(...)` gains an optional **`enabled_channels`** keep-set. When provided, it filters both the line and window channel lists to those channels (the window pass reuses the same filtered `available_channels`, so one filter covers both). Guard rail falls back to the full set if the filter empties it. When `None`, byte-identical to before.

**Backend `backend/blueprints/fusion.py`**
- Parse + sanitize `disabled_channels`; convert to the enabled keep-set; add to the cache key only when it restricts; pass to `iter_fusion_search`.

**Backend `backend/cache.py`**
- `channel_weights` and `enabled_channels` now participate in the cache key, but **only when present**, so default searches keep byte-identical keys. (Previously these keys were silently ignored by the fixed key whitelist, so custom searches could collide with the default cache entry — this also fixes that latent issue for the weights path.)

**Frontend**
- `client/src/components/search/SearchSettings.jsx`: each channel row is now **[on/off checkbox] [plain-English label] [weight input]**. All channels on by default; unchecking greys/disables that channel's weight input. Panel renamed to **"Advanced — Channels & weights"**. **Reset to defaults** now restores BOTH the weights and the all-on state. Note updated to *"the defaults are optimized; custom settings can reduce recall."*
- `client/src/App.jsx`: `settings.disabled_channels` state (default `[]`); included in the fusion request **only when non-empty** (stripped in both the normal and rerun-fresh param builders).

Plain-English labels: Shared words = lemma, Single word = lemma_min1, Exact, Sound, Spelling = edit_distance, Meaning = semantic, Synonyms = dictionary, Syntax, Structure = syntax_structural, Rare words = rare_word.

---

## Conservative choices (noted)
- `quotation` is **not** exposed in the UI (0 for Latin/Greek/English; managed by the Coptic biblical profile). Because the wire format is the OFF list, it stays on and is never accidentally dropped when the user restricts other channels.
- Weight clamp range is **0–20**; overrides merge over the language default, so switching language re-bases the defaults automatically.

## Verification (venv)
- **Sanitizers/conversion:** `sanitize_channel_keys` drops unknown keys and returns `None` for empty/all-unknown; the blueprint's disabled→enabled conversion returns `None` (default) for nothing-off / empty / all-unknown / everything-off (guard rail), and the correct keep-set for a partial selection.
- **Live channel filtering** (`iter_fusion_search` on two short Latin texts): default run started all channels (line: lemma, exact, quotation, rare_word, dictionary, syntax, lemma_min1, semantic, sound, edit_distance; window: lemma, lemma_min1, rare_word, dictionary) and returned 76 results. Restricted to `{sound, syntax, syntax_structural}` → only `syntax` + `sound` ran. Restricted to `{lemma, exact}` → only `lemma`/`exact` (line) + `lemma` (window) ran, and the 76 default results (which came from the excluded lemma_min1/semantic/edit_distance channels) dropped to 0 — confirming excluded channels no longer pull pairs in.
- **Cache key:** default key is byte-identical whether or not a falsy `enabled_channels` is present; a restricting keep-set produces a different key.
- **Unit tests:** `pytest -k "fusion or channel or cache"` → 78 passed, 1 skipped.
- **Frontend build:** `npm run build` at repo root succeeds (2877 modules). No `dist/` artifacts are included in this PR.

> Note: a clean `npm run build` of `main` currently needs three deps imported by existing admin/login code but not declared in `package.json` — `lucide-react`, `recharts`, `react-router-dom`. Installed locally into the gitignored `node_modules` to complete the build; not added to `package.json`. Pre-existing and unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
