### PR TITLE
Help: official Tesserae GPT first + method-transparency GPT instructions + API privacy page

### DIFF
--- a/client/src/components/pages/HelpPage.jsx
+++ b/client/src/components/pages/HelpPage.jsx
@@ -4,17 +4,39 @@ import FusionFlowchart from '../search/FusionFlowchart';
 
 const AI_SCHEMA_URL = 'https://tesserae.caset.buffalo.edu/tesserae-data/tesserae-openapi.yaml';
 
-const GPT_INSTRUCTIONS = `You are Tesserae, an assistant for finding intertextual parallels (allusions, echoes, quotations) in classical literature, using the provided Tesserae actions.
+// The public share URL of the ONE official Tesserae GPT in ChatGPT.
+// Set this to the GPT's share link once it exists (Help → "Use with your AI" →
+// ChatGPT). While it is an empty string, the "Use Tesserae in ChatGPT" button is
+// hidden and a short "coming soon" note is shown instead. This is the single
+// place to configure it.
+const OFFICIAL_GPT_URL = '';
 
-- Follow the user's lead; they are the scholar. Surface a relevant capability briefly when useful, then defer.
-- Typical workflow: identify two texts (listTexts) -> find distinctive shared vocabulary (rarePairsSearch / rareWordsSearch) -> test how unique a shared phrase is across the whole corpus (lineSearch) -> interpret the strongest, rarest parallels, quoting both passages and their loci.
-- Listing texts: a whole language is large. To list an author's texts (e.g. "list Vergil's texts"), call listTexts with language AND author (author=Vergil) — never fetch a whole language unfiltered; use a limit if browsing.
-- For a two-text comparison use rarePairsSearch/rareWordsSearch, or fusionSearchPoll for the full fusion search: call it, and while it returns status "running", call it again every ~20-30s until status is "complete". Do NOT call the streaming fusionSearch (Actions can't stream).
-- POLL the slow ones so they don't time out: if a plain rarePairsSearch/rareWordsSearch/stringSearch is slow on large texts, use rarePairsPoll/rareWordsPoll/stringSearchPoll instead (same running->complete polling as fusionSearchPoll).
-- Cross-language (a Greek model behind a Latin passage, etc.): use crossLanguageSearch (POST only; separate source_language/target_language).
-- Uniqueness check with lineSearch: use the response's distinct_loci (not total) — the corpus lists some whole works and their parts separately, so total double-counts. Pass a small max_results/limit and keep only the top results.
-- PROVENANCE (important): keep Tesserae's results and your own interpretation clearly separate. Attribute matches, loci, and rarity to Tesserae (transparent, reproducible); present your analysis as AI-assisted inference the scholar should verify. Encourage citing Tesserae for the parallels and describing surrounding analysis as AI-assisted.
-- Always show the actual passages and loci; be candid about weak matches. Language codes: la (Latin), grc (Greek), en (English), cop (Coptic).`;
+// Privacy policy for the API / ChatGPT-Action integration (static, plain-HTML
+// page — the URL to paste into the GPT builder's "Privacy policy" field).
+const API_PRIVACY_URL = 'https://tesserae.caset.buffalo.edu/tesserae-data/tesserae-api-privacy.html';
+
+const GPT_INSTRUCTIONS = `You are Tesserae, an assistant for finding intertextual parallels (allusions, echoes, quotations, borrowings) in classical literature, using the provided Tesserae actions. Follow the user's lead; they are the scholar. Show actual passages and loci; be candid about weak or ambiguous matches. Language codes: la (Latin), grc (Greek), en (English), cop (Coptic).
+
+WHICH SEARCH TO USE
+- General, unqualified two-text request ("find intertextual parallels between Aeneid 4 and Georgics 4"): use the FULL FUSION search (fusionSearchPoll) — Tesserae's most comprehensive method, combining ten similarity signals (shared words, sound, meaning, rare vocabulary, syntax, and more). Tell the user you are running the comprehensive fusion search; it can take a few minutes on the first run for a pair (poll until complete). If the user wants a quick first pass, offer rarePairsSearch instead.
+- Requests emphasizing "distinctive", "rare", "unusual" shared vocabulary/phrases, or a fast exploratory scan: use rarePairsSearch (rare shared word-pairs) or rareWordsSearch (rare shared single words). These are fast and target distinctive vocabulary specifically.
+- How unique a candidate phrase is across the whole corpus: use lineSearch. Report distinct_loci (NOT total) — the corpus lists some whole works and their parts separately, so total double-counts; pass a small max_results/limit.
+- Cross-language (e.g. a Greek model behind a Latin passage): crossLanguageSearch (POST only; separate source_language/target_language).
+
+METHOD TRANSPARENCY (required)
+- Always tell the user, briefly, WHICH Tesserae method produced the reported results and what it looks for, in scholar-facing language — e.g. "Method: Tesserae rare-pairs search, which looks for unusually distinctive shared word-pairs," or "Method: Tesserae full fusion search, which combines ten similarity signals." Use plain language, not just API names.
+- Never imply that one specialized method's output represents every possible Tesserae search. When it would materially help, note that another method could give a different perspective (e.g. a full fusion pass after a fast rare-pairs scan).
+
+LISTING TEXTS
+- A whole language is large (well over a thousand entries). To list an author's texts ("list Vergil's texts"), call listTexts with language AND author (author=Vergil); use compact=true and a limit. Never fetch a whole language unfiltered just to find one author. Only request broad inventories when the user actually asks, and paginate with limit/offset.
+
+POLLING (Actions can't stream)
+- The full fusion search and the slow variants of string/rare-pairs/rare-words searches are poll-based: call the *Poll operation (fusionSearchPoll / stringSearchPoll / rareWordsPoll / rarePairsPoll); while it returns status "running", call the SAME operation again every ~20-30s until status is "complete". Do NOT call the streaming fusionSearch.
+
+PROVENANCE (keep Tesserae's results and your interpretation separate)
+- Attribute matches, loci, scores/rarity, and corpus-search facts to Tesserae — they are transparent and reproducible.
+- Label your literary interpretation as AI-assisted inference the scholar should verify.
+- Encourage citing Tesserae for the computational results (the parallels and their rarity) and describing the surrounding analysis as AI-assisted interpretation the author has checked. Do not present your inference as Tesserae's conclusion.`;
 
 const MCP_PIP = 'pip install fastmcp requests';
 
@@ -1368,12 +1390,11 @@ export default function HelpPage({ initialSection = null, onSectionConsumed } = 
             <div className="prose max-w-none">
               <h3 className="text-xl font-semibold text-gray-900 mb-4">Use Tesserae with your AI assistant</h3>
               <p className="text-gray-700 mb-4">
-                You can let your own AI assistant (such as Claude or ChatGPT) run Tesserae searches for you — comparing
-                texts, testing parallels for uniqueness across the corpus, and helping you interpret the results.
-                Tesserae does the searching, free, on its open API; your assistant orchestrates and interprets. Three
-                ways to connect are below. The one-URL <strong>Claude connector</strong> is being finalized (see the
-                note under it); for now, the <strong>paste-in guide</strong> and <strong>ChatGPT Custom GPT</strong> below
-                work today.
+                You can let an AI assistant (ChatGPT or Claude) run Tesserae searches for you — comparing texts, testing
+                parallels for uniqueness across the corpus, and helping you interpret the results. Tesserae does the
+                searching, free, on its open API; the assistant orchestrates and interprets. The simplest, no-setup route
+                is the <strong>official Tesserae GPT in ChatGPT</strong> (see ChatGPT below). You can also paste a guide
+                into any assistant, build your own GPT, or (soon) add the one-URL Claude connector.
               </p>
 
               <h4 className="text-lg font-semibold text-gray-900 mt-6 mb-2">1 · Claude connector <span className="text-sm font-normal text-amber-700">— coming soon</span></h4>
@@ -1420,29 +1441,65 @@ export default function HelpPage({ initialSection = null, onSectionConsumed } = 
                 </a>
               </p>
 
-              <h4 className="text-lg font-semibold text-gray-900 mt-6 mb-2">3 · ChatGPT Custom GPT <span className="text-sm font-normal text-gray-500">— included in ChatGPT Plus</span></h4>
-              <p className="text-gray-700 text-sm mb-2">
-                Build a reusable “Tesserae” GPT once; then you (and anyone you share it with) just chat with it.
-                GPT-building is included in ChatGPT Plus — find it under <strong>Explore GPTs → “+ Create”</strong> (top-right).
+              <h4 className="text-lg font-semibold text-gray-900 mt-6 mb-2">3 · ChatGPT <span className="text-sm font-normal text-gray-500">— the official Tesserae GPT</span></h4>
+
+              <p className="text-gray-700 text-sm mb-2 font-medium">Use the official Tesserae GPT — no setup.</p>
+              {OFFICIAL_GPT_URL ? (
+                <p className="mb-3">
+                  <a href={OFFICIAL_GPT_URL} target="_blank" rel="noopener noreferrer"
+                    className="inline-block bg-emerald-700 hover:bg-emerald-800 text-white text-sm font-medium px-4 py-2 rounded no-underline">
+                    Use Tesserae in ChatGPT →
+                  </a>
+                </p>
+              ) : (
+                <div className="border border-amber-300 bg-amber-50 rounded p-3 text-sm text-amber-900 mb-3">
+                  <strong>Coming soon.</strong> The official Tesserae GPT link will appear here shortly. In the meantime,
+                  you can build your own below, or use the paste-in guide above.
+                </div>
+              )}
+              <p className="text-gray-700 text-sm mb-1">Open it and ask it to find, compare, or investigate intertextual parallels using Tesserae. It works like an ordinary ChatGPT conversation:</p>
+              <ul className="list-disc list-inside text-gray-700 text-sm space-y-1 mb-2">
+                <li>You chat with it normally; it calls the Tesserae API for you when a search is needed.</li>
+                <li>The first time it runs a search, ChatGPT may ask permission to contact <code>tesserae.caset.buffalo.edu</code> — that's the normal Custom GPT permission prompt; choose <em>Allow</em> (or <em>Always allow</em>).</li>
+                <li>You don't configure any schemas or Actions — that's already built into the official GPT.</li>
+              </ul>
+              <p className="text-gray-500 text-xs mb-4">
+                Using a GPT works on the ChatGPT web and app clients. (<em>Creating or editing</em> a GPT is web-browser-only — see below.)
               </p>
-              <p className="text-gray-700 text-sm mb-2">
-                <strong>Do this in a web browser</strong> at <code>chatgpt.com</code> — the ChatGPT desktop app does not
-                show the GPT-builder.
-              </p>
-              <ol className="list-decimal list-inside text-gray-700 text-sm space-y-1 mb-3">
-                <li>In ChatGPT (web browser): <strong>Explore GPTs → + Create → Configure</strong>. Name it <strong>Tesserae</strong>.</li>
-                <li>Paste the <em>Instructions</em> below into the Instructions box.</li>
-                <li><strong>Actions → Create new action → Import from URL</strong>, paste the schema URL below, set <strong>Authentication: None</strong>.</li>
-                <li>Test it (e.g. “List Vergil's texts”), then <strong>Save</strong> — privately or as a shared link.</li>
-              </ol>
-              <p className="text-gray-700 text-sm font-medium mb-1">Schema URL (for the Action):</p>
-              <CopyBlock text={AI_SCHEMA_URL} />
-              <p className="text-gray-700 text-sm font-medium mb-1 mt-3">Instructions (paste into the GPT):</p>
-              <CopyBlock text={GPT_INSTRUCTIONS} />
-              <p className="text-gray-500 text-xs mt-2 mb-6">
-                The GPT can run everything, including the full fusion search — it polls the fusion job until the
-                results are ready.
-              </p>
+
+              <details className="text-sm text-gray-700 mb-4">
+                <summary className="cursor-pointer text-gray-800 font-medium">Advanced: build your own Tesserae GPT</summary>
+                <div className="mt-2 pl-1 space-y-2">
+                  <p className="text-gray-600">
+                    Optional — for researchers who want their own copy or custom instructions, developers, or institutions
+                    that want their own configuration. Most scholars can just use the official GPT above.
+                  </p>
+                  <p>
+                    <strong>Building or editing a GPT must be done in ChatGPT in a web browser</strong> at <code>chatgpt.com</code>
+                    — the desktop app doesn't clearly expose the GPT-builder. (Once built, you and anyone you share it with
+                    just chat with it normally, on any client, and you can edit it later.)
+                  </p>
+                  <ol className="list-decimal list-inside space-y-1">
+                    <li>In ChatGPT (web browser): <strong>Explore GPTs → + Create → Configure</strong>. Name it <strong>Tesserae</strong>. (The <em>Preview</em> pane beside Configure is just for testing your draft.)</li>
+                    <li>Paste the <em>Instructions</em> below into the Instructions box.</li>
+                    <li><strong>Actions → Create new action → Import from URL</strong>, paste the schema URL below, set <strong>Authentication: None</strong>.</li>
+                    <li>If you plan to share the GPT by link or publish it, add a <strong>Privacy policy</strong> URL (see the link below).</li>
+                    <li>Test it (e.g. “List Vergil's texts”), then <strong>Create</strong> — privately or as a shared link.</li>
+                  </ol>
+                  <p className="font-medium mb-1">Schema URL (for the Action):</p>
+                  <CopyBlock text={AI_SCHEMA_URL} />
+                  <p className="font-medium mb-1 mt-2">Instructions (paste into the GPT):</p>
+                  <CopyBlock text={GPT_INSTRUCTIONS} />
+                  <p className="text-gray-600 text-xs mt-1">
+                    Privacy policy URL (for the builder's “Privacy policy” field, required to share/publish):{' '}
+                    <a href={API_PRIVACY_URL} target="_blank" rel="noopener noreferrer" className="text-blue-700 underline break-all">{API_PRIVACY_URL}</a>
+                  </p>
+                  <p className="text-gray-500 text-xs">
+                    A custom GPT can run everything, including the full fusion search — it polls the fusion job until the
+                    results are ready. Building GPTs is included in ChatGPT Plus.
+                  </p>
+                </div>
+              </details>
 
               <div className="bg-amber-50 p-4 rounded border border-amber-200">
                 <h4 className="font-medium text-amber-900 mb-2">A note on scholarly use</h4>

--- a/static/downloads/tesserae-api-privacy.html
+++ b/static/downloads/tesserae-api-privacy.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Tesserae — API &amp; ChatGPT Integration Privacy Policy</title>
+<meta name="description" content="What happens to your data when Tesserae's open search API is used, including through a ChatGPT Custom GPT.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,600;0,700;1,400&family=Noto+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --paper:#faf8f4; --panel:#ffffff; --ink:#2a2521; --muted:#6f6558;
+    --line:#ece3d6; --line-strong:#dccdb6;
+    --amber-600:#d97706; --amber-900:#78350f; --amber-tint:#fffbeb;
+    --accent:#b91c1c; --accent-deep:#991b1b; --accent-hover:#ea580c; --orange-100:#ffedd5;
+    --serif:'Crimson Pro',Georgia,'Times New Roman',serif;
+    --sans:'Noto Sans','Inter',system-ui,-apple-system,sans-serif;
+    --mono:ui-monospace,'SF Mono',Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box}
+  html{-webkit-text-size-adjust:100%}
+  body{margin:0;background:var(--paper);color:var(--ink);font-family:var(--sans);font-size:17px;line-height:1.62;-webkit-font-smoothing:antialiased;}
+  .wrap{max-width:760px;margin:0 auto;padding:0 24px 96px;}
+  .site-header{background:linear-gradient(to right,var(--accent-deep),var(--accent) 55%,var(--accent-hover));box-shadow:0 2px 12px rgba(0,0,0,.15)}
+  .site-header-inner{max-width:760px;margin:0 auto;padding:16px 24px;display:flex;align-items:center;gap:16px}
+  .site-logo{width:56px;height:56px;border-radius:9999px;flex:none;object-fit:cover;box-shadow:0 0 0 2px rgba(255,255,255,.25)}
+  .site-title{font-family:var(--serif);font-weight:600;font-size:32px;letter-spacing:.06em;color:#fff;line-height:1}
+  .site-subtitle{color:var(--orange-100);font-size:13px;margin-top:3px}
+  header.hero{padding:40px 0 4px}
+  .eyebrow{font-weight:700;font-size:12px;letter-spacing:.16em;text-transform:uppercase;color:var(--accent)}
+  h1{font-family:var(--serif);font-weight:700;font-size:clamp(28px,5vw,40px);line-height:1.1;margin:.3em 0 .3em;letter-spacing:-.01em}
+  h2{font-family:var(--serif);font-weight:700;font-size:23px;margin:40px 0 6px;padding-top:14px;border-top:1px solid var(--line)}
+  p{margin:.7em 0}
+  a{color:var(--accent);text-decoration:underline;text-underline-offset:2px}
+  a:hover{color:var(--accent-hover)}
+  strong{font-weight:700;color:#37302a}
+  ul{margin:.6em 0;padding-left:1.3em}
+  li{margin:.34em 0}
+  code{font-family:var(--mono);font-size:.86em;background:#f0e7d8;color:#5a3a10;padding:.08em .38em;border-radius:5px;border:1px solid #e6d8c0}
+  .lede{font-size:18px;color:#4a4239}
+  .callout{background:var(--amber-tint);border:1px solid #f0dcbb;border-left:4px solid var(--amber-600);border-radius:10px;padding:14px 18px;margin:20px 0}
+  .callout p:first-child{margin-top:0}.callout p:last-child{margin-bottom:0}
+  footer{margin-top:56px;padding-top:18px;border-top:1px solid var(--line);color:var(--muted);font-size:14px}
+  @media (max-width:560px){body{font-size:16px}.wrap{padding:0 18px 72px}}
+</style>
+</head>
+<body>
+<header class="site-header">
+  <div class="site-header-inner">
+    <img src="/tesserae-icon.jpg" alt="Tesserae" class="site-logo">
+    <div>
+      <div class="site-title">TESSERAE</div>
+      <div class="site-subtitle">Intertextual and Literary Discovery</div>
+    </div>
+  </div>
+</header>
+<div class="wrap">
+  <header class="hero">
+    <div class="eyebrow">Privacy</div>
+    <h1>Tesserae API &amp; ChatGPT Integration — Privacy Policy</h1>
+    <p class="lede">This page explains, in plain terms, what happens to your data when Tesserae's open search API is used — including when you use it through a ChatGPT “Custom GPT” or another AI assistant. It describes the API only; the interactive website has its own <a href="https://tesserae.caset.buffalo.edu/privacy">privacy policy</a>.</p>
+  </header>
+
+  <h2>The service</h2>
+  <p>Tesserae is a free, non-commercial scholarly tool operated by the Tesserae project at the University at Buffalo. Its search API is <strong>open and keyless</strong>: there is no account, sign-in, or API key. When an AI assistant such as a ChatGPT Custom GPT searches Tesserae for you, it sends ordinary web requests to <code>tesserae.caset.buffalo.edu</code>. ChatGPT may ask your permission the first time before contacting the Tesserae server — that is the normal Custom-GPT permission prompt.</p>
+
+  <h2>What is sent to Tesserae</h2>
+  <p>Each search request carries only the <strong>search parameters</strong> — for example the two text ids being compared, a search word or phrase, a language code, or an author filter. Because it is keyless, no ChatGPT account details, no API key, and no login identifier are sent. As with any request over the internet, the request also carries the <strong>network IP address</strong> it comes from.</p>
+  <p>The Tesserae corpus is public classical literature, and searches are ordinary scholarly queries. <strong>Please do not put personal, confidential, or sensitive information into your searches</strong> — search terms are logged (see below).</p>
+
+  <h2>What Tesserae records</h2>
+  <p>For most search requests, the server writes a log entry containing:</p>
+  <ul>
+    <li>the search type and its parameters (the text ids compared, or the query word/phrase, and the language);</li>
+    <li>the number of results and a timestamp;</li>
+    <li>the requesting <strong>IP address</strong>, and an <strong>approximate city and country</strong> derived from it.</li>
+  </ul>
+  <p>These entries are used to understand load and usage of the shared research server. Some requests are <em>not</em> logged — listing texts or languages, and the “polling” search endpoints, record no such entry.</p>
+
+  <h2>Approximate location lookup</h2>
+  <p>To turn an IP address into an approximate city and country, Tesserae sends the IP to a third-party geolocation service (<code>ipinfo.io</code>, with <code>ip-api.com</code> as a fallback). This yields only a coarse, city-level location — never a precise position — and is subject to those services' own terms.</p>
+
+  <h2>Retention</h2>
+  <p>Search-log entries (including the IP address and approximate location) are stored on the Tesserae server and are <strong>currently retained indefinitely</strong>; there is no automatic deletion. Aggregated, de-identified usage may inform research on the Tesserae methods; no personally identifying information is included in research publications. You may contact the project (below) to ask about, or request deletion of, log data associated with your IP address.</p>
+
+  <h2>Cookies, tracking, and caching</h2>
+  <p>The API sets <strong>no cookies</strong> for anonymous search requests and uses <strong>no advertising or analytics trackers</strong>. To make repeated searches fast, Tesserae caches search <em>results</em> keyed by the search parameters; that results cache stores <strong>no IP address, location, or other personal data</strong>.</p>
+
+  <h2>Feature or bug requests</h2>
+  <p>If you ask the assistant to file a feature, text, or bug request on your behalf — and only after you explicitly confirm it — the request text is posted as a <strong>public GitHub issue</strong> for the development team. Any contact email you choose to include is kept <strong>private</strong>: it is stored for the team and is <strong>not</strong> placed in the public issue.</p>
+
+  <h2>Other data flows</h2>
+  <p>Tesserae does not sell or share your data. The only outbound data flows are those described above: the geolocation lookup, and (for a confirmed feature/bug request) filing a GitHub issue with the contact removed. Dictionary look-ups on the website may consult Wiktionary/Perseus, but those are part of the interactive site, not the search API.</p>
+
+  <h2>Contact</h2>
+  <p>For privacy questions or a data-deletion request, contact the Tesserae project team through the feedback form in the website's Help &amp; Support section, or the contact listed on <a href="https://tesserae.caset.buffalo.edu/about">the About page</a>.</p>
+
+  <footer>
+    Tesserae · University at Buffalo. This policy covers the open Tesserae search API and its use through AI assistants such as ChatGPT.<br>
+    Last updated: August 2026.
+  </footer>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Follows the successful ChatGPT end-to-end test. Strategic change: most scholars should use **one official Tesserae GPT**, not build their own.

**Help page (ChatGPT section reorganized):**
- Leads with **Use the official Tesserae GPT** — a 'Use Tesserae in ChatGPT' button gated on a single `OFFICIAL_GPT_URL` constant (hidden with a 'coming soon' note until the share URL exists).
- Build-your-own moved to an optional **Advanced** `<details>` (kept for researchers/developers/reproducibility).
- Adds: the external-Action permission note (ChatGPT may ask to contact tesserae.caset.buffalo.edu), the browser-only-for-*building* note, and the preview/create lifecycle clarification.

**GPT instructions revised** for method transparency (always state which Tesserae method ran + what it looks for, in scholar-facing language) and search selection (general two-text → full fusion via `fusionSearchPoll`; distinctive/rare → rarePairs/rareWords; `lineSearch` for uniqueness via `distinct_loci`; cross-language; polling preserved). Provenance rules kept.

**New API privacy policy** — static `static/downloads/tesserae-api-privacy.html`, to be hosted at `/tesserae-data/tesserae-api-privacy.html` (the URL for the GPT builder's Privacy-policy field). Grounded in an audit of actual server behavior (keyless API; most search endpoints log params + query + client IP + approx city/country via ipinfo.io/ip-api.com to `search_logs`, no auto-deletion; no cookies/analytics; feature-request contact kept out of the public GitHub issue).

No schema/API code changed; existing schema + texts-filter tests still pass; frontend builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MN8Nj65nzGa6iJxiU7weLW