### PR TITLE
Consolidate: Phrases = always fusion; enable sound/edit_distance for English

### DIFF
--- a/backend/fusion.py
+++ b/backend/fusion.py
@@ -204,6 +204,15 @@ CHANNEL_WEIGHTS = {
 WEIGHT_PROFILES = {
     "latin_epic": dict(CHANNEL_WEIGHTS),  # snapshot of the historical Latin-tuned defaults
 
+    # English default. Same as latin_epic EXCEPT sound + edit_distance default
+    # to 0: those two channels are language-agnostic and are now available for
+    # English (so users can weight them up in the Advanced panel / run a
+    # sound-only or spelling-only English search), but they are noisy for
+    # English (edit_distance in particular yields many loose fuzzy matches), so
+    # the conservative default is 0 — English fusion output is unchanged unless
+    # a user opts in. All other weights match latin_epic.
+    "english": {**dict(CHANNEL_WEIGHTS), "sound": 0.0, "edit_distance": 0.0},
+
     # Best-composite result from Phase 9 optimization (iter 16, seed 314).
     # 50-iter biblical-bias search over log-uniform [0.1×, 10×]; semantic and
     # quotation channels included as tunables. Objective: R@100 against the
@@ -283,12 +292,14 @@ def get_weight_profile(language=None, corpus_type=None, profile_name=None):
     Selection order:
       1. Explicit profile_name (overrides everything).
       2. (language, corpus_type) tuple lookup — future extension point.
-      3. Language default: cop → biblical_coptic; everything else → latin_epic.
+      3. Language default: cop → biblical_coptic; en → english; else → latin_epic.
     """
     if profile_name and profile_name in WEIGHT_PROFILES:
         return dict(WEIGHT_PROFILES[profile_name])
     if language == "cop":
         return dict(WEIGHT_PROFILES["biblical_coptic"])
+    if language == "en":
+        return dict(WEIGHT_PROFILES["english"])
     return dict(WEIGHT_PROFILES["latin_epic"])
 
 
@@ -532,8 +543,8 @@ CHANNEL_ORDER = [
 # skipped and not counted in the "N channels" progress message.
 CHANNEL_LANGUAGE_SUPPORT = {
     "dictionary":    {"la", "grc", "cop"},  # Latin/Greek synonym pairs; Coptic uses Coptic Wordnet (Slaughter et al. 2019)
-    "sound":         {"la", "grc", "cop"},  # character trigram Jaccard similarity
-    "edit_distance": {"la", "grc", "cop"},  # Levenshtein fuzzy matching
+    "sound":         {"la", "grc", "cop", "en"},  # character trigram Jaccard similarity (language-agnostic)
+    "edit_distance": {"la", "grc", "cop", "en"},  # Levenshtein fuzzy matching (language-agnostic)
     "syntax":        {"la", "grc", "cop"},  # requires syntax DB (syntax_latin.db / syntax_greek.db / syntax_coptic.db)
     "semantic":      {"la", "grc", "en", "cop"},  # SPhilBERTa (la/grc/en) + multilingual-e5-large (cop)
     "quotation":     {"la", "grc", "cop", "en"},  # runs of identical tokens — language-agnostic

--- a/client/src/components/search/SearchSettings.jsx
+++ b/client/src/components/search/SearchSettings.jsx
@@ -135,21 +135,11 @@ const SearchSettings = ({ settings, setSettings, showAdvanced, setShowAdvanced, 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            Match Type
+            Search Method
           </label>
-          <select
-            value={settings.match_type}
-            onChange={(e) => handleChange('match_type', e.target.value)}
-            className="w-full border rounded px-2 py-2 text-base sm:text-sm"
-          >
-            <option value="fusion">Fusion — All Channels (best recall)</option>
-            <option value="lemma">Dictionary Form (Lemma)</option>
-            <option value="exact">Exact Match</option>
-            <option value="semantic">AI Semantic</option>
-            <option value="dictionary">Dictionary (V3 Synonyms)</option>
-            <option value="sound">Sound Matching (slower)</option>
-            <option value="edit_distance">Edit Distance (slower)</option>
-          </select>
+          <p className="w-full border rounded px-2 py-2 text-base sm:text-sm bg-gray-50 text-gray-800">
+            Fusion — all channels
+          </p>
           {settings.match_type === 'fusion' && (
             <p className="text-xs text-gray-500 mt-1">
               Runs 9 channels with weighted scoring. Best recall but slower.

--- a/tests/test_fusion_scoring.py
+++ b/tests/test_fusion_scoring.py
@@ -422,10 +422,22 @@ class TestWeightProfileFirewall:
         from backend.fusion import get_weight_profile, WEIGHT_PROFILES
         assert get_weight_profile(language='cop') == WEIGHT_PROFILES['biblical_coptic']
 
-    def test_latin_greek_english_get_latin_epic(self):
+    def test_latin_greek_get_latin_epic(self):
         from backend.fusion import get_weight_profile, WEIGHT_PROFILES
-        for lang in ('la', 'grc', 'en'):
+        for lang in ('la', 'grc'):
             assert get_weight_profile(language=lang) == WEIGHT_PROFILES['latin_epic']
+
+    def test_english_gets_english_profile(self):
+        # English uses its own profile: identical to latin_epic EXCEPT sound and
+        # edit_distance default to 0 (those channels are available for English
+        # but noisy, so off by default; users can weight them up in Advanced).
+        from backend.fusion import get_weight_profile, WEIGHT_PROFILES
+        en = get_weight_profile(language='en')
+        latin = WEIGHT_PROFILES['latin_epic']
+        assert en == WEIGHT_PROFILES['english']
+        assert en['sound'] == 0.0 and en['edit_distance'] == 0.0
+        assert all(en[k] == latin[k] for k in latin
+                   if k not in ('sound', 'edit_distance'))
 
     def test_none_and_unknown_default_to_latin_epic(self):
         from backend.fusion import get_weight_profile, WEIGHT_PROFILES


### PR DESCRIPTION
Removes the redundant single-method **Match Type** dropdown from the Phrases search now that the Advanced channel selector (PR #187) covers those methods. Phrases is always fusion + the channel selector.

## Redundancy (verified live)
The six dropdown methods — `lemma`, `exact`, `semantic`, `dictionary`, `sound`, `edit_distance` — are single-channel two-text searches reproducible via fusion with one channel enabled. **Kept:** Lines & String (corpus-wide), Rare Words/Pairs, Cross-Language (distinct workflows).

## English coverage gap → fixed
Live tests showed English `sound` (works) and `edit_distance` (works) had **no** channel-selector equivalent (they were excluded from English), while `dictionary` returns 0 for English (no synonym data). To make coverage complete:
- **Enable `sound` + `edit_distance` for English** (language-agnostic channels).
- New **`english` weight profile** = `latin_epic` with `sound`/`edit_distance` defaulted to **0**, so **default English fusion output is unchanged**; users can weight them up in the Advanced panel to run a sound-only / spelling-only English search. `dictionary` stays off for English.
- Latin / Greek / Coptic defaults **untouched** (verified: la still sound=5/edit=2).

## Scope
- Frontend: replace the Match Type dropdown with a static "Fusion — all channels" indicator (`match_type` already defaults to `fusion`). Single-method backend endpoints remain for API/back-compat.
- Backend: `CHANNEL_LANGUAGE_SUPPORT` (+en for sound/edit_distance), new `english` profile, `get_weight_profile` en→english.

## Verification
- Config: `get_channels_for_language('en')` includes sound/edit_distance; `get_weight_profile('en')` → sound=0/edit=0; la unchanged.
- Live (branch on prod): en endpoint exposes sound/edit_distance at 0; Latin arma-virum regression passes; English fusion search runs clean (see PR discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)