### PR TITLE
GET support for light search endpoints (URL-param access for restricted AI assistants)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1574,7 +1574,7 @@ def add_text():
 # These routes enable searching for words/phrases across the entire corpus
 # using the pre-built inverted index for fast lookups.
 
-@api_route('/line-search', methods=['POST'])
+@api_route('/line-search', methods=['GET', 'POST'])
 def line_search():
     """
     Search for words/phrases across the corpus with optional filters.
@@ -1584,8 +1584,10 @@ def line_search():
         from backend.inverted_index import is_index_available, find_co_occurring_lemmas, has_lines_data, get_lines_batch
         from backend.distance_filter import passes_distance_filter, is_prose_text as is_prose_text_unified
         
-        data = request.get_json() or {}
-        
+        # Accept both POST JSON bodies and GET query-string params, so any
+        # assistant that can only fetch a URL can still run this search.
+        data = request.get_json(silent=True) or request.args
+
         query = data.get('query', '')
         language = data.get('language', 'la')
         search_type = data.get('search_type', 'lemma')

--- a/backend/blueprints/hapax.py
+++ b/backend/blueprints/hapax.py
@@ -1933,7 +1933,7 @@ def _scan_text_lemma_locations(text_id, language, lemmas_of_interest):
     return out
 
 
-@hapax_bp.route('/hapax-search', methods=['POST'])
+@hapax_bp.route('/hapax-search', methods=['GET', 'POST'])
 def hapax_search():
     """
     Find shared rare words between source and target texts.
@@ -1948,7 +1948,8 @@ def hapax_search():
         exclude_proper_nouns: filter out proper nouns like names/places (default: false)
     """
     try:
-        data = request.get_json() or {}
+        # Accept both POST JSON bodies and GET query-string params.
+        data = request.get_json(silent=True) or request.args
         try:
             source_id, target_id, language = _parse_search_params(data)
         except ValueError as e:
@@ -2092,7 +2093,7 @@ def hapax_search():
         return jsonify({'error': str(e)}), 500
 
 
-@hapax_bp.route('/rare-bigram-search', methods=['POST'])
+@hapax_bp.route('/rare-bigram-search', methods=['GET', 'POST'])
 def rare_bigram_search():
     """
     Find shared rare word-pairs (bigrams) between source and target texts.
@@ -2114,7 +2115,8 @@ def rare_bigram_search():
             extract_bigrams, get_bigram_rarity_score, make_bigram_key
         )
 
-        data = request.get_json() or {}
+        # Accept both POST JSON bodies and GET query-string params.
+        data = request.get_json(silent=True) or request.args
         try:
             source_id, target_id, language = _parse_search_params(data)
         except ValueError as e:

--- a/backend/blueprints/search.py
+++ b/backend/blueprints/search.py
@@ -1576,7 +1576,7 @@ def clear_search_cache():
         return jsonify({'success': False, 'error': str(e)}), 500
 
 
-@search_bp.route('/wildcard-search', methods=['POST'])
+@search_bp.route('/wildcard-search', methods=['GET', 'POST'])
 def wildcard_search_endpoint():
     """
     PHI-style wildcard/boolean search.
@@ -1589,7 +1589,8 @@ def wildcard_search_endpoint():
     try:
         from backend.wildcard_search import wildcard_search
         
-        data = request.get_json()
+        # Accept both POST JSON bodies and GET query-string params.
+        data = request.get_json(silent=True) or request.args
         query = data.get('query', '').strip()
         language = data.get('language', 'la')
         target_text = data.get('target_text')


### PR DESCRIPTION
Most consumer chat assistants can *read a URL* (GET via a web tool) but cannot send POST JSON or hold streaming connections. So the four light endpoints now accept **GET with query-string params** as well as POST JSON, returning the same JSON:

- `GET /api/line-search?query=arma+virumque&language=la&search_type=lemma`
- `GET /api/wildcard-search?query=arma*&language=la`
- `GET /api/hapax-search?source=...&target=...&language=la`
- `GET /api/rare-bigram-search?source=...&target=...&language=la`

Each reads `request.get_json(silent=True) or request.args`, so existing POST behaviour is unchanged. (Fusion stays POST/SSE — a GET job/poll pattern is a separate follow-up.)

Backend only; py_compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)