### PR TITLE
Help: hide the AI-announcement banner on the Help page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -662,7 +662,7 @@ function App() {
           <AdminPanel />
         ) : (
           <>
-        <AiAnnouncement onOpen={openAiHelp} />
+        {pageType !== 'help' && <AiAnnouncement onOpen={openAiHelp} />}
         {pageType === 'search' && activeTab !== 'cross' && (
           <div className="space-y-6">
             <div className="bg-white rounded-lg shadow p-4 sm:p-6">


### PR DESCRIPTION
The '✨ New — use your own AI with Tesserae' banner links from the search page to the AI Help section. It's redundant (and self-referential) once the user is already on the Help page it points to. Gate it to render on every page except `pageType === 'help'`.

One-line change in `App.jsx`; frontend builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MN8Nj65nzGa6iJxiU7weLW