### PR TITLE
Gated AI-protocol feature-request endpoint (POST /api/feature-request)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -488,6 +488,7 @@ from backend.blueprints.hapax import hapax_bp, init_hapax_blueprint
 from backend.blueprints.batch import batch_bp, init_batch_blueprint
 from backend.blueprints.api_docs import api_docs_bp
 from backend.blueprints.fusion import fusion_bp, init_fusion_blueprint
+from backend.blueprints.feature_request import feature_request_bp
 from backend.email_notifications import notify_text_request, notify_feedback
 
 author_dates_path = os.path.join(os.path.dirname(__file__), 'author_dates.json')
@@ -557,6 +558,7 @@ app.register_blueprint(hapax_bp, url_prefix=API_PREFIX or None)
 app.register_blueprint(batch_bp, url_prefix=batch_prefix)
 app.register_blueprint(api_docs_bp, url_prefix=API_PREFIX or None)
 app.register_blueprint(fusion_bp, url_prefix=API_PREFIX or None)
+app.register_blueprint(feature_request_bp, url_prefix=API_PREFIX or None)
 
 app_logger.info(f"Blueprints registered (API_PREFIX='{API_PREFIX}', env={DEPLOYMENT_ENV})")
 

--- a/backend/blueprints/feature_request.py
+++ b/backend/blueprints/feature_request.py
@@ -1,0 +1,158 @@
+"""
+Tesserae V6 - Feature Request Blueprint
+
+POST /api/feature-request — intake for structured feature / language / text /
+bug requests submitted by a user's AI assistant following the Tesserae
+AI-assistant guide.
+
+Flow for each submission:
+    1. Validate + rate-limit (per IP).
+    2. Store privately in the `feedback` table (includes contact, if given).
+    3. Email the team privately (includes contact).
+    4. For actionable types (feature / language / bug), ALSO auto-file a public
+       GitHub issue — with the submitter's contact/email STRIPPED — so it lands
+       in the dev triage workflow. Gated: no token configured => this step is
+       skipped and the request still lands via DB + email.
+
+The AI is instructed (in the guide) to obtain explicit user sign-off before
+calling this endpoint and to warn the user that the description becomes a public
+GitHub issue; contact info is kept private by this endpoint regardless.
+"""
+import os
+import time
+import logging
+import threading
+
+from flask import Blueprint, jsonify, request
+
+from backend.db_utils import get_db_cursor
+from backend.email_notifications import send_notification
+from backend.github_feedback import github_feedback_enabled, create_feedback_issue
+
+logger = logging.getLogger(__name__)
+
+feature_request_bp = Blueprint('feature_request', __name__)
+
+VALID_TYPES = {'feature', 'language', 'text', 'bug', 'other'}
+GITHUB_TYPES = {'feature', 'language', 'bug'}   # 'text' -> curatorial flow; 'other' -> no issue
+MAX_FIELD = 4000
+MAX_TOTAL = 12000
+
+# --- simple per-IP rate limit (mirrors the admin-login limiter) ---
+_RL_MAX = int(os.environ.get('FEATURE_REQUEST_MAX_PER_HOUR', '6'))
+_RL_WINDOW = 3600
+_rl_attempts = {}
+_rl_lock = threading.Lock()
+
+
+def _client_ip():
+    fwd = (request.headers.get('X-Forwarded-For') or '').split(',')[0].strip()
+    return fwd or request.remote_addr or 'unknown'
+
+
+def _rate_limited():
+    now = time.time()
+    ip = _client_ip()
+    cutoff = now - _RL_WINDOW
+    with _rl_lock:
+        # prune all buckets
+        for k in list(_rl_attempts):
+            kept = [t for t in _rl_attempts[k] if t >= cutoff]
+            if kept:
+                _rl_attempts[k] = kept
+            else:
+                _rl_attempts.pop(k, None)
+        recent = _rl_attempts.get(ip, [])
+        if len(recent) >= _RL_MAX:
+            return True
+        recent.append(now)
+        _rl_attempts[ip] = recent
+        return False
+
+
+def _field(data, name):
+    v = data.get(name)
+    return str(v).strip()[:MAX_FIELD] if v else ''
+
+
+@feature_request_bp.route('/feature-request', methods=['POST'])
+def feature_request():
+    data = request.get_json(silent=True) or {}
+
+    req_type = (data.get('type') or 'feature').strip().lower()
+    if req_type not in VALID_TYPES:
+        req_type = 'other'
+
+    title = _field(data, 'title')
+    problem = _field(data, 'problem')
+    desired = _field(data, 'desired')
+    example = _field(data, 'example')
+    tried = _field(data, 'tried')
+    context = _field(data, 'context')
+    contact = _field(data, 'contact')          # email — kept PRIVATE (DB + email only)
+
+    if not (title or problem or desired):
+        return jsonify({'error': 'Please include at least a title or a description '
+                                 'of what you want.'}), 400
+
+    if _rate_limited():
+        return jsonify({'error': 'Too many requests from this address. '
+                                 'Please try again later.'}), 429, {'Retry-After': str(_RL_WINDOW)}
+
+    # --- public-safe body (NO contact) — shared by the DB record, email, and GitHub issue ---
+    parts = []
+    if title:
+        parts.append(f"**Title:** {title}")
+    parts.append(f"**Type:** {req_type}")
+    if problem:
+        parts.append(f"**Problem / need:**\n{problem}")
+    if desired:
+        parts.append(f"**Desired Tesserae behaviour:**\n{desired}")
+    if example:
+        parts.append(f"**Example:**\n{example}")
+    if tried:
+        parts.append(f"**Current workaround / what they tried:**\n{tried}")
+    if context:
+        parts.append(f"**Search context (auto-captured):**\n{context}")
+    public_body = "\n\n".join(parts)[:MAX_TOTAL]
+    public_body += "\n\n---\n_Filed via the Tesserae AI-assistant protocol._"
+
+    feedback_id = None
+    issue_url = None
+
+    # --- (2) private DB record (feedback table), contact included ---
+    try:
+        with get_db_cursor() as cur:
+            cur.execute(
+                '''INSERT INTO feedback (name, email, feedback_type, message)
+                   VALUES (%s, %s, %s, %s) RETURNING id''',
+                (None, contact or None, f'ai:{req_type}',
+                 public_body + (f"\n\n[contact: {contact}]" if contact else '')),
+            )
+            row = cur.fetchone()
+            feedback_id = row[0] if row else None
+    except Exception as e:
+        logger.warning("feature_request DB insert failed: %s", e)
+
+    # --- (3) private email to the team, contact included ---
+    try:
+        subject = f"New AI-protocol {req_type} request" + (f": {title}" if title else "")
+        email_body = public_body + (
+            f"\n\nContact (private): {contact}" if contact else "\n\nContact: not provided")
+        send_notification(subject, email_body, 'feature_request')
+    except Exception as e:
+        logger.warning("feature_request email notify failed: %s", e)
+
+    # --- (4) public GitHub issue for actionable types, email STRIPPED ---
+    if req_type in GITHUB_TYPES and github_feedback_enabled():
+        gh_title = f"[{req_type}] " + (title or f"{req_type} request")
+        issue_url = create_feedback_issue(gh_title, public_body,
+                                          ['from-ai-protocol', req_type])
+
+    return jsonify({
+        'success': True,
+        'id': feedback_id,
+        'type': req_type,
+        'github_filed': bool(issue_url),
+        'issue_url': issue_url,
+    })

--- a/backend/github_feedback.py
+++ b/backend/github_feedback.py
@@ -1,0 +1,65 @@
+"""
+GitHub issue filing for AI-protocol feature/language/bug requests.
+
+A user's AI assistant (following the Tesserae AI-assistant guide) can submit a
+structured request via POST /api/feature-request. For actionable types this
+module files a labelled GitHub issue in the team's repo so it lands directly in
+the dev triage workflow.
+
+Gating & safety:
+    - Fully OFF unless BOTH GITHUB_FEEDBACK_TOKEN and GITHUB_FEEDBACK_REPO are
+      set (and FEEDBACK_GITHUB_ENABLED is not explicitly false). With the token
+      absent, callers fall back to the private DB + email path only.
+    - The public issue NEVER contains the submitter's contact/email — the caller
+      is responsible for passing an already-stripped body. This module does not
+      accept or embed contact info.
+    - The token is read from the environment and never logged.
+"""
+import os
+import logging
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+GITHUB_API = "https://api.github.com"
+_TIMEOUT = 10
+
+
+def github_feedback_enabled():
+    """True only when a token + repo are configured and the kill-switch is on."""
+    token = os.environ.get('GITHUB_FEEDBACK_TOKEN', '').strip()
+    repo = os.environ.get('GITHUB_FEEDBACK_REPO', '').strip()
+    enabled = os.environ.get('FEEDBACK_GITHUB_ENABLED', 'true').strip().lower()
+    return bool(token and repo and enabled in ('1', 'true', 'yes', 'on'))
+
+
+def create_feedback_issue(title, body, labels):
+    """Create a GitHub issue and return its html_url, or None on failure/disabled.
+
+    `title` and `body` must ALREADY have any submitter contact info removed —
+    this becomes a public issue.
+    """
+    if not github_feedback_enabled():
+        return None
+    token = os.environ.get('GITHUB_FEEDBACK_TOKEN', '').strip()
+    repo = os.environ.get('GITHUB_FEEDBACK_REPO', '').strip()
+    try:
+        resp = requests.post(
+            f"{GITHUB_API}/repos/{repo}/issues",
+            headers={
+                'Authorization': f'Bearer {token}',
+                'Accept': 'application/vnd.github+json',
+                'X-GitHub-Api-Version': '2022-11-28',
+            },
+            json={'title': title[:250], 'body': body, 'labels': labels},
+            timeout=_TIMEOUT,
+        )
+        if resp.status_code == 201:
+            return resp.json().get('html_url')
+        # Never log the token; response text may include useful GitHub error detail.
+        logger.warning("GitHub feedback issue failed: %s %s",
+                       resp.status_code, resp.text[:300])
+    except Exception as e:
+        logger.warning("GitHub feedback issue error: %s", e)
+    return None

--- a/tests/test_github_feedback.py
+++ b/tests/test_github_feedback.py
@@ -1,0 +1,50 @@
+"""Tests for backend.github_feedback — the gate that guards AI-protocol
+feature requests from filing GitHub issues unless explicitly configured.
+
+The critical safety property: with no token/repo configured, GitHub filing is
+OFF and create_feedback_issue() is a no-op returning None (requests fall back to
+the private DB + email path).
+"""
+import backend.github_feedback as gf
+
+
+def _clear_env(monkeypatch):
+    for k in ('GITHUB_FEEDBACK_TOKEN', 'GITHUB_FEEDBACK_REPO', 'FEEDBACK_GITHUB_ENABLED'):
+        monkeypatch.delenv(k, raising=False)
+
+
+def test_disabled_when_unconfigured(monkeypatch):
+    _clear_env(monkeypatch)
+    assert gf.github_feedback_enabled() is False
+
+
+def test_disabled_with_token_but_no_repo(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv('GITHUB_FEEDBACK_TOKEN', 'x')
+    assert gf.github_feedback_enabled() is False
+
+
+def test_enabled_with_token_and_repo(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv('GITHUB_FEEDBACK_TOKEN', 'x')
+    monkeypatch.setenv('GITHUB_FEEDBACK_REPO', 'org/repo')
+    assert gf.github_feedback_enabled() is True
+
+
+def test_kill_switch_off(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv('GITHUB_FEEDBACK_TOKEN', 'x')
+    monkeypatch.setenv('GITHUB_FEEDBACK_REPO', 'org/repo')
+    monkeypatch.setenv('FEEDBACK_GITHUB_ENABLED', 'false')
+    assert gf.github_feedback_enabled() is False
+
+
+def test_create_issue_noop_when_disabled(monkeypatch):
+    """Must never call the network when disabled."""
+    _clear_env(monkeypatch)
+
+    def _boom(*a, **k):
+        raise AssertionError("requests.post must not be called when disabled")
+
+    monkeypatch.setattr(gf.requests, 'post', _boom)
+    assert gf.create_feedback_issue('t', 'b', ['from-ai-protocol', 'feature']) is None


### PR DESCRIPTION
Lets a user's AI assistant (following the Tesserae AI-assistant guide) submit a **structured feature / language / text / bug request**. Draft — see the two setup items at the bottom before enabling the GitHub half.

## What it does
`POST /api/feature-request` with `{type, title, problem, desired, example, tried, context, contact}`:
1. **Stores privately** in the `feedback` table (with contact).
2. **Emails the team** privately (with contact) via the existing notifier.
3. For **feature / language / bug**, also **auto-files a public GitHub issue** (`from-ai-protocol` + type) so it hits the dev triage workflow — **with the submitter's contact/email stripped** from the public issue.

`text` requests go to DB+email only (the curatorial `text_requests` flow is the right home); `other` never files an issue.

## Safety / gating
- **GitHub filing is OFF** unless `GITHUB_FEEDBACK_TOKEN` + `GITHUB_FEEDBACK_REPO` are set (kill-switch `FEEDBACK_GITHUB_ENABLED`). **Without a token it degrades to the private DB+email path** — so this is safe to merge before anything is provisioned.
- Per-IP rate limit (`FEATURE_REQUEST_MAX_PER_HOUR`, default 6), field/size caps, required-field validation.
- Token read from env, never logged; contact never in the public issue.
- **Explicit user sign-off** is enforced in the guide/protocol (the AI confirms with the user before calling), not the endpoint.

## Tests
`tests/test_github_feedback.py` — GitHub filing stays off without a token and makes no network call when disabled.

## To activate the GitHub half (not required to merge)
1. Create a fine-grained GitHub PAT (ideally a shared/bot account), scoped to **only `tesserae/tesserae-v6`, Issues: read/write**.
2. Set in prod `.env`: `GITHUB_FEEDBACK_TOKEN=…` and `GITHUB_FEEDBACK_REPO=tesserae/tesserae-v6`.

Follow-up (separate): add a "Requesting a feature" section to the AI guide (task #13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)