### PR TITLE
Fix distinct_loci to actually collapse whole-work/part duplicates

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1947,10 +1947,18 @@ def line_search():
             search_time = round(time_module.time() - search_start_time, 3)
             # distinct_loci collapses the corpus's whole-work vs .part.N
             # duplication: e.g. vergil.aeneid.tess and vergil.aeneid.part.1.tess
-            # both report Aeneid 1.146, so `total` double-counts. For a
-            # uniqueness check, count unique (author, work, locus) instead.
+            # both report Aeneid 1.146, so `total` double-counts. Key on the
+            # text_id with any .part.N stripped, plus the locus — the whole and
+            # its part normalize to the same id (their `work` labels differ:
+            # "Aeneid" vs "Aeneid, Book 1", so we can't key on work). Different
+            # works keep distinct ids, so they are not collapsed.
+            import re as _re_dl
+
+            def _base_tid(tid):
+                return _re_dl.sub(r'\.part\.\d+\.tess$', '.tess', tid) if tid else tid
+
             distinct_loci = len({
-                (r.get('author'), r.get('work'), r.get('locus'))
+                (_base_tid(r.get('text_id')) or r.get('author'), r.get('locus'))
                 for r in results
             })
             return jsonify({


### PR DESCRIPTION
Follow-up to #208. The whole work and its `.part.N` carry different `work` labels ("Aeneid" vs "Aeneid, Book 1"), so keying `distinct_loci` on `(author, work, locus)` never collapsed them — distinct_loci equalled total. Key on the text_id with `.part.N` stripped + locus instead. Verified on the live syrtis+aequor case: total 9 → distinct_loci 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MN8Nj65nzGa6iJxiU7weLW