### PR TITLE
Fix line-search/wildcard GET crash on max_results (string vs int)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1613,8 +1613,15 @@ def line_search():
         work_filter = data.get('work', '')
         line_start = data.get('line_start')
         line_end = data.get('line_end')
-        max_results = data.get('max_results', 500)
-        
+        # Coerce to int: on a GET request query-string params arrive as strings,
+        # and max_results is compared with `len(results) >= max_results`.
+        try:
+            max_results = int(data.get('max_results', 500))
+        except (TypeError, ValueError):
+            max_results = 500
+        if max_results <= 0:
+            max_results = 500
+
         # Source exclusion - don't include the source line in results
         exclude_text_id = data.get('exclude_text_id', '')
         exclude_locus = data.get('exclude_locus', '')

--- a/backend/blueprints/search.py
+++ b/backend/blueprints/search.py
@@ -1595,7 +1595,13 @@ def wildcard_search_endpoint():
         language = data.get('language', 'la')
         target_text = data.get('target_text')
         case_sensitive = data.get('case_sensitive', False)
-        max_results = data.get('max_results', 500)
+        # Coerce to int: GET query-string params arrive as strings.
+        try:
+            max_results = int(data.get('max_results', 500))
+        except (TypeError, ValueError):
+            max_results = 500
+        if max_results <= 0:
+            max_results = 500
         era_filter = data.get('era_filter')
         
         if not query:


### PR DESCRIPTION
A GET like `/api/line-search?query=arma+virumque&language=la&max_results=40` crashed with `'>=' not supported between instances of 'int' and 'str'` — GET query params are strings and both line-search and wildcard-search compare `len(results) >= max_results`. The new AI-guide documents `max_results` on GET, exposing this. Fix: coerce to int with a safe fallback (POST/JSON was unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MN8Nj65nzGa6iJxiU7weLW