### PR TITLE
Trim the AI search-page flag (drop the Claude-capabilities line)

### DIFF
--- a/client/src/components/AiAnnouncement.jsx
+++ b/client/src/components/AiAnnouncement.jsx
@@ -10,8 +10,7 @@ const AiAnnouncement = ({ onOpen }) => {
       <span className="text-lg leading-none" aria-hidden="true">✨</span>
       <span className="flex-1 text-sm text-amber-900">
         <strong>New — use your own AI with Tesserae.</strong>{' '}
-        Have ChatGPT or Claude run searches and help interpret results.{' '}
-        <span className="text-amber-800">Claude gives the fullest capabilities.</span>
+        Have ChatGPT or Claude run searches and help interpret results.
       </span>
       <span className="text-sm font-semibold text-amber-800 whitespace-nowrap">Learn how →</span>
     </button>


### PR DESCRIPTION
Removes 'Claude gives the fullest capabilities.' from the search-page flag — that detail is on the Help page. Frontend only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)