### PR TITLE
Surface the 'use your own AI' option (search-page banner + fuller Help)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import { Repository } from './components/repository';
 import { AdminPanel } from './components/admin';
 import { AboutPage, HelpPage, DownloadsPage, PrivacyPage, ResearchPage, BlogArchivePage } from './components/pages';
 import TextCredits from './components/about/TextCredits';
+import AiAnnouncement from './components/AiAnnouncement';
 import VisualizationsPage from './components/pages/VisualizationsPage';
 import { useCorpus, useSearch } from './hooks';
 import { getSessionValue, setSessionValue } from './utils/storage';
@@ -652,6 +653,7 @@ function App() {
           <AdminPanel />
         ) : (
           <>
+        <AiAnnouncement />
         {pageType === 'search' && activeTab !== 'cross' && (
           <div className="space-y-6">
             <div className="bg-white rounded-lg shadow p-4 sm:p-6">

--- a/client/src/components/AiAnnouncement.jsx
+++ b/client/src/components/AiAnnouncement.jsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+
+// Dismissible banner announcing the "use your own AI with Tesserae" option.
+// Links to the setup hub; dismissal persists via localStorage.
+const KEY = 'tesserae_ai_banner_dismissed_v1';
+
+const AiAnnouncement = () => {
+  const [hidden, setHidden] = useState(() => {
+    try { return localStorage.getItem(KEY) === '1'; } catch { return false; }
+  });
+  if (hidden) return null;
+
+  const dismiss = () => {
+    try { localStorage.setItem(KEY, '1'); } catch { /* ignore */ }
+    setHidden(true);
+  };
+
+  return (
+    <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 flex items-start gap-3">
+      <span className="text-lg leading-none mt-0.5" aria-hidden="true">✨</span>
+      <div className="flex-1 text-sm text-amber-900">
+        <strong>New — use your own AI with Tesserae.</strong>{' '}
+        Have ChatGPT or Claude run searches and help interpret the results.{' '}
+        <a
+          href="/tesserae-data/tesserae-ai-setup.html"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-semibold underline hover:text-amber-700"
+        >
+          Set it up →
+        </a>{' '}
+        <span className="text-amber-800">(Claude gives the fullest capabilities.)</span>
+      </div>
+      <button
+        onClick={dismiss}
+        className="text-amber-700 hover:text-amber-900 text-xl leading-none px-1 -mt-1"
+        aria-label="Dismiss announcement"
+      >
+        ×
+      </button>
+    </div>
+  );
+};
+
+export default AiAnnouncement;

--- a/client/src/components/pages/HelpPage.jsx
+++ b/client/src/components/pages/HelpPage.jsx
@@ -1301,24 +1301,53 @@ export default function HelpPage() {
             <div className="prose max-w-none">
               <h3 className="text-xl font-semibold text-gray-900 mb-4">Use Tesserae with your AI assistant</h3>
               <p className="text-gray-700 mb-4">
-                You can let your own AI assistant (such as ChatGPT or Claude) run Tesserae searches for you — comparing
+                You can let your own AI assistant (such as Claude or ChatGPT) run Tesserae searches for you — comparing
                 texts, testing parallels for uniqueness across the corpus, and helping you interpret the results.
                 Tesserae does the searching, free, on its open API; your assistant orchestrates the steps and interprets.
+                There are three ways to connect, from simplest to most capable.
               </p>
+
+              <a
+                href="/tesserae-data/tesserae-ai-setup.html"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-medium px-4 py-2 rounded no-underline mb-5"
+              >
+                Open the full setup guide →
+              </a>
+
+              <div className="space-y-3 mb-5">
+                <div className="bg-gray-50 p-4 rounded border border-gray-200">
+                  <h4 className="font-medium text-gray-900 mb-1">1 · Paste-in guide <span className="text-xs font-normal text-gray-500">— any AI, no setup</span></h4>
+                  <p className="text-gray-700 text-sm">
+                    Open our <a href="/tesserae-data/ai-guide.html" target="_blank" rel="noopener noreferrer" className="text-blue-700 underline">paste-in guide</a>,
+                    copy it, and paste it into any web-capable assistant (ChatGPT, Claude, Gemini…) as your first
+                    message. It teaches the assistant Tesserae's full toolbox and a step-by-step research workflow.
+                  </p>
+                </div>
+                <div className="bg-gray-50 p-4 rounded border border-gray-200">
+                  <h4 className="font-medium text-gray-900 mb-1">2 · ChatGPT Custom GPT <span className="text-xs font-normal text-gray-500">— included in ChatGPT Plus</span></h4>
+                  <p className="text-gray-700 text-sm">
+                    Build a reusable “Tesserae” GPT (Explore GPTs → “+ Create”), paste our instructions, and import our
+                    API schema by URL. The setup guide has the exact steps, the schema URL, and the instructions to paste.
+                  </p>
+                </div>
+                <div className="bg-gray-50 p-4 rounded border border-gray-200">
+                  <h4 className="font-medium text-gray-900 mb-1">3 · Claude, via a connector (MCP) <span className="text-xs font-normal text-gray-500">— most capable</span></h4>
+                  <p className="text-gray-700 text-sm">
+                    Add Tesserae as a connector so Claude can call it directly. Because this route has no short time
+                    limit, it can run even the full fusion search. Needs Python; the setup guide has the download and config.
+                  </p>
+                </div>
+              </div>
+
               <div className="bg-blue-50 p-4 rounded border border-blue-200 mb-4">
-                <p className="text-gray-700 text-sm mb-3">
-                  We've written a guide you can paste into your assistant as its first message. It teaches the assistant
-                  Tesserae's full toolbox, a step-by-step research workflow, and — importantly — to keep a clear line
-                  between Tesserae's reproducible results and the AI's own interpretation.
+                <p className="text-gray-700 text-sm">
+                  <strong>Recommendation:</strong> for the fullest capabilities — including running the complete fusion
+                  search from your assistant — use <strong>Claude with the connector (route 3)</strong>. ChatGPT and the
+                  paste-in guide work well for text discovery, corpus-uniqueness checks, and rare-word / rare-pair
+                  comparison, but can't run the long fusion search directly.
                 </p>
-                <a
-                  href="/tesserae-data/ai-guide.html"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-medium px-4 py-2 rounded no-underline"
-                >
-                  Open the full guide →
-                </a>
               </div>
               <div className="bg-amber-50 p-4 rounded border border-amber-200">
                 <h4 className="font-medium text-amber-900 mb-2">A note on scholarly use</h4>


### PR DESCRIPTION
Makes the AI-integration options discoverable on the site.

- **Search-page banner** (dismissible, localStorage) → links the AI setup hub; notes Claude gives the fullest capabilities.
- **Help → Use with your AI**: repointed to the setup hub and expanded to full instructions for all three routes (paste-in guide, ChatGPT Custom GPT, Claude MCP), with an explicit recommendation to use Claude (route 3) for the full fusion search.

Frontend only. Build verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)