### PR TITLE
Fix duplicate line and window matches in fusion results

### DIFF
--- a/backend/blueprints/fusion.py
+++ b/backend/blueprints/fusion.py
@@ -142,6 +142,10 @@ def search_fusion_stream():
             skip_cache = data.get('skip_cache', False)
             cache_settings = {
                 'match_type': 'fusion',
+                # The merged result shape changed when single-line window
+                # duplicates began being removed.  Keep old cached fusion
+                # results from being served after deployment.
+                'result_version': 2,
                 'mode': mode,
                 'max_results': max_results,
                 'language': language,

--- a/backend/cache.py
+++ b/backend/cache.py
@@ -49,6 +49,10 @@ def get_cache_key(source_id, target_id, language, settings):
         key_parts['channel_weights'] = settings['channel_weights']
     if settings.get('enabled_channels'):
         key_parts['enabled_channels'] = settings['enabled_channels']
+    # Only version caches that explicitly opt in.  Leaving this out preserves
+    # cache keys for unrelated search implementations.
+    if 'result_version' in settings:
+        key_parts['result_version'] = settings['result_version']
     key_str = json.dumps(key_parts, sort_keys=True)
     return hashlib.md5(key_str.encode()).hexdigest()  # nosec B324
 

--- a/backend/fusion.py
+++ b/backend/fusion.py
@@ -2517,10 +2517,9 @@ def _which_line_has_matches(positions, boundary):
 def _trim_to_line(side, line_num):
     """Trim a window unit dict to show only one line of text.
 
-    Keeps the original range ref so merge_line_and_window treats it as a
-    window (with one novel line pair), preserving recall for pairs found
-    only via window channels. Trims text, tokens, and highlights to the
-    relevant line. Removes line_token_counts so frontend renders as single line.
+    Keeps the original range ref for contextual display and for window-only
+    matches. Trims text, tokens, and highlights to the relevant line. Removes
+    line_token_counts so frontend renders as single line.
     """
     counts = side.get('line_token_counts', [])
     if not counts or len(counts) < 2:
@@ -2542,15 +2541,46 @@ def _trim_to_line(side, line_num):
     side['tokens'] = new_tokens
     side['text'] = new_text
     side['highlight_indices'] = sorted(new_highlights)
-    # Keep the original range ref — merge_line_and_window needs it to
-    # correctly identify this as a window result with a novel line pair.
-    # Removing window metadata so frontend renders as single line.
+    # Keep the original range ref for contextual display; merge uses a private
+    # matched-line key when it needs exact single-line deduplication.
+    # Remove window metadata so frontend renders this as a single line.
     side.pop('line_token_counts', None)
     side.pop('line_refs', None)
     return side
 
 
-def penalize_single_line_windows(window_results):
+def _single_line_match_key(src, tgt, src_positions, tgt_positions,
+                           src_boundary, tgt_boundary):
+    """Return the actual line-pair for a non-enjambed window match.
+
+    The display ref of a trimmed window remains its two-line range so that a
+    window-only result retains its surrounding context.  This helper records
+    the one source×target line pair on which its matched words actually fall,
+    allowing the merge step to distinguish a duplicate line result from a
+    genuinely novel window result.
+
+    Return ``None`` when the positions or original per-line refs are not
+    available.  In that case the merge keeps its existing conservative
+    range-based behavior rather than risking a recall loss.
+    """
+    if not src_positions or not tgt_positions:
+        return None
+
+    src_refs = src.get('line_refs', [])
+    tgt_refs = tgt.get('line_refs', [])
+    if len(src_refs) < 2 or len(tgt_refs) < 2:
+        return None
+
+    src_line_ref = src_refs[_which_line_has_matches(src_positions, src_boundary)]
+    tgt_line_ref = tgt_refs[_which_line_has_matches(tgt_positions, tgt_boundary)]
+    src_book, src_line = parse_ref(src_line_ref)
+    tgt_book, tgt_line = parse_ref(tgt_line_ref)
+    if src_book is None or tgt_book is None:
+        return None
+    return src_book, src_line, tgt_book, tgt_line
+
+
+def penalize_single_line_windows(window_results, annotate_for_merge=False):
     """Filter and penalize window results based on enjambment quality.
 
     Three outcomes per result:
@@ -2561,6 +2591,11 @@ def penalize_single_line_windows(window_results):
        Preserves recall without visual clutter.
     3. No positions determinable → fall back to highlight_indices for the
        span check (handles scorer fallback to lemma forms).
+
+    When ``annotate_for_merge`` is true, non-enjambed windows with determinable
+    matched-word positions receive a private line-pair key.  The merged-search
+    path consumes that key before returning results; window-only mode leaves no
+    internal metadata on its public results.
     """
     out = []
     for r in window_results:
@@ -2617,6 +2652,12 @@ def penalize_single_line_windows(window_results):
             out.append(r)
         else:
             # Not a genuine enjambment — trim to single-line display
+            if annotate_for_merge:
+                match_key = _single_line_match_key(
+                    src, tgt, src_positions, tgt_positions,
+                    src_boundary, tgt_boundary)
+                if match_key is not None:
+                    r['_single_line_match_key'] = match_key
             r['source'] = _trim_to_line(
                 dict(src), _which_line_has_matches(src_positions, src_boundary))
             r['target'] = _trim_to_line(
@@ -2729,6 +2770,15 @@ def merge_line_and_window(line_results, window_results):
 
     kept_windows = []
     for r in window_results:
+        # A trimmed single-line window can have the same visible text as a
+        # line result while retaining a two-line display ref.  Compare the
+        # actual matched line-pair captured before trimming, not the whole
+        # window span, so empty neighboring line-pairs cannot make a duplicate
+        # look novel.  Always consume this private merge-only annotation.
+        single_line_match_key = r.pop('_single_line_match_key', None)
+        if single_line_match_key in line_by_ref:
+            continue
+
         rs = r.get("source", {}).get("ref", "")
         rt = r.get("target", {}).get("ref", "")
         rs_b, rs_start, rs_end = parse_range_ref(rs)
@@ -3116,7 +3166,8 @@ def iter_fusion_search(source_units, target_units, matcher, scorer,
                                  language=language,
                                  freq_basis=freq_basis,
                                  source_id=source_id, target_id=target_id)
-    window_fused = penalize_single_line_windows(window_fused)
+    window_fused = penalize_single_line_windows(
+        window_fused, annotate_for_merge=(mode != 'window'))
 
     if mode == 'window':
         final = window_fused[:max_results] if max_results > 0 else window_fused
@@ -3279,7 +3330,8 @@ def run_fusion_search(source_units, target_units, matcher, scorer,
     window_fused = fuse_results(window_channel_results, language=language,
                                  freq_basis=freq_basis,
                                  source_id=source_id, target_id=target_id)
-    window_fused = penalize_single_line_windows(window_fused)
+    window_fused = penalize_single_line_windows(
+        window_fused, annotate_for_merge=(mode != 'window'))
 
     if mode == 'window':
         return window_fused[:max_results] if max_results > 0 else window_fused

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,21 @@
+"""Tests for result-cache key isolation."""
+
+from backend.cache import get_cache_key
+
+
+def test_result_version_only_changes_opted_in_cache_keys():
+    settings = {
+        'match_type': 'fusion',
+        'source_unit_type': 'line',
+        'target_unit_type': 'line',
+        'freq_basis': 'corpus',
+    }
+
+    unversioned = get_cache_key('source.tess', 'target.tess', 'la', settings)
+    unchanged_copy = get_cache_key(
+        'source.tess', 'target.tess', 'la', dict(settings))
+    versioned = get_cache_key(
+        'source.tess', 'target.tess', 'la', {**settings, 'result_version': 2})
+
+    assert unchanged_copy == unversioned
+    assert versioned != unversioned

--- a/tests/test_fusion_scoring.py
+++ b/tests/test_fusion_scoring.py
@@ -248,6 +248,119 @@ class TestTrimToLine:
         assert '-' in result['ref']
 
 
+class TestMergeLineAndWindow:
+    """Regression tests for trimmed single-line window deduplication."""
+
+    @staticmethod
+    def _line_result(source_ref="stat. theb. 12.597",
+                     target_ref="verg. aen. 1.20", score=10.0):
+        return {
+            'source': {
+                'ref': source_ref,
+                'text': 'arma',
+                'tokens': ['arma'],
+                'highlight_indices': [0],
+            },
+            'target': {
+                'ref': target_ref,
+                'text': 'arma',
+                'tokens': ['arma'],
+                'highlight_indices': [0],
+            },
+            'matched_words': [{
+                'lemma': 'arma', 'source_word': 'arma', 'target_word': 'arma',
+            }],
+            'fused_score': score,
+        }
+
+    @staticmethod
+    def _window_result(source_tokens, target_tokens, matched_words, score=9.0):
+        return {
+            'source': {
+                'ref': 'stat. theb. 12.597-stat. theb. 12.598',
+                'text': ' '.join(source_tokens[:1]) + '\n' + ' '.join(source_tokens[1:]),
+                'tokens': source_tokens,
+                'highlight_indices': [],
+                'line_token_counts': [1, 1],
+                'line_refs': ['stat. theb. 12.597', 'stat. theb. 12.598'],
+            },
+            'target': {
+                'ref': 'verg. aen. 1.20-verg. aen. 1.21',
+                'text': ' '.join(target_tokens[:1]) + '\n' + ' '.join(target_tokens[1:]),
+                'tokens': target_tokens,
+                'highlight_indices': [],
+                'line_token_counts': [1, 1],
+                'line_refs': ['verg. aen. 1.20', 'verg. aen. 1.21'],
+            },
+            'matched_words': matched_words,
+            'fused_score': score,
+        }
+
+    def test_drops_trimmed_window_when_line_pair_already_exists(self):
+        from backend.fusion import merge_line_and_window, penalize_single_line_windows
+
+        line = self._line_result()
+        window = self._window_result(
+            ['arma', 'cano'], ['arma', 'cano'],
+            [{'lemma': 'arma', 'source_word': 'arma', 'target_word': 'arma'}],
+        )
+        trimmed = penalize_single_line_windows([window], annotate_for_merge=True)
+        merged = merge_line_and_window([line], trimmed)
+
+        assert len(merged) == 1
+        assert merged[0]['source']['ref'] == 'stat. theb. 12.597'
+        assert '_single_line_match_key' not in merged[0]
+
+    def test_keeps_trimmed_window_for_window_only_line_pair(self):
+        from backend.fusion import merge_line_and_window, penalize_single_line_windows
+
+        line = self._line_result()
+        window = self._window_result(
+            ['cano', 'arma'], ['cano', 'arma'],
+            [{'lemma': 'arma', 'source_word': 'arma', 'target_word': 'arma'}],
+        )
+        trimmed = penalize_single_line_windows([window], annotate_for_merge=True)
+        merged = merge_line_and_window([line], trimmed)
+
+        assert len(merged) == 2
+        kept_window = next(r for r in merged if '-' in r['source']['ref'])
+        assert kept_window['source']['text'] == 'arma'
+        assert kept_window['target']['text'] == 'arma'
+        assert '_single_line_match_key' not in kept_window
+
+    def test_keeps_genuine_enjambment_window(self):
+        from backend.fusion import merge_line_and_window, penalize_single_line_windows
+
+        line = self._line_result()
+        window = self._window_result(
+            ['arma', 'cano'], ['arma', 'cano'],
+            [
+                {'lemma': 'arma', 'source_word': 'arma', 'target_word': 'arma'},
+                {'lemma': 'cano', 'source_word': 'cano', 'target_word': 'cano'},
+            ],
+            score=9.0,
+        )
+        filtered = penalize_single_line_windows([window], annotate_for_merge=True)
+        merged = merge_line_and_window([line], filtered)
+
+        assert len(merged) == 2
+        kept_window = next(r for r in merged if '-' in r['source']['ref'])
+        assert '\n' in kept_window['source']['text']
+        assert 'line_token_counts' in kept_window['source']
+        assert '_single_line_match_key' not in kept_window
+
+    def test_window_only_mode_does_not_add_merge_metadata(self):
+        from backend.fusion import penalize_single_line_windows
+
+        window = self._window_result(
+            ['arma', 'cano'], ['arma', 'cano'],
+            [{'lemma': 'arma', 'source_word': 'arma', 'target_word': 'arma'}],
+        )
+        result = penalize_single_line_windows([window])
+
+        assert '_single_line_match_key' not in result[0]
+
+
 # ── Syntax Scoring ─────────────────────────────────────────────────────────
 
 class TestComputeSyntaxScore:
@@ -744,9 +857,6 @@ class TestTextPairFrequencyBaseline:
         assert freqs.get("rabbit", 0) >= 1
         # Non-existent words should return 0 frequency
         assert freqs.get("nonexistentword12345", 0) == 0
-
-
-
 # ── Clean matched-lemma extraction (corpus-search input) ───────────────────
 
 class TestCleanMatchedLemmas:


### PR DESCRIPTION
## Summary
- track the actual matched line pair before trimming non-enjambed window results
- drop trimmed window copies when the same line result already exists
- preserve genuinely novel window-only matches and genuine enjambments
- keep merge-only metadata out of public results and cache payloads

## Verification
- `pytest -q tests/test_fusion_scoring.py tests/test_cache.py` — 75 passed, 1 skipped
- `pytest -q` — passed
- `git diff --check origin/main...HEAD` — clean
- merge-tree check against current `origin/main` — clean