### PR TITLE
Feature the Claude connector URL in Help + MCP-over-HTTP tests

### DIFF
--- a/client/src/components/pages/HelpPage.jsx
+++ b/client/src/components/pages/HelpPage.jsx
@@ -24,6 +24,7 @@ const MCP_CONFIG = `{
 }`;
 
 const MCP_CLAUDE_CODE = 'claude mcp add tesserae -- python /full/path/to/tesserae_mcp.py';
+const MCP_CONNECTOR_URL = 'https://tesserae.caset.buffalo.edu/api/mcp';
 
 function CopyBlock({ text, label = 'Copy' }) {
   const [copied, setCopied] = useState(false);
@@ -1405,24 +1406,30 @@ export default function HelpPage({ initialSection = null, onSectionConsumed } = 
                 the web app for the full fusion search. For full fusion from an AI, use route 3.
               </p>
 
-              <h4 className="text-lg font-semibold text-gray-900 mt-6 mb-2">3 · Claude, via a connector (MCP) <span className="text-sm font-normal text-gray-500">— most capable</span></h4>
+              <h4 className="text-lg font-semibold text-gray-900 mt-6 mb-2">3 · Claude connector <span className="text-sm font-normal text-gray-500">— easiest for Claude, most capable</span></h4>
               <p className="text-gray-700 text-sm mb-2">
-                MCP (Model Context Protocol) lets Claude call Tesserae directly. Because MCP tools aren't limited to a
-                few seconds, this route can run <strong>the full fusion search</strong>. It needs Python on your machine.
+                Add Tesserae to Claude once, and regular chat Claude can run everything — including the full fusion
+                search — with no Python and no guide-pasting. In <strong>Claude Desktop</strong> or <strong>claude.ai
+                on a computer</strong>, go to <strong>Settings → Connectors → “Add custom connector”</strong> and paste
+                this URL:
               </p>
-              <ol className="list-decimal list-inside text-gray-700 text-sm space-y-1 mb-2">
-                <li>Download the server: <a href="/tesserae-data/tesserae_mcp.py" target="_blank" rel="noopener noreferrer" className="text-blue-700 underline">tesserae_mcp.py</a></li>
-                <li>Install its dependencies:</li>
-              </ol>
-              <CopyBlock text={MCP_PIP} />
-              <p className="text-gray-700 text-sm mt-3 mb-1"><strong>Claude Desktop:</strong> Settings → Developer → Edit Config, and add (use the real path to the file):</p>
-              <CopyBlock text={MCP_CONFIG} />
-              <p className="text-gray-700 text-sm mt-3 mb-1"><strong>Claude Code:</strong> instead run:</p>
-              <CopyBlock text={MCP_CLAUDE_CODE} />
-              <p className="text-gray-700 text-sm mt-3 mb-6">
-                Restart Claude, then ask, e.g.: “Use Tesserae to compare Aeneid 1 with Lucan's Civil War 1 and show the
-                strongest parallels.”
+              <CopyBlock text={MCP_CONNECTOR_URL} />
+              <p className="text-gray-700 text-sm mt-2 mb-2">
+                Then just ask, e.g.: “Use Tesserae to compare Aeneid 1 with Lucan's Civil War 1 and show the strongest
+                parallels.” Custom connectors need a paid Claude plan and are added on desktop or web (not the mobile app).
               </p>
+              <details className="text-sm text-gray-600 mb-6">
+                <summary className="cursor-pointer text-gray-700 font-medium">Advanced: run the connector locally instead (offline; no account/connector needed)</summary>
+                <div className="mt-2 pl-1">
+                  <p className="mb-2">Prefer to run the server on your own machine? Download <a href="/tesserae-data/tesserae_mcp.py" target="_blank" rel="noopener noreferrer" className="text-blue-700 underline">tesserae_mcp.py</a> and install its dependencies:</p>
+                  <CopyBlock text={MCP_PIP} />
+                  <p className="mt-3 mb-1"><strong>Claude Desktop:</strong> Settings → Developer → Edit Config, and add (use the real path to the file):</p>
+                  <CopyBlock text={MCP_CONFIG} />
+                  <p className="mt-3 mb-1"><strong>Claude Code:</strong> instead run:</p>
+                  <CopyBlock text={MCP_CLAUDE_CODE} />
+                  <p className="mt-3">Restart Claude, then ask it to use Tesserae.</p>
+                </div>
+              </details>
 
               <div className="bg-amber-50 p-4 rounded border border-amber-200">
                 <h4 className="font-medium text-amber-900 mb-2">A note on scholarly use</h4>

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -1,0 +1,71 @@
+"""Tests for the remote MCP-over-HTTP protocol layer (backend.blueprints.mcp_http).
+
+Exercises the JSON-RPC dispatch without any network — tool bodies are monkeypatched.
+"""
+import json
+
+import backend.blueprints.mcp_http as M
+
+ALL_TOOLS = {"get_languages", "list_texts", "line_search", "string_search",
+             "rare_pairs", "rare_words", "fusion_search", "submit_feature_request"}
+
+
+def test_initialize_echoes_protocol_and_serverinfo():
+    r = M._handle({"jsonrpc": "2.0", "id": 1, "method": "initialize",
+                   "params": {"protocolVersion": "2025-06-18"}})
+    assert r["result"]["protocolVersion"] == "2025-06-18"
+    assert r["result"]["serverInfo"]["name"] == "tesserae"
+    assert "tools" in r["result"]["capabilities"]
+
+
+def test_initialize_defaults_protocol_when_missing():
+    r = M._handle({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+    assert r["result"]["protocolVersion"] == M.DEFAULT_PROTOCOL
+
+
+def test_tools_list_has_all_tools_with_schemas():
+    r = M._handle({"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+    tools = r["result"]["tools"]
+    assert ALL_TOOLS <= {t["name"] for t in tools}
+    for t in tools:
+        assert t["inputSchema"]["type"] == "object"
+        assert t["description"]
+
+
+def test_ping_returns_empty_result():
+    assert M._handle({"jsonrpc": "2.0", "id": 3, "method": "ping"})["result"] == {}
+
+
+def test_notification_returns_none():
+    assert M._handle({"jsonrpc": "2.0", "method": "notifications/initialized"}) is None
+
+
+def test_unknown_method_is_method_not_found():
+    r = M._handle({"jsonrpc": "2.0", "id": 9, "method": "does/not/exist"})
+    assert r["error"]["code"] == -32601
+
+
+def test_tools_call_unknown_tool_errors():
+    r = M._handle({"jsonrpc": "2.0", "id": 4, "method": "tools/call",
+                   "params": {"name": "nope", "arguments": {}}})
+    assert r["error"]["code"] == -32602
+
+
+def test_tools_call_dispatches_and_wraps_result(monkeypatch):
+    monkeypatch.setitem(M._TOOLS_BY_NAME, "get_languages",
+                        {**M._TOOLS_BY_NAME["get_languages"], "fn": lambda a: {"ok": True}})
+    r = M._handle({"jsonrpc": "2.0", "id": 5, "method": "tools/call",
+                   "params": {"name": "get_languages", "arguments": {}}})
+    assert r["result"]["isError"] is False
+    assert json.loads(r["result"]["content"][0]["text"]) == {"ok": True}
+
+
+def test_tools_call_error_is_wrapped_not_raised(monkeypatch):
+    def boom(a):
+        raise ValueError("kaboom")
+    monkeypatch.setitem(M._TOOLS_BY_NAME, "get_languages",
+                        {**M._TOOLS_BY_NAME["get_languages"], "fn": boom})
+    r = M._handle({"jsonrpc": "2.0", "id": 6, "method": "tools/call",
+                   "params": {"name": "get_languages", "arguments": {}}})
+    assert r["result"]["isError"] is True
+    assert "kaboom" in r["result"]["content"][0]["text"]


### PR DESCRIPTION
Now that the remote MCP server (#200) is validated against a real MCP client, surface it as the recommended Claude path.

- **Help route 3** leads with the one-step connector: add `https://tesserae.caset.buffalo.edu/api/mcp` under Settings → Connectors (no Python). The local-Python server is folded into an 'Advanced' `<details>` block.
- **tests/test_mcp_http.py**: JSON-RPC protocol coverage (initialize/tools-list/tools-call/ping/notifications/errors), no network.

Frontend + tests; build + tests verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)