### PR TITLE
Fix Custom GPT schema (300-char descriptions) + cross_language MCP tool + Help note

### DIFF
--- a/backend/blueprints/mcp_http.py
+++ b/backend/blueprints/mcp_http.py
@@ -129,6 +129,28 @@ def _t_fusion_search(a):
         time.sleep(15)
 
 
+def _t_cross_language(a):
+    """Cross-language fusion — a source in one language vs a target in another
+    (e.g. a Greek model behind a Latin poem). Synchronous POST /search; may take
+    a few minutes on first run for a large pair."""
+    body = {'source': a.get('source'), 'target': a.get('target'),
+            'source_language': a.get('source_language', 'grc'),
+            'target_language': a.get('target_language', 'la'),
+            'match_type': 'crosslingual_fusion', 'min_matches': a.get('min_matches', 2)}
+    r = requests.post(f"{API_BASE}/search", json=body, timeout=_FUSION_POLL_TIMEOUT)
+    r.raise_for_status()
+    d = r.json()
+    results = (d.get('results') or [])[:30]
+    return {'count': len(results),
+            'parallels': [{'score': round(x.get('overall_score', 0), 2),
+                           'source': {'ref': (x.get('source') or {}).get('ref'),
+                                      'text': (x.get('source') or {}).get('text')},
+                           'target': {'ref': (x.get('target') or {}).get('ref'),
+                                      'text': (x.get('target') or {}).get('text')},
+                           'matched': x.get('matched_words')}
+                          for x in results]}
+
+
 def _t_submit_feature_request(a):
     """File a feature/language/text/bug request. Requires explicit user sign-off
     first; feature/language/bug are auto-filed as a public GitHub issue (contact
@@ -178,6 +200,14 @@ TOOLS = [
      "inputSchema": {"type": "object", "properties": {"source": _STR, "target": _STR, "language": _STR},
                      "required": ["source", "target", "language"]},
      "fn": _t_fusion_search},
+    {"name": "cross_language",
+     "description": "Cross-language parallels between two texts in DIFFERENT languages (e.g. a Greek source behind a Latin poem). Give source/target ids (from list_texts) and their languages. Synchronous; may take a few minutes on a large pair.",
+     "inputSchema": {"type": "object",
+                     "properties": {"source": _STR, "target": _STR,
+                                    "source_language": _STR, "target_language": _STR,
+                                    "min_matches": {"type": "integer"}},
+                     "required": ["source", "target", "source_language", "target_language"]},
+     "fn": _t_cross_language},
     {"name": "submit_feature_request",
      "description": "File a feature / language / text / bug request. ONLY after the user explicitly confirms; warn them feature/language/bug requests become a public GitHub issue (contact kept private). type: feature|language|text|bug.",
      "inputSchema": {"type": "object",

--- a/client/src/components/pages/HelpPage.jsx
+++ b/client/src/components/pages/HelpPage.jsx
@@ -1424,8 +1424,12 @@ export default function HelpPage({ initialSection = null, onSectionConsumed } = 
                 Build a reusable “Tesserae” GPT once; then you (and anyone you share it with) just chat with it.
                 GPT-building is included in ChatGPT Plus — find it under <strong>Explore GPTs → “+ Create”</strong> (top-right).
               </p>
+              <p className="text-gray-700 text-sm mb-2">
+                <strong>Do this in a web browser</strong> at <code>chatgpt.com</code> — the ChatGPT desktop app does not
+                show the GPT-builder.
+              </p>
               <ol className="list-decimal list-inside text-gray-700 text-sm space-y-1 mb-3">
-                <li>In ChatGPT: <strong>Explore GPTs → + Create → Configure</strong>. Name it <strong>Tesserae</strong>.</li>
+                <li>In ChatGPT (web browser): <strong>Explore GPTs → + Create → Configure</strong>. Name it <strong>Tesserae</strong>.</li>
                 <li>Paste the <em>Instructions</em> below into the Instructions box.</li>
                 <li><strong>Actions → Create new action → Import from URL</strong>, paste the schema URL below, set <strong>Authentication: None</strong>.</li>
                 <li>Test it (e.g. “List Vergil's texts”), then <strong>Save</strong> — privately or as a shared link.</li>

--- a/integrations/mcp/README.md
+++ b/integrations/mcp/README.md
@@ -39,6 +39,7 @@ Lucan's Civil War 1 and show the strongest parallels."*
 | `rare_pairs` | Rare shared two-word collocations between two texts |
 | `rare_words` | Rare shared individual words between two texts |
 | `fusion_search` | Full weighted fusion comparison (can take minutes) |
+| `cross_language` | Cross-language parallels (e.g. a Greek source behind a Latin poem) |
 
 `TESSERAE_API_BASE` overrides the API base (default the production site).
 

--- a/integrations/mcp/tesserae_mcp.py
+++ b/integrations/mcp/tesserae_mcp.py
@@ -205,6 +205,36 @@ def fusion_search(source: str, target: str, language: str = "la", top: int = 20)
 
 
 @mcp.tool()
+def cross_language(source: str, target: str, source_language: str,
+                   target_language: str, top: int = 20) -> dict:
+    """Cross-language intertext parallels between two texts in DIFFERENT languages
+    (e.g. the Greek model behind a Latin poem). Use text ids from list_texts and
+    give each text's language. Synchronous; may take a few minutes on a large pair.
+
+    Args:
+        source: source text id.
+        target: target text id.
+        source_language: source language (la | grc | en | cop).
+        target_language: target language (la | grc | en | cop).
+        top: max parallels to return.
+    """
+    r = requests.post(f"{API_BASE}/search", json={
+        "source": source, "target": target,
+        "source_language": source_language, "target_language": target_language,
+        "match_type": "crosslingual_fusion", "min_matches": 2,
+    }, timeout=_FUSION_TIMEOUT)
+    r.raise_for_status()
+    d = r.json()
+    parallels = [{
+        "score": round(x.get("overall_score", 0), 2),
+        "source": {"ref": (x.get("source") or {}).get("ref"), "text": (x.get("source") or {}).get("text")},
+        "target": {"ref": (x.get("target") or {}).get("ref"), "text": (x.get("target") or {}).get("text")},
+        "matched": x.get("matched_words"),
+    } for x in (d.get("results") or [])[:top]]
+    return {"source": source, "target": target, "count": len(parallels), "parallels": parallels}
+
+
+@mcp.tool()
 def submit_feature_request(request_type: str, title: str = "", problem: str = "",
                            desired: str = "", example: str = "", context: str = "",
                            contact: str = "") -> dict:

--- a/static/downloads/tesserae-openapi.yaml
+++ b/static/downloads/tesserae-openapi.yaml
@@ -124,10 +124,10 @@ paths:
       operationId: lineSearch
       summary: Find corpus lines sharing words with a phrase (corpus-wide)
       description: >-
-        Enter a line or phrase; returns every line in the corpus that shares 2+
-        words with it. This is the corpus-wide UNIQUENESS check: run a candidate
-        parallel's shared words here to see how common the wording is elsewhere.
-        Few results ⇒ distinctive ⇒ a stronger claim of deliberate allusion.
+        Every corpus line sharing 2+ words with a phrase — the corpus-wide
+        UNIQUENESS check. Run a candidate parallel's shared words here: few
+        results = distinctive wording = a stronger allusion claim. Use
+        distinct_loci (not total) for the count.
       requestBody:
         required: true
         content:
@@ -308,14 +308,10 @@ paths:
       operationId: submitFeatureRequest
       summary: File a feature / language / text / bug request (ONLY with the user's sign-off)
       description: >-
-        Submit a request for something Tesserae doesn't yet do (a feature, a
-        language, or a text/corpus addition), or report a bug. ONLY call this
-        after the user has explicitly confirmed the exact request — never file
-        silently. WARN the user first that feature/language/bug requests are
-        auto-filed as a PUBLIC GitHub issue for the dev team; any contact email
-        is kept private and never placed in the public issue. Put the actual
-        queries/results that prompted the request in `context` so it is
-        actionable. Include at least a title or a problem description.
+        File a feature/language/text/bug request. ONLY after the user's explicit
+        sign-off — never file silently. Warn them it becomes a PUBLIC GitHub
+        issue; any contact email is kept private. Put the queries/results that
+        prompted it in `context`.
       requestBody:
         required: true
         content:
@@ -349,14 +345,9 @@ paths:
       operationId: fusionSearchPoll
       summary: Full fusion comparison of two texts, as a poll-able GET (use THIS for fusion)
       description: >-
-        The flagship two-text fusion search, exposed as a poll so any client —
-        including a Custom GPT — can use it. Returns {"status":"complete",
-        "parallels":[...]} when results are ready; otherwise starts the run and
-        returns {"status":"running"} — call this SAME operation again every
-        ~20-30s until status is "complete". A large comparison may take a few
-        minutes on first run; results are cached, so a pair already computed
-        (here or in the web app) returns instantly. Each parallel has a score,
-        the channels that fired, source/target {ref, text}, and matched words.
+        Two-text fusion as a poll. Returns status "running" until ready, then
+        "complete" with a pre-sorted parallels array — call the SAME operation
+        again every ~20-30s until complete. A cached pair returns instantly.
       parameters:
         - name: source
           in: query
@@ -403,13 +394,10 @@ paths:
       operationId: fusionSearch
       summary: "Streaming fusion (browsers/dev tools only — GPTs must use fusionSearchPoll instead)"
       description: >-
-        The flagship search: ranks the passages of two texts most likely to be
-        genuine parallels, fusing ten similarity channels. IMPORTANT: this
-        response is a Server-Sent Events stream (text/event-stream) and can run
-        for minutes — it is NOT usable as a synchronous Action and a Custom GPT
-        must not call it. Documented here for completeness. For a two-text
-        comparison from an AI assistant, use rarePairsSearch / rareWordsSearch;
-        for full fusion, use the web app at https://tesserae.caset.buffalo.edu.
+        Streaming SSE fusion for browsers/dev tools only. It is a
+        text/event-stream that runs for minutes and is NOT a usable Action — a
+        Custom GPT must NOT call it; use fusionSearchPoll instead. Documented
+        here for completeness.
       requestBody:
         required: true
         content:
@@ -437,11 +425,10 @@ paths:
       operationId: crossLanguageSearch
       summary: Cross-language fusion (e.g. Greek source behind a Latin/Coptic passage)
       description: >-
-        Find parallels ACROSS languages between two texts — e.g. the Greek model
-        behind a Latin poem. Set match_type to "crosslingual_fusion" and give
-        SEPARATE source_language and target_language (not a combined "grc-la"
-        code). Returns plain JSON (not a stream). POST only — there is no poll/GET
-        form. Use getLanguages to see supported pairs.
+        Cross-language parallels (e.g. a Greek model behind a Latin passage). Set
+        match_type=crosslingual_fusion and give SEPARATE source_language and
+        target_language (not a combined code). Plain JSON, POST only. See
+        getLanguages for supported pairs.
       requestBody:
         required: true
         content:
@@ -480,9 +467,8 @@ paths:
       summary: String/wildcard search as a poll (use for slow queries / from a GPT)
       description: >-
         Same as stringSearch but poll-able so it can't time out: the first call
-        starts the job and returns {"status":"running"}; call this SAME operation
-        again every ~25s until {"status":"complete","results":[...]}. Results are
-        capped (max_results, default 200).
+        returns status "running"; call the SAME operation again every ~25s until
+        status "complete" with results. Results are capped (max_results, 200).
       parameters:
         - { name: query, in: query, required: true, schema: { type: string } }
         - { name: language, in: query, required: true, schema: { type: string, enum: [la, grc, en, cop] } }

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -7,7 +7,8 @@ import json
 import backend.blueprints.mcp_http as M
 
 ALL_TOOLS = {"get_languages", "list_texts", "line_search", "string_search",
-             "rare_pairs", "rare_words", "fusion_search", "submit_feature_request"}
+             "rare_pairs", "rare_words", "fusion_search", "cross_language",
+             "submit_feature_request"}
 
 
 def test_initialize_echoes_protocol_and_serverinfo():

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -1,0 +1,73 @@
+"""Guards for static/downloads/tesserae-openapi.yaml — the schema an OpenAI
+Custom GPT imports as an Action.
+
+OpenAI's GPT Action builder rejects a schema (and then refuses to run the
+action) if any operation description exceeds 300 characters. It also requires
+an operationId on every operation and a single server URL. These tests keep the
+canonical schema importable so the "Tesserae" Custom GPT keeps working.
+"""
+import os
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+SCHEMA_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)),
+    "static", "downloads", "tesserae-openapi.yaml",
+)
+
+# OpenAI's Custom GPT Action importer limit; keep a small margin below it.
+OPENAI_DESC_LIMIT = 300
+
+
+@pytest.fixture(scope="module")
+def schema():
+    with open(SCHEMA_PATH, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _operations(schema):
+    for path, ops in schema["paths"].items():
+        for method, op in ops.items():
+            if method.lower() in ("get", "post", "put", "patch", "delete"):
+                yield path, method, op
+
+
+def test_schema_parses_and_has_paths(schema):
+    assert schema.get("openapi", "").startswith("3.")
+    assert schema["paths"]
+
+
+def test_single_server_url(schema):
+    servers = schema.get("servers", [])
+    assert len(servers) == 1, "Custom GPT Actions need exactly one server URL"
+    assert servers[0]["url"].startswith("https://")
+
+
+def test_every_operation_has_operationid(schema):
+    missing = [f"{m.upper()} {p}" for p, m, op in _operations(schema)
+               if not op.get("operationId")]
+    assert not missing, f"operations missing operationId: {missing}"
+
+
+def test_operation_descriptions_under_openai_limit(schema):
+    """The concrete bug that broke the Custom GPT import (2026-08-11)."""
+    offenders = {
+        op["operationId"]: len(op.get("description", "") or "")
+        for _p, _m, op in _operations(schema)
+        if len(op.get("description", "") or "") > OPENAI_DESC_LIMIT
+    }
+    assert not offenders, (
+        f"operation descriptions over OpenAI's {OPENAI_DESC_LIMIT}-char limit: "
+        f"{offenders}"
+    )
+
+
+def test_operation_summaries_under_limit(schema):
+    offenders = {
+        op["operationId"]: len(op.get("summary", "") or "")
+        for _p, _m, op in _operations(schema)
+        if len(op.get("summary", "") or "") > OPENAI_DESC_LIMIT
+    }
+    assert not offenders, f"operation summaries over {OPENAI_DESC_LIMIT}: {offenders}"


### PR DESCRIPTION
**Fixes the ChatGPT Custom GPT import** that a manual test hit: OpenAI's Action importer rejects operation descriptions over 300 chars (and then refuses to run the action). Four were over — `submitFeatureRequest` (546), `fusionSearchPoll` (558), `fusionSearch` (492), `crossLanguageSearch` (334) — plus `lineSearch` (286) trimmed for margin. All operation descriptions are now ≤254 chars; the detailed polling/usage guidance already lives in `info.description`, so nothing operational was lost. No paths/operationIds/params/schemas/behavior changed.

Server-side diagnosis: `/api/languages` returns HTTP 200 + `application/json` even to a ChatGPT-User agent, so the execution failure is almost certainly the validation errors blocking the action, not the API.

Also:
- **Guard test** `tests/test_openapi_schema.py` — fails if any operation description/summary exceeds 300 chars, or an operation lacks an operationId, or there isn't exactly one server URL.
- **cross_language MCP tool** added to both MCP servers (remote `mcp_http.py` + stdio `tesserae_mcp.py`) — the two residual items from the audit work.
- **Help note**: the Custom GPT builder must be used in a **web browser** (the desktop app doesn't expose it).

All tests pass locally (21 incl. new schema + mcp tests); frontend builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MN8Nj65nzGa6iJxiU7weLW