### PR TITLE
MCP: fusion_search fits client timeout; mark Claude connector live

### DIFF
--- a/backend/blueprints/mcp_http.py
+++ b/backend/blueprints/mcp_http.py
@@ -27,7 +27,12 @@ API_BASE = os.environ.get('TESSERAE_API_BASE', 'https://tesserae.caset.buffalo.e
 SERVER_INFO = {"name": "tesserae", "version": "1.0.0"}
 DEFAULT_PROTOCOL = "2025-06-18"
 _TIMEOUT = 90
-_FUSION_POLL_TIMEOUT = 330   # seconds to block-and-poll a fresh fusion run
+_FUSION_POLL_TIMEOUT = 330   # HTTP request timeout for a fresh fusion run
+# Remote MCP clients (e.g. Claude's connector) cap each tool call at ~60s, so a
+# fusion tool call must return well under that. We block-and-poll only for this
+# budget, then hand back a "still running" status telling the assistant to call
+# again — the job keeps computing server-side and its result is cached.
+_FUSION_MCP_BUDGET = 45      # seconds to block before returning status=running
 
 
 # --------------------------------------------------------------------------
@@ -112,10 +117,12 @@ def _t_rare_words(a):
 
 
 def _t_fusion_search(a):
-    """Full fusion — blocks and polls the GET fusion endpoint until complete
-    (MCP tools have no short timeout, so a few-minute wait is fine)."""
+    """Full fusion — starts the server-side job and block-polls the GET fusion
+    endpoint for a short budget, then returns status=running so the (time-limited)
+    MCP client can call again to pick up the cached result once it completes."""
     params = {'source': a.get('source'), 'target': a.get('target'), 'language': a.get('language', 'la')}
-    deadline = time.time() + _FUSION_POLL_TIMEOUT
+    poll_interval = 8
+    deadline = time.time() + _FUSION_MCP_BUDGET
     while True:
         d = _get('/fusion-search', params)
         status = d.get('status')
@@ -123,10 +130,14 @@ def _t_fusion_search(a):
             return {'status': 'complete', 'count': d.get('count'), 'parallels': d.get('parallels')}
         if status == 'error':
             return {'status': 'error', 'error': d.get('error')}
-        if time.time() > deadline:
+        # Return before starting a sleep that would push us past the budget, so
+        # the tool call never trips the client's ~60s per-call timeout.
+        if time.time() + poll_interval >= deadline:
             return {'status': 'running',
-                    'note': 'Still computing after a few minutes; call fusion_search again shortly to get the cached result.'}
-        time.sleep(15)
+                    'note': ('Fusion is still computing server-side (first runs take a few minutes) '
+                             'and its result will be cached. Call fusion_search again with the same '
+                             'arguments in ~30-60 seconds to retrieve it.')}
+        time.sleep(poll_interval)
 
 
 def _t_cross_language(a):

--- a/client/src/components/pages/HelpPage.jsx
+++ b/client/src/components/pages/HelpPage.jsx
@@ -1404,16 +1404,10 @@ export default function HelpPage({ initialSection = null, onSectionConsumed } = 
                 parallels for uniqueness across the corpus, and helping you interpret the results. Tesserae does the
                 searching, free, on its open API; the assistant orchestrates and interprets. The simplest, no-setup route
                 is the <strong>official Tesserae GPT in ChatGPT</strong> (see ChatGPT below). You can also paste a guide
-                into any assistant, build your own GPT, or (soon) add the one-URL Claude connector.
+                into any assistant, build your own GPT, or add the one-URL Claude connector.
               </p>
 
-              <h4 className="text-lg font-semibold text-gray-900 mt-6 mb-2">1 · Claude connector <span className="text-sm font-normal text-amber-700">— coming soon</span></h4>
-              <div className="border border-amber-300 bg-amber-50 rounded p-3 text-sm text-amber-900 mb-3">
-                <strong>Under development.</strong> The one-URL Claude connector is built but not live yet — it's waiting
-                on a small server-configuration change, so Claude can add it but can't yet complete a search through it.
-                In the meantime, the <strong>paste-in guide</strong> and <strong>ChatGPT Custom GPT</strong> below both
-                work today.
-              </div>
+              <h4 className="text-lg font-semibold text-gray-900 mt-6 mb-2">1 · Claude connector <span className="text-sm font-normal text-gray-500">— one URL, full fusion search built in</span></h4>
               <p className="text-gray-700 text-sm mb-2">
                 Add Tesserae to Claude once, and regular chat Claude can run everything — including the full fusion
                 search — with no Python and no guide-pasting. In <strong>Claude Desktop</strong> or <strong>claude.ai


### PR DESCRIPTION
## What
The Claude custom connector authenticates and runs searches end-to-end now that `WSGIPassAuthorization On` is set on the vhost. Two fixes to finish the rollout:

1. **`fusion_search` timed out on first run.** The tool block-polled the fusion endpoint for up to 330s, but remote MCP clients (Claude's connector) cap each tool call at ~60s — so a first-run fusion (which takes a few minutes) always tripped the client timeout. Now it polls for a **45s budget**, then returns `status: running` with a clear 'call again in ~30-60s' note. The job keeps computing server-side and its result is cached, so the assistant's next call returns it fast. Each tool call stays comfortably under 60s.

2. **Help page still said 'coming soon / under development.'** Dropped that language (the amber warning box + '(soon)' + 'coming soon' badge) now that the connector works.

## Verification
- `py_compile` clean.
- End-to-end against the live URL: OAuth handshake (discovery → authorize → token) works; no token → 401, valid token → 200; `tools/list` returns 9 tools; `line_search` returns results.
- Will verify the new fusion_search behavior live after deploy (first call returns `running` <60s; retry returns cached `complete`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)