### PR TITLE
docs: document DEPLOYMENT_ENV/SESSION_SECRET requirement for local dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,14 @@
 # Database connection URL (PostgreSQL)
 DATABASE_URL=postgresql://tesseraev6:password@localhost:5432/tesseraev6
 
-# Secret key for Flask session signing
+# Secret key for Flask session signing.
+# REQUIRED to start the app unless DEPLOYMENT_ENV=dev (see below).
 SESSION_SECRET=some-secret-key-here
+
+# Deployment environment. Set to "dev" for local development: this lets the app
+# start with an auto-generated ephemeral session key when SESSION_SECRET is unset.
+# Any non-dev value requires SESSION_SECRET to be set, or the app refuses to start.
+DEPLOYMENT_ENV=dev
 
 # Geolocation simulation mode for local development (true/1 to enable)
 # When active, local/private client IPs are simulated as Buffalo, NY instead of returning empty values

--- a/README.md
+++ b/README.md
@@ -52,10 +52,16 @@ cd tesserae-v6
 # 2. Install Python dependencies
 pip install -r requirements.txt
 
-# 3. Download search index files (~5.3 GB from tesserae.caset.buffalo.edu)
+# 3. Set up environment variables (copy the template, then edit as needed)
+cp .env.example .env
+# NOTE: for local development, .env must set DEPLOYMENT_ENV=dev (or provide a
+# SESSION_SECRET). Otherwise the app will refuse to start — this is a safeguard
+# against running a real deployment without a proper session secret.
+
+# 4. Download search index files (~5.3 GB from tesserae.caset.buffalo.edu)
 python scripts/download_data.py
 
-# 4. Start the application
+# 5. Start the application
 python main.py
 ```
 


### PR DESCRIPTION
Closes #216. Follow-up to #156, which made `SESSION_SECRET` mandatory at startup unless `DEPLOYMENT_ENV=dev`.

The README's "For Developers" steps didn't mention `.env` at all, so a fresh clone following them would now fail to boot. This adds:
- an environment-setup step to the README (`cp .env.example .env`, with a note that local dev needs `DEPLOYMENT_ENV=dev` or a `SESSION_SECRET`);
- a `DEPLOYMENT_ENV=dev` line (with explanation) to `.env.example`, so copying the template gives a working local config.

Docs/config only — no code or runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MN8Nj65nzGa6iJxiU7weLW