### PR TITLE
listTexts: server-side author filter + pagination (fix GPT ResponseTooLargeError)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -64,7 +64,8 @@ from backend.text_processor import TextProcessor
 from backend.matcher import Matcher
 from backend.scorer import Scorer
 from backend.utils import (
-    get_text_metadata, build_text_hierarchy, clean_cts_reference, resolve_text_path
+    get_text_metadata, build_text_hierarchy, clean_cts_reference, resolve_text_path,
+    apply_text_list_filters
 )
 from backend.cache import (
     get_cached_results, save_cached_results, 
@@ -902,6 +903,11 @@ def get_texts():
             texts.append(metadata)
 
     texts.sort(key=lambda x: (x['author'], x['title']))
+
+    # Optional server-side author filter / pagination / compaction (absent params
+    # → full list, so the web app is unaffected). Lets AI-agent clients request
+    # e.g. ?author=Vergil instead of pulling the whole corpus.
+    texts = apply_text_list_filters(texts, request.args)
 
     return jsonify(texts)
 

--- a/backend/blueprints/corpus.py
+++ b/backend/blueprints/corpus.py
@@ -17,6 +17,7 @@ from backend.utils import (
     normalize_author_date_key,
     load_provenance,
     resolve_text_path,
+    apply_text_list_filters,
 )
 from backend.frequency_cache import get_corpus_frequencies, recalculate_language_frequencies
 
@@ -84,7 +85,11 @@ def get_texts():
             texts.append(metadata)
     
     texts.sort(key=lambda x: (x['author'], x['title']))
-    
+
+    # Optional server-side author filter / pagination / compaction (absent params
+    # → full list, so the web app is unaffected).
+    texts = apply_text_list_filters(texts, request.args)
+
     return jsonify(texts)
 
 

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -664,6 +664,52 @@ def get_text_metadata(filepath):
     
     return result
 
+
+_TEXT_COMPACT_FIELDS = ('id', 'author', 'work', 'title', 'part', 'language')
+
+
+def apply_text_list_filters(texts, args):
+    """Optional server-side filtering / pagination / compaction for the /texts
+    list, keeping the bare-array response shape.
+
+    All params are optional, so callers that pass none (e.g. the web app, which
+    needs the full corpus list) get the unchanged full list — no regression.
+    Used mainly by AI-agent clients (ChatGPT Actions) whose response size is
+    capped: filtering by author, or a limit, keeps the payload small.
+
+    Params (from request.args): author (alias contains) case-insensitive
+    substring over author/work/title/id; offset/limit ints for pagination;
+    compact truthy → only id/author/work/title/part/language per text.
+    """
+    author = (args.get('author') or args.get('contains') or '').strip().lower()
+    if author:
+        def _hay(t):
+            return ' '.join(str(t.get(k, '') or '')
+                            for k in ('author', 'work', 'title', 'display_name', 'id')).lower()
+        texts = [t for t in texts if author in _hay(t)]
+
+    try:
+        offset = max(0, int(args.get('offset', 0)))
+    except (TypeError, ValueError):
+        offset = 0
+    if offset:
+        texts = texts[offset:]
+
+    limit_raw = args.get('limit')
+    if limit_raw not in (None, ''):
+        try:
+            n = int(limit_raw)
+            if n >= 0:
+                texts = texts[:n]
+        except (TypeError, ValueError):
+            pass
+
+    if str(args.get('compact', '')).strip().lower() in ('1', 'true', 'yes', 'on'):
+        texts = [{k: t.get(k) for k in _TEXT_COMPACT_FIELDS} for t in texts]
+
+    return texts
+
+
 def build_text_hierarchy(texts):
     """Build hierarchical structure: Author -> Work -> Parts"""
     hierarchy = {}

--- a/client/src/components/pages/HelpPage.jsx
+++ b/client/src/components/pages/HelpPage.jsx
@@ -8,6 +8,7 @@ const GPT_INSTRUCTIONS = `You are Tesserae, an assistant for finding intertextua
 
 - Follow the user's lead; they are the scholar. Surface a relevant capability briefly when useful, then defer.
 - Typical workflow: identify two texts (listTexts) -> find distinctive shared vocabulary (rarePairsSearch / rareWordsSearch) -> test how unique a shared phrase is across the whole corpus (lineSearch) -> interpret the strongest, rarest parallels, quoting both passages and their loci.
+- Listing texts: a whole language is large. To list an author's texts (e.g. "list Vergil's texts"), call listTexts with language AND author (author=Vergil) — never fetch a whole language unfiltered; use a limit if browsing.
 - For a two-text comparison use rarePairsSearch/rareWordsSearch, or fusionSearchPoll for the full fusion search: call it, and while it returns status "running", call it again every ~20-30s until status is "complete". Do NOT call the streaming fusionSearch (Actions can't stream).
 - POLL the slow ones so they don't time out: if a plain rarePairsSearch/rareWordsSearch/stringSearch is slow on large texts, use rarePairsPoll/rareWordsPoll/stringSearchPoll instead (same running->complete polling as fusionSearchPoll).
 - Cross-language (a Greek model behind a Latin passage, etc.): use crossLanguageSearch (POST only; separate source_language/target_language).

--- a/static/downloads/tesserae-openapi.yaml
+++ b/static/downloads/tesserae-openapi.yaml
@@ -36,6 +36,12 @@ info:
     number of distinct works.
 
 
+    LISTING TEXTS: a whole language is large — with listTexts ALWAYS pass an
+    `author` filter (e.g. author=Vergil) or a `limit`; never fetch a whole
+    language unfiltered. To answer "list <author>'s texts", call listTexts with
+    language + author=<author>.
+
+
     NOTE ON SLOW SEARCHES (poll, don't block): a Custom GPT Action times out
     after ~30-45s, but several searches run longer. Use the poll operations:
     call once, and while the response is {"status":"running"}, call the SAME
@@ -88,10 +94,12 @@ paths:
   /texts:
     get:
       operationId: listTexts
-      summary: List texts (with their ids) for a language
+      summary: List texts (with their ids) for a language — filter by author
       description: >-
-        Returns every text with its id (e.g. "vergil.aeneid.part.1.tess"). Use
-        these ids as the source/target for two-text searches.
+        Texts (ids like "vergil.aeneid.part.1.tess") for a language; use an id as
+        source/target. A whole language is large — narrow with `author` (e.g.
+        author=Vergil) or a `limit`, never fetch it unfiltered. For "list X's
+        texts", pass language + author=X.
       parameters:
         - name: language
           in: query
@@ -99,6 +107,26 @@ paths:
           schema:
             type: string
             enum: [la, grc, en, cop]
+        - name: author
+          in: query
+          required: false
+          description: "Case-insensitive substring over author/work/title/id (e.g. 'Vergil'). Use this to answer 'list <author>'s texts'."
+          schema: { type: string }
+        - name: limit
+          in: query
+          required: false
+          description: "Max texts to return (keep the response small)."
+          schema: { type: integer, default: 50 }
+        - name: offset
+          in: query
+          required: false
+          description: "Skip this many (pagination)."
+          schema: { type: integer, default: 0 }
+        - name: compact
+          in: query
+          required: false
+          description: "true → return only id/author/work/title/part/language (smaller response)."
+          schema: { type: boolean, default: true }
       responses:
         "200":
           description: List of texts

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -71,3 +71,16 @@ def test_operation_summaries_under_limit(schema):
         if len(op.get("summary", "") or "") > OPENAI_DESC_LIMIT
     }
     assert not offenders, f"operation summaries over {OPENAI_DESC_LIMIT}: {offenders}"
+
+
+def test_list_texts_exposes_filter_params(schema):
+    """listTexts must offer author/limit so a GPT can avoid pulling a whole
+    language (which overflows the Action response size)."""
+    op = None
+    for _p, _m, o in _operations(schema):
+        if o.get("operationId") == "listTexts":
+            op = o
+            break
+    assert op is not None, "listTexts operation missing"
+    params = {p["name"] for p in op.get("parameters", [])}
+    assert {"author", "limit"} <= params, f"listTexts params: {params}"

--- a/tests/test_texts_filter.py
+++ b/tests/test_texts_filter.py
@@ -1,0 +1,76 @@
+"""Tests for apply_text_list_filters — the server-side author/limit/offset/
+compact filtering behind GET /texts (added so an AI-agent client can request
+e.g. one author's texts instead of the whole language, which overflowed a
+ChatGPT Custom GPT Action response)."""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from backend.utils import apply_text_list_filters
+
+
+def _corpus():
+    return [
+        {"id": "vergil.aeneid.part.1.tess", "author": "Vergil", "work": "Aeneid",
+         "title": "Aeneid, Book 1", "part": "Book 1", "language": "la", "year": -19},
+        {"id": "vergil.georgics.tess", "author": "Vergil", "work": "Georgics",
+         "title": "Georgics", "part": None, "language": "la", "year": -29},
+        {"id": "ovid.metamorphoses.part.1.tess", "author": "Ovid", "work": "Metamorphoses",
+         "title": "Metamorphoses, Book 1", "part": "Book 1", "language": "la", "year": 8},
+        {"id": "lucan.bellum_civile.part.1.tess", "author": "Lucan", "work": "Bellum Civile",
+         "title": "Bellum Civile, Book 1", "part": "Book 1", "language": "la", "year": 61},
+    ]
+
+
+class Args(dict):
+    """Minimal stand-in for request.args (a plain mapping with .get)."""
+
+
+def test_no_params_returns_full_list_unchanged():
+    texts = _corpus()
+    out = apply_text_list_filters(texts, Args())
+    assert out == texts  # existing callers (web app) get the full list
+
+
+def test_author_filter_vergil():
+    out = apply_text_list_filters(_corpus(), Args(author="Vergil"))
+    assert {t["id"] for t in out} == {"vergil.aeneid.part.1.tess", "vergil.georgics.tess"}
+
+
+def test_author_filter_is_case_insensitive_and_substring():
+    out = apply_text_list_filters(_corpus(), Args(author="ovid"))
+    assert [t["author"] for t in out] == ["Ovid"]
+
+
+def test_contains_alias_matches_work_title_and_id():
+    # 'aeneid' appears in work/title/id, not the author field
+    out = apply_text_list_filters(_corpus(), Args(contains="aeneid"))
+    assert [t["id"] for t in out] == ["vergil.aeneid.part.1.tess"]
+
+
+def test_author_filter_no_match_returns_empty():
+    assert apply_text_list_filters(_corpus(), Args(author="Homer")) == []
+
+
+def test_limit_caps_results():
+    out = apply_text_list_filters(_corpus(), Args(limit="2"))
+    assert len(out) == 2
+
+
+def test_offset_and_limit_paginate():
+    page2 = apply_text_list_filters(_corpus(), Args(offset="2", limit="2"))
+    assert [t["id"] for t in page2] == ["ovid.metamorphoses.part.1.tess",
+                                        "lucan.bellum_civile.part.1.tess"]
+
+
+def test_compact_returns_only_essential_fields():
+    out = apply_text_list_filters(_corpus(), Args(author="Vergil", compact="true"))
+    for t in out:
+        assert set(t.keys()) == {"id", "author", "work", "title", "part", "language"}
+        assert "year" not in t
+
+
+def test_bad_limit_is_ignored_not_crashing():
+    out = apply_text_list_filters(_corpus(), Args(limit="not-a-number"))
+    assert len(out) == len(_corpus())


### PR DESCRIPTION
The ChatGPT Custom GPT retest passed getLanguages but `listTexts` for Latin failed with **ResponseTooLargeError** — the endpoint returns the entire language corpus (~1700 entries), too large for a Custom GPT Action.

**Fix:** add optional `author` (alias `contains`) substring filter + `limit`/`offset`/`compact` to `GET /texts`, via a shared `apply_text_list_filters` helper applied in both `/texts` handlers (app.py + corpus.py). So "list Vergil's texts" → `?language=la&author=Vergil` → ~10 entries.

**Backward compatible:** all params optional; absent → the full list, unchanged. The web app (CorpusBrowser/LineSearch fetch the full list) is unaffected — verified those callers pass no filter params.

**OpenAPI:** `listTexts` gains `author`/`limit`(default 50)/`offset`/`compact`(default true) params and instructions to always filter by author; matching GPT-instruction line added.

**Tests:** `tests/test_texts_filter.py` (author/contains/limit/offset/compact/no-params-passthrough/bad-input) + a listTexts-params assertion in `test_openapi_schema.py`. All pass locally; branch boots clean; frontend builds. Integration verified on prod post-deploy (local box has an 8080 port conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MN8Nj65nzGa6iJxiU7weLW