### PR TITLE
Fusion Custom-GPT UX: check-back workflow + honest poll progress

### DIFF
--- a/backend/blueprints/fusion.py
+++ b/backend/blueprints/fusion.py
@@ -382,6 +382,59 @@ def _fusion_marker(job_key, kind):
     return os.path.join(CACHE_DIR, f"fusion_{kind}_{job_key}.marker")
 
 
+def _fusion_status_path(job_key):
+    return os.path.join(CACHE_DIR, f"fusion_status_{job_key}.json")
+
+
+def _write_fusion_status(job_key, event_type, evt_data):
+    """Persist the latest real progress from the fusion generator so the GET
+    poll can report honest stage info. Only channel/intermediate events carry
+    usable data. We record the phase (line -> window), the number of similarity
+    signals (channels) completed vs. this phase's total, the current signal, and
+    the running candidate count. We deliberately do NOT compute a time-percentage
+    or ETA: channel costs are very unequal and the total step count isn't known
+    until the run finishes, so any smooth percent would be fabricated."""
+    status = None
+    if event_type in ('channel_start', 'channel_done'):
+        step = evt_data.get('step') or 0
+        status = {
+            'phase': evt_data.get('phase'),
+            'current_signal': evt_data.get('channel'),
+            'signals_done': max(0, step - (1 if event_type == 'channel_start' else 0)),
+            'signals_total': evt_data.get('total'),
+        }
+    elif event_type == 'intermediate':
+        status = {
+            'phase': evt_data.get('phase'),
+            'signals_done': evt_data.get('channels_done'),
+            'signals_total': evt_data.get('channels_total'),
+            'candidates_so_far': evt_data.get('total_results'),
+        }
+    if status is None:
+        return
+    status = {k: v for k, v in status.items() if v is not None}
+    try:
+        with open(_fusion_status_path(job_key), 'w', encoding='utf-8') as f:
+            json.dump(status, f)
+    except IOError:
+        pass
+
+
+def _read_fusion_status(job_key):
+    try:
+        with open(_fusion_status_path(job_key), 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except (IOError, ValueError):
+        return None
+
+
+def _clear_fusion_status(job_key):
+    try:
+        os.remove(_fusion_status_path(job_key))
+    except OSError:
+        pass
+
+
 def _run_fusion_job(source_id, target_id, language, max_results, job_key):
     """Compute a default-settings fusion search and cache it (runs in a thread)."""
     slot = None
@@ -407,6 +460,8 @@ def _run_fusion_job(source_id, target_id, language, max_results, job_key):
             user_settings={'use_meter': False}, freq_basis='corpus',
             channel_weights={}, enabled_channels=None,
         ):
+            # Record honest coarse progress for the GET poll (see _write_fusion_status).
+            _write_fusion_status(job_key, event_type, evt_data)
             if event_type == 'complete':
                 final_results = evt_data['results']
         save_cached_results(
@@ -427,6 +482,7 @@ def _run_fusion_job(source_id, target_id, language, max_results, job_key):
             os.remove(_fusion_marker(job_key, 'running'))
         except OSError:
             pass
+        _clear_fusion_status(job_key)
 
 
 @fusion_bp.route('/fusion-search', methods=['GET'])
@@ -469,6 +525,7 @@ def fusion_search_get():
                 os.remove(_fusion_marker(job_key, kind))
             except OSError:
                 pass
+        _clear_fusion_status(job_key)
         top = cached_results[:100]
         return jsonify({
             'status': 'complete', 'cached': True,
@@ -492,11 +549,27 @@ def fusion_search_get():
         return jsonify({'status': 'error', 'error': err,
                         'message': 'The fusion run failed; call again to retry.'}), 500
 
-    # Already running (fresh marker)?
+    # Already running (fresh marker)? Reuse the in-flight job — do NOT start a
+    # second one — and report honest coarse progress.
     run_marker = _fusion_marker(job_key, 'running')
     if os.path.exists(run_marker) and (time.time() - os.path.getmtime(run_marker)) < _FUSION_MARKER_TTL:
-        return jsonify({'status': 'running', 'source': source_id, 'target': target_id,
-                        'message': 'Fusion is computing. Poll this URL again in ~20-30s.'})
+        elapsed = int(time.time() - os.path.getmtime(run_marker))
+        resp = {
+            'status': 'running', 'source': source_id, 'target': target_id,
+            'elapsed_seconds': elapsed,
+            'message': 'Still computing on the Tesserae server (a full fusion search '
+                       'typically takes ~2-3 minutes). It will finish and cache even if you '
+                       'stop checking; call this same URL again in a minute or two.',
+        }
+        st = _read_fusion_status(job_key)
+        if st:
+            # Honest coarse progress. signals_done/signals_total = similarity
+            # signals (channels) computed this phase — NOT a time percentage
+            # (later signals are much slower). stage = 'line' then 'window'.
+            for k in ('phase', 'current_signal', 'signals_done', 'signals_total', 'candidates_so_far'):
+                if st.get(k) is not None:
+                    resp['stage' if k == 'phase' else k] = st[k]
+        return jsonify(resp)
 
     # Start a new background run.
     try:

--- a/client/src/components/pages/HelpPage.jsx
+++ b/client/src/components/pages/HelpPage.jsx
@@ -18,25 +18,35 @@ const API_PRIVACY_URL = 'https://tesserae.caset.buffalo.edu/tesserae-data/tesser
 const GPT_INSTRUCTIONS = `You are Tesserae, an assistant for finding intertextual parallels (allusions, echoes, quotations, borrowings) in classical literature, using the provided Tesserae actions. Follow the user's lead; they are the scholar. Show actual passages and loci; be candid about weak or ambiguous matches. Language codes: la (Latin), grc (Greek), en (English), cop (Coptic).
 
 WHICH SEARCH TO USE
-- General, unqualified two-text request ("find intertextual parallels between Aeneid 4 and Georgics 4"): use the FULL FUSION search (fusionSearchPoll) — Tesserae's most comprehensive method, combining ten similarity signals (shared words, sound, meaning, rare vocabulary, syntax, and more). Tell the user you are running the comprehensive fusion search; it can take a few minutes on the first run for a pair (poll until complete). If the user wants a quick first pass, offer rarePairsSearch instead.
-- Requests emphasizing "distinctive", "rare", "unusual" shared vocabulary/phrases, or a fast exploratory scan: use rarePairsSearch (rare shared word-pairs) or rareWordsSearch (rare shared single words). These are fast and target distinctive vocabulary specifically.
-- How unique a candidate phrase is across the whole corpus: use lineSearch. Report distinct_loci (NOT total) — the corpus lists some whole works and their parts separately, so total double-counts; pass a small max_results/limit.
+- General, unqualified two-text request ("find intertextual parallels between Aeneid 4 and Georgics 4"): use the FULL FUSION search (fusionSearchPoll) — Tesserae's comprehensive comparison, combining ten similarity signals (shared words, sound, meaning, rare vocabulary, syntax, and more). See FULL FUSION below for how to handle its timing.
+- Requests emphasizing "distinctive", "rare", "unusual" shared vocabulary/phrases, or a fast exploratory scan: use rarePairsSearch (rare shared word-pairs) or rareWordsSearch (rare shared single words) — fast, and targeted at distinctive vocabulary.
+- How widespread or distinctive a candidate expression is across the whole corpus: use lineSearch. Report distinct_loci (NOT total) — the corpus lists some whole works and their parts separately, so total double-counts; pass a small max_results/limit. Use this to test the strongest candidates from a rare-pairs/rare-words scan.
+- A specific word, form, or pattern the scholar names: stringSearch (wildcards, AND/OR/NOT, "phrases").
 - Cross-language (e.g. a Greek model behind a Latin passage): crossLanguageSearch (POST only; separate source_language/target_language).
 
-METHOD TRANSPARENCY (required)
-- Always tell the user, briefly, WHICH Tesserae method produced the reported results and what it looks for, in scholar-facing language — e.g. "Method: Tesserae rare-pairs search, which looks for unusually distinctive shared word-pairs," or "Method: Tesserae full fusion search, which combines ten similarity signals." Use plain language, not just API names.
-- Never imply that one specialized method's output represents every possible Tesserae search. When it would materially help, note that another method could give a different perspective (e.g. a full fusion pass after a fast rare-pairs scan).
+METHOD TRANSPARENCY (required, scholar-facing)
+- Always briefly identify which Tesserae method produced the reported results and what it looks for — e.g. "Method: Tesserae full fusion search, the general comparison combining Tesserae's matching signals," or "Method: Tesserae rare-pairs search, which looks for unusually distinctive shared word-pairs." If you use one method to find candidates and another to test them, say so: "I used rare-pairs search to find candidates, then corpus-wide line search to test how distinctive the strongest ones are." Lead with plain language, not API names, and never present a specialized result as if it were every possible Tesserae analysis.
+
+FULL FUSION — timing and the check-back workflow (important)
+- Full fusion normally takes about 2-3 minutes. That is NORMAL — never call it slow or say something is wrong just because it is still running.
+- It runs on the Tesserae server and keeps running after you reply; the finished result is cached. You are NOT monitoring it in the background between messages.
+- When you start fusion and it returns status "running", tell the user once, e.g.: "Method: Tesserae full fusion search — this normally takes about 2-3 minutes and keeps running on the Tesserae server even after I reply. Ask me to 'check the fusion search' in a couple of minutes and I'll retrieve the results." Then end your turn. Do NOT say you will keep checking, and do NOT imply continuous background monitoring.
+- When the user later asks to check ("has the fusion search finished?" / "check the fusion search"), call fusionSearchPoll AGAIN with the SAME source/target/language. This reuses the existing job and cache — it does NOT start a new search. If status is "complete", retrieve and discuss the cached results. If still "running", report it (see PROGRESS) and invite another check shortly. If status is "error", report the failure and offer an alternative (e.g. a fast rarePairsSearch).
+- Poll conservatively: make at most ONE status check per user request. Do not loop many calls; if you ever poll within a single turn, stop the instant status is "complete".
+
+PROGRESS (honest only)
+- The running response may include elapsed_seconds, stage ("line" then "window"), current_signal, signals_done/signals_total, and candidates_so_far. Report these plainly if present, e.g. "Still running (~90s in): line-comparison phase, 7 of 10 signals computed, 40 candidates so far." signals_done/signals_total is the number of similarity signals computed, NOT a time percentage — later signals are much slower — so do not present it as "% complete" or invent an ETA.
 
 LISTING TEXTS
 - A whole language is large (well over a thousand entries). To list an author's texts ("list Vergil's texts"), call listTexts with language AND author (author=Vergil); use compact=true and a limit. Never fetch a whole language unfiltered just to find one author. Only request broad inventories when the user actually asks, and paginate with limit/offset.
 
-POLLING (Actions can't stream)
-- The full fusion search and the slow variants of string/rare-pairs/rare-words searches are poll-based: call the *Poll operation (fusionSearchPoll / stringSearchPoll / rareWordsPoll / rarePairsPoll); while it returns status "running", call the SAME operation again every ~20-30s until status is "complete". Do NOT call the streaming fusionSearch.
+POLLING GENERALLY (Actions can't stream)
+- The full fusion search and the slow variants of string/rare-pairs/rare-words searches are poll-based: call the *Poll operation (fusionSearchPoll / stringSearchPoll / rareWordsPoll / rarePairsPoll); while it returns "running", call the SAME operation again until "complete". Do NOT call the streaming fusionSearch.
 
 PROVENANCE (keep Tesserae's results and your interpretation separate)
-- Attribute matches, loci, scores/rarity, and corpus-search facts to Tesserae — they are transparent and reproducible.
-- Label your literary interpretation as AI-assisted inference the scholar should verify.
-- Encourage citing Tesserae for the computational results (the parallels and their rarity) and describing the surrounding analysis as AI-assisted interpretation the author has checked. Do not present your inference as Tesserae's conclusion.`;
+- Attribute the matches, loci, scores/rarity, and corpus-search facts to Tesserae — they are transparent and reproducible.
+- Present your literary reading as AI-assisted inference the scholar should verify; never attribute an interpretive judgment to Tesserae itself.
+- Encourage citing Tesserae for the computational results (the parallels and their rarity) and describing the surrounding analysis as AI-assisted interpretation the author has checked.`;
 
 const MCP_PIP = 'pip install fastmcp requests';
 
@@ -1466,6 +1476,14 @@ export default function HelpPage({ initialSection = null, onSectionConsumed } = 
               <p className="text-gray-500 text-xs mb-4">
                 Using a GPT works on the ChatGPT web and app clients. (<em>Creating or editing</em> a GPT is web-browser-only — see below.)
               </p>
+
+              <div className="border border-gray-200 bg-gray-50 rounded p-3 text-sm text-gray-700 mb-4">
+                <strong>A note on the full fusion search.</strong> Tesserae's most comprehensive comparison (“full fusion”)
+                usually takes about <strong>2–3 minutes</strong>. It keeps running on the Tesserae server even after ChatGPT
+                has replied, and the finished result is cached. If it's still running, just ask the GPT to
+                “<em>check the fusion search</em>” after a couple of minutes — it will retrieve and discuss the completed
+                results. The faster “rare-pairs” and “rare-words” searches return in seconds.
+              </div>
 
               <details className="text-sm text-gray-700 mb-4">
                 <summary className="cursor-pointer text-gray-800 font-medium">Advanced: build your own Tesserae GPT</summary>

--- a/static/downloads/tesserae-openapi.yaml
+++ b/static/downloads/tesserae-openapi.yaml
@@ -373,9 +373,10 @@ paths:
       operationId: fusionSearchPoll
       summary: Full fusion comparison of two texts, as a poll-able GET (use THIS for fusion)
       description: >-
-        Two-text fusion as a poll. Returns status "running" until ready, then
-        "complete" with a pre-sorted parallels array — call the SAME operation
-        again every ~20-30s until complete. A cached pair returns instantly.
+        Two-text fusion as a poll. Returns "running" until ready, then "complete"
+        with a pre-sorted parallels array. Full fusion typically takes ~2-3 min;
+        call the SAME operation again every ~30s until complete — it reuses the
+        job, never a duplicate. Cached pairs return instantly.
       parameters:
         - name: source
           in: query
@@ -400,6 +401,13 @@ paths:
                 type: object
                 properties:
                   status: { type: string, enum: [running, complete, error] }
+                  message: { type: string, description: "Human-readable status note (e.g. the ~2-3 min guidance while running)." }
+                  elapsed_seconds: { type: integer, description: "Seconds since the job started (running only)." }
+                  stage: { type: string, description: "Coarse phase while running: 'line' then 'window'." }
+                  current_signal: { type: string, description: "The similarity signal (channel) being computed now." }
+                  signals_done: { type: integer, description: "Similarity signals computed so far THIS phase. NOTE: NOT a time-percentage — later signals (sound, semantic, edit-distance) are much slower, so this rises fast then slows." }
+                  signals_total: { type: integer, description: "Total similarity signals in the current phase." }
+                  candidates_so_far: { type: integer, description: "Candidate parallels found so far (running only)." }
                   count: { type: integer }
                   parallels:
                     type: array

--- a/tests/test_fusion_status.py
+++ b/tests/test_fusion_status.py
@@ -1,0 +1,83 @@
+"""Tests for the fusion GET-poll honest-progress capture (backend.blueprints.fusion):
+the background job records real coarse progress (phase, signals done/total,
+candidates) to a status file that the poll reports. No fabricated time-percent.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import backend.blueprints.fusion as F
+
+
+def _use_tmp_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr(F, "CACHE_DIR", str(tmp_path))
+
+
+def test_channel_start_records_prior_signals_done(tmp_path, monkeypatch):
+    _use_tmp_cache(tmp_path, monkeypatch)
+    F._write_fusion_status("job1", "channel_start",
+                           {"channel": "sound", "step": 7, "total": 10, "phase": "line"})
+    st = F._read_fusion_status("job1")
+    # a channel just STARTING means step-1 have finished
+    assert st["signals_done"] == 6
+    assert st["signals_total"] == 10
+    assert st["current_signal"] == "sound"
+    assert st["phase"] == "line"
+
+
+def test_channel_done_counts_the_finished_signal(tmp_path, monkeypatch):
+    _use_tmp_cache(tmp_path, monkeypatch)
+    F._write_fusion_status("job2", "channel_done",
+                           {"channel": "lemma", "step": 3, "total": 10, "phase": "line", "skipped": False})
+    st = F._read_fusion_status("job2")
+    assert st["signals_done"] == 3
+    assert st["signals_total"] == 10
+
+
+def test_intermediate_records_candidates(tmp_path, monkeypatch):
+    _use_tmp_cache(tmp_path, monkeypatch)
+    F._write_fusion_status("job3", "intermediate",
+                           {"channels_done": 5, "channels_total": 10,
+                            "total_results": 42, "phase": "window", "results": []})
+    st = F._read_fusion_status("job3")
+    assert st["signals_done"] == 5
+    assert st["signals_total"] == 10
+    assert st["candidates_so_far"] == 42
+    assert st["phase"] == "window"
+
+
+def test_non_progress_events_write_nothing(tmp_path, monkeypatch):
+    _use_tmp_cache(tmp_path, monkeypatch)
+    for ev in ("complete", "heartbeat", "error"):
+        F._write_fusion_status("job4", ev, {"results": [1, 2]})
+    assert F._read_fusion_status("job4") is None
+
+
+def test_status_omits_missing_fields(tmp_path, monkeypatch):
+    _use_tmp_cache(tmp_path, monkeypatch)
+    # channel event with no phase/total present
+    F._write_fusion_status("job5", "channel_start", {"channel": "sound", "step": 2})
+    st = F._read_fusion_status("job5")
+    assert "phase" not in st          # None values dropped
+    assert "signals_total" not in st
+    assert st["signals_done"] == 1
+    assert st["current_signal"] == "sound"
+
+
+def test_clear_removes_status(tmp_path, monkeypatch):
+    _use_tmp_cache(tmp_path, monkeypatch)
+    F._write_fusion_status("job6", "channel_done",
+                           {"channel": "lemma", "step": 1, "total": 10, "phase": "line"})
+    assert F._read_fusion_status("job6") is not None
+    F._clear_fusion_status("job6")
+    assert F._read_fusion_status("job6") is None
+    # clearing a non-existent status is a no-op (no exception)
+    F._clear_fusion_status("job6")
+
+
+def test_status_path_is_under_cache_dir(tmp_path, monkeypatch):
+    _use_tmp_cache(tmp_path, monkeypatch)
+    p = F._fusion_status_path("abc")
+    assert p.startswith(str(tmp_path))
+    assert p.endswith("fusion_status_abc.json")


### PR DESCRIPTION
From continued ChatGPT QA. Full fusion normally takes ~2-3 min but keeps running server-side and caches its result — so the remaining issue is **status/progress UX, not execution**.

**Poll progress (honest only):** `GET /api/fusion-search` now returns, while running, `elapsed_seconds` (from the job-start marker) plus real coarse fields the background job records to a status file as it consumes the fusion generator — `stage` (line→window), `current_signal`, `signals_done`/`signals_total`, `candidates_so_far`. **No fabricated time-percent or ETA** (channel costs are grossly unequal and total steps aren't known until done — agent-verified against the code). Status file cleared on complete/error. Existing running/complete/error and no-duplicate-start behavior unchanged; the follow-up poll reuses the same job/cache.

**OpenAPI:** `fusionSearchPoll` documents the new fields (with the 'not a time percentage' caveat) + ~2-3 min / reuses-the-job wording (≤273 chars; the ≤300 guard caught a 303 during dev).

**GPT instructions (Help page)** rewritten coherently: full-fusion check-back workflow ('ask me to check the fusion search', reuse the same call, never a duplicate, don't imply background monitoring, poll conservatively), honest progress, candidate→test transparency, selection, listTexts, provenance. Plain Help-page note added about the ~2-3 min fusion timing.

**No per-job live-progress URL:** the site pre-fills from URL params but does not auto-run, so such a link would land on an idle form — left out (explained).

Tests: `tests/test_fusion_status.py`; schema + texts-filter guards still pass; frontend builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MN8Nj65nzGa6iJxiU7weLW