### PR TITLE
Ceremonial OAuth 2.1 for the MCP connector (unblocks Claude custom connector)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -489,6 +489,7 @@ from backend.blueprints.batch import batch_bp, init_batch_blueprint
 from backend.blueprints.api_docs import api_docs_bp
 from backend.blueprints.fusion import fusion_bp, init_fusion_blueprint
 from backend.blueprints.mcp_http import mcp_http_bp
+from backend.blueprints.mcp_oauth import mcp_oauth_bp
 from backend.blueprints.feature_request import feature_request_bp
 from backend.email_notifications import notify_text_request, notify_feedback
 
@@ -560,6 +561,7 @@ app.register_blueprint(batch_bp, url_prefix=batch_prefix)
 app.register_blueprint(api_docs_bp, url_prefix=API_PREFIX or None)
 app.register_blueprint(fusion_bp, url_prefix=API_PREFIX or None)
 app.register_blueprint(mcp_http_bp, url_prefix=API_PREFIX or None)
+app.register_blueprint(mcp_oauth_bp, url_prefix=API_PREFIX or None)
 app.register_blueprint(feature_request_bp, url_prefix=API_PREFIX or None)
 
 app_logger.info(f"Blueprints registered (API_PREFIX='{API_PREFIX}', env={DEPLOYMENT_ENV})")

--- a/backend/blueprints/mcp_http.py
+++ b/backend/blueprints/mcp_http.py
@@ -252,6 +252,19 @@ def mcp_endpoint():
         # This server never initiates messages, so it offers no SSE stream.
         return Response('Method Not Allowed', status=405)
 
+    # OAuth: the connector must present a bearer token (issued via /api/oauth).
+    # Missing/invalid -> 401 with WWW-Authenticate, which triggers the client's
+    # OAuth discovery + registration flow. (The resource behind this is the open
+    # Tesserae API, so the token is ceremonial — see backend/blueprints/mcp_oauth.)
+    from backend.blueprints.mcp_oauth import verify_access_token, PRM_URL
+    auth = request.headers.get('Authorization', '')
+    if not (auth.startswith('Bearer ') and verify_access_token(auth[7:])):
+        resp = jsonify({"jsonrpc": "2.0", "id": None,
+                        "error": {"code": -32001, "message": "Unauthorized"}})
+        resp.status_code = 401
+        resp.headers['WWW-Authenticate'] = f'Bearer resource_metadata="{PRM_URL}"'
+        return resp
+
     payload = request.get_json(silent=True)
     if payload is None:
         return jsonify(_error(None, -32700, "Parse error")), 400

--- a/backend/blueprints/mcp_oauth.py
+++ b/backend/blueprints/mcp_oauth.py
@@ -1,0 +1,195 @@
+"""
+Ceremonial OAuth 2.1 for the Tesserae MCP connector (served under /api/oauth).
+
+Claude's custom-connector flow requires OAuth. Tesserae's API is open (no
+accounts, nothing to protect), so this is a *ceremonial* OAuth server: dynamic
+client registration is auto-granted, authorization auto-approves (no login
+screen), and access tokens are opaque HMAC-signed strings the /api/mcp endpoint
+accepts. Because there is nothing sensitive behind it, the tokens don't need to
+be bulletproof — the point is only to satisfy the client's OAuth handshake.
+
+Stateless by design: authorization codes and access tokens are HMAC-signed with
+SESSION_SECRET, so any of the (multiple) worker processes can issue and verify
+them without shared storage. Everything lives under /api so it is routed to
+Flask without an Apache change.
+"""
+import os
+import json
+import time
+import hmac
+import base64
+import hashlib
+import secrets
+import logging
+
+from flask import Blueprint, request, jsonify, redirect
+
+logger = logging.getLogger(__name__)
+mcp_oauth_bp = Blueprint('mcp_oauth', __name__)
+
+PUBLIC_BASE = os.environ.get('TESSERAE_PUBLIC_BASE', 'https://tesserae.caset.buffalo.edu').rstrip('/')
+ISSUER = f"{PUBLIC_BASE}/api/oauth"
+MCP_RESOURCE = f"{PUBLIC_BASE}/api/mcp"
+PRM_URL = f"{PUBLIC_BASE}/api/mcp/.well-known/oauth-protected-resource"
+CODE_TTL = 600            # authorization code lifetime (10 min)
+TOKEN_TTL = 90 * 24 * 3600  # access token lifetime (the resource is public anyway)
+
+
+# --------------------------------------------------------------------------
+# HMAC-signed, stateless tokens/codes
+# --------------------------------------------------------------------------
+def _key():
+    return (os.environ.get('SESSION_SECRET') or 'tesserae-mcp-oauth-fallback-key').encode()
+
+
+def _b64u(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b'=').decode()
+
+
+def _b64u_decode(s: str) -> bytes:
+    return base64.urlsafe_b64decode(s + '=' * (-len(s) % 4))
+
+
+def _sign(payload: dict) -> str:
+    body = _b64u(json.dumps(payload, separators=(',', ':'), sort_keys=True).encode())
+    sig = _b64u(hmac.new(_key(), body.encode(), hashlib.sha256).digest())
+    return f"{body}.{sig}"
+
+
+def _unsign(token: str):
+    """Return the payload dict if the signature is valid and not expired, else None."""
+    try:
+        body, sig = token.split('.', 1)
+        expected = _b64u(hmac.new(_key(), body.encode(), hashlib.sha256).digest())
+        if not hmac.compare_digest(sig, expected):
+            return None
+        payload = json.loads(_b64u_decode(body))
+        if float(payload.get('exp', 0)) < time.time():
+            return None
+        return payload
+    except Exception:
+        return None
+
+
+def verify_access_token(token: str) -> bool:
+    """Public helper used by the /api/mcp endpoint."""
+    p = _unsign(token or '')
+    return bool(p and p.get('typ') == 'at')
+
+
+# --------------------------------------------------------------------------
+# Discovery metadata
+# --------------------------------------------------------------------------
+def _as_metadata():
+    return {
+        "issuer": ISSUER,
+        "authorization_endpoint": f"{ISSUER}/authorize",
+        "token_endpoint": f"{ISSUER}/token",
+        "registration_endpoint": f"{ISSUER}/register",
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code"],
+        "code_challenge_methods_supported": ["S256", "plain"],
+        "token_endpoint_auth_methods_supported": ["none"],
+        "scopes_supported": ["mcp"],
+    }
+
+
+# Authorization-server metadata — served at several candidate paths so different
+# clients' discovery rules all land on Flask (all under /api, no Apache change).
+@mcp_oauth_bp.route('/oauth/.well-known/oauth-authorization-server', methods=['GET'])
+@mcp_oauth_bp.route('/.well-known/oauth-authorization-server', methods=['GET'])
+@mcp_oauth_bp.route('/oauth/.well-known/openid-configuration', methods=['GET'])
+def authorization_server_metadata():
+    return jsonify(_as_metadata())
+
+
+# Protected-resource metadata (RFC 9728) — the 401 from /api/mcp points here.
+@mcp_oauth_bp.route('/mcp/.well-known/oauth-protected-resource', methods=['GET'])
+@mcp_oauth_bp.route('/.well-known/oauth-protected-resource', methods=['GET'])
+def protected_resource_metadata():
+    return jsonify({
+        "resource": MCP_RESOURCE,
+        "authorization_servers": [ISSUER],
+        "scopes_supported": ["mcp"],
+        "bearer_methods_supported": ["header"],
+    })
+
+
+# --------------------------------------------------------------------------
+# Dynamic client registration (RFC 7591) — auto-grant
+# --------------------------------------------------------------------------
+@mcp_oauth_bp.route('/oauth/register', methods=['POST'])
+def register():
+    data = request.get_json(silent=True) or {}
+    resp = {
+        "client_id": "tess-" + secrets.token_hex(8),
+        "client_id_issued_at": int(time.time()),
+        "token_endpoint_auth_method": "none",
+        "grant_types": ["authorization_code"],
+        "response_types": ["code"],
+        "redirect_uris": data.get("redirect_uris", []),
+    }
+    for k in ("client_name", "scope", "client_uri"):
+        if data.get(k):
+            resp[k] = data[k]
+    return jsonify(resp), 201
+
+
+# --------------------------------------------------------------------------
+# Authorization endpoint — auto-approve (no login; the resource is public)
+# --------------------------------------------------------------------------
+@mcp_oauth_bp.route('/oauth/authorize', methods=['GET'])
+def authorize():
+    redirect_uri = request.args.get('redirect_uri')
+    state = request.args.get('state')
+    code_challenge = request.args.get('code_challenge')
+    code_challenge_method = request.args.get('code_challenge_method', 'plain')
+    if not redirect_uri or not code_challenge:
+        return jsonify({"error": "invalid_request",
+                        "error_description": "redirect_uri and code_challenge are required"}), 400
+    code = _sign({
+        "typ": "code",
+        "ru": redirect_uri,
+        "cc": code_challenge,
+        "ccm": code_challenge_method,
+        "exp": int(time.time()) + CODE_TTL,
+    })
+    sep = '&' if '?' in redirect_uri else '?'
+    location = f"{redirect_uri}{sep}code={code}"
+    if state is not None:
+        location += f"&state={state}"
+    return redirect(location, code=302)
+
+
+# --------------------------------------------------------------------------
+# Token endpoint — authorization_code + PKCE
+# --------------------------------------------------------------------------
+@mcp_oauth_bp.route('/oauth/token', methods=['POST'])
+def token():
+    form = request.form if request.form else (request.get_json(silent=True) or {})
+    if form.get('grant_type') != 'authorization_code':
+        return jsonify({"error": "unsupported_grant_type"}), 400
+
+    payload = _unsign(form.get('code') or '')
+    if not payload or payload.get('typ') != 'code':
+        return jsonify({"error": "invalid_grant", "error_description": "bad or expired code"}), 400
+    if payload.get('ru') != form.get('redirect_uri'):
+        return jsonify({"error": "invalid_grant", "error_description": "redirect_uri mismatch"}), 400
+
+    # PKCE
+    verifier = form.get('code_verifier') or ''
+    if payload.get('ccm') == 'S256':
+        calc = _b64u(hashlib.sha256(verifier.encode()).digest())
+        if not hmac.compare_digest(calc, payload.get('cc', '')):
+            return jsonify({"error": "invalid_grant", "error_description": "PKCE verification failed"}), 400
+    else:  # plain
+        if not hmac.compare_digest(verifier, payload.get('cc', '')):
+            return jsonify({"error": "invalid_grant", "error_description": "PKCE verification failed"}), 400
+
+    access = _sign({"typ": "at", "scope": "mcp", "exp": int(time.time()) + TOKEN_TTL})
+    return jsonify({
+        "access_token": access,
+        "token_type": "Bearer",
+        "expires_in": TOKEN_TTL,
+        "scope": "mcp",
+    })

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -1,0 +1,84 @@
+"""End-to-end test of the ceremonial OAuth flow for the MCP connector.
+
+Register -> authorize (auto-approve, 302 with code) -> token (PKCE) -> gated
+/api/mcp (401 without a token, 200 with it). No network needed.
+"""
+import os
+import hashlib
+import urllib.parse as up
+
+os.environ.setdefault('SESSION_SECRET', 'test-oauth-secret')
+
+import pytest
+from flask import Flask
+
+from backend.blueprints.mcp_oauth import mcp_oauth_bp, _b64u, verify_access_token
+from backend.blueprints.mcp_http import mcp_http_bp
+
+
+@pytest.fixture()
+def client():
+    app = Flask(__name__)
+    app.register_blueprint(mcp_oauth_bp)
+    app.register_blueprint(mcp_http_bp)
+    return app.test_client()
+
+
+def _auth_code(client, challenge):
+    r = client.get('/oauth/authorize?response_type=code&client_id=x'
+                   '&redirect_uri=https://claude.ai/cb'
+                   f'&code_challenge={challenge}&code_challenge_method=S256&state=st1')
+    assert r.status_code == 302
+    q = up.parse_qs(up.urlparse(r.headers['Location']).query)
+    assert q['state'][0] == 'st1'
+    return q['code'][0]
+
+
+def test_dynamic_registration(client):
+    r = client.post('/oauth/register', json={'redirect_uris': ['https://claude.ai/cb']})
+    assert r.status_code == 201
+    assert r.get_json()['client_id'].startswith('tess-')
+
+
+def test_full_pkce_flow_and_gate(client):
+    verifier = 'verifier-1234567890-verifier-1234567890-verifier'
+    challenge = _b64u(hashlib.sha256(verifier.encode()).digest())
+    code = _auth_code(client, challenge)
+
+    tok = client.post('/oauth/token', data={
+        'grant_type': 'authorization_code', 'code': code,
+        'redirect_uri': 'https://claude.ai/cb', 'code_verifier': verifier})
+    assert tok.status_code == 200
+    access = tok.get_json()['access_token']
+    assert tok.get_json()['token_type'] == 'Bearer'
+    assert verify_access_token(access)
+
+    # /mcp is gated
+    no_auth = client.post('/mcp', json={'jsonrpc': '2.0', 'id': 1, 'method': 'initialize',
+                                        'params': {'protocolVersion': '2025-06-18'}})
+    assert no_auth.status_code == 401
+    assert 'resource_metadata=' in no_auth.headers.get('WWW-Authenticate', '')
+
+    ok = client.post('/mcp', json={'jsonrpc': '2.0', 'id': 1, 'method': 'initialize',
+                                   'params': {'protocolVersion': '2025-06-18'}},
+                     headers={'Authorization': 'Bearer ' + access})
+    assert ok.status_code == 200
+    assert ok.get_json()['result']['protocolVersion'] == '2025-06-18'
+
+
+def test_bad_pkce_rejected(client):
+    verifier = 'verifier-1234567890-verifier-1234567890-verifier'
+    challenge = _b64u(hashlib.sha256(verifier.encode()).digest())
+    code = _auth_code(client, challenge)
+    bad = client.post('/oauth/token', data={
+        'grant_type': 'authorization_code', 'code': code,
+        'redirect_uri': 'https://claude.ai/cb', 'code_verifier': 'WRONG'})
+    assert bad.status_code == 400
+
+
+def test_discovery_metadata(client):
+    asm = client.get('/oauth/.well-known/oauth-authorization-server').get_json()
+    assert asm['token_endpoint'].endswith('/api/oauth/token')
+    assert 'S256' in asm['code_challenge_methods_supported']
+    prm = client.get('/mcp/.well-known/oauth-protected-resource').get_json()
+    assert prm['authorization_servers'] == [asm['issuer']]


### PR DESCRIPTION
Claude's connector requires OAuth (it does dynamic client registration; our no-auth server failed to add). This adds a **self-contained, stateless OAuth 2.1 server under `/api/oauth`** — no Apache change, no accounts.

- Discovery metadata (`/api/oauth/.well-known/oauth-authorization-server`, `/api/mcp/.well-known/oauth-protected-resource`).
- Auto-granted **dynamic client registration**; **auto-approving** `/authorize` (no login — the resource is public); PKCE `/token`.
- Codes + tokens are **HMAC-signed with SESSION_SECRET** (stateless → all 3 workers agree).
- `/api/mcp` now requires a bearer and returns **401 + WWW-Authenticate** to trigger the flow.

Ceremonial by design: the resource is the open Tesserae API, so the token protects nothing — it only satisfies the client handshake. **Full flow tested end-to-end** (register → authorize → PKCE token → gated mcp; bad-PKCE rejected). `tests/test_mcp_oauth.py` + `tests/test_mcp_http.py` = 13 tests.

Verification note: NC re-adds the connector in Claude to confirm the real client completes the flow. If Claude's discovery uses a root-level `.well-known` (not under /api), a one-line Apache route may be needed (Chris).

🤖 Generated with [Claude Code](https://claude.com/claude-code)