### PR TITLE
Fusion poll route: ref-prefix / min_score filters + limit (single-poem questions)

### DIFF
--- a/backend/blueprints/fusion.py
+++ b/backend/blueprints/fusion.py
@@ -586,15 +586,50 @@ def fusion_search_get():
             except OSError:
                 pass
         _clear_fusion_status(job_key)
+
+        # Optional server-side filters applied over the FULL result set (all
+        # `max_results`) BEFORE the display cap, so single-poem / high-precision
+        # questions aren't biased by the top-N slice. Ref filters match anywhere
+        # in the (author-abbreviated) ref, so a trailing dot pins a number
+        # exactly, e.g. source_ref_prefix="ecl. 1." matches "verg. ecl. 1.x"
+        # but not "verg. ecl. 10.x".
+        def _norm(s):
+            return ' '.join((s or '').split()).lower()
+
+        results = cached_results
+        src_pfx = _norm(request.args.get('source_ref_prefix', ''))
+        tgt_pfx = _norm(request.args.get('target_ref_prefix', ''))
+        try:
+            min_score = float(request.args.get('min_score')) if request.args.get('min_score') else None
+        except (TypeError, ValueError):
+            min_score = None
+        if src_pfx:
+            results = [r for r in results if src_pfx in _norm((r.get('source') or {}).get('ref'))]
+        if tgt_pfx:
+            results = [r for r in results if tgt_pfx in _norm((r.get('target') or {}).get('ref'))]
+        if min_score is not None:
+            results = [r for r in results if (r.get('fused_score') or 0) >= min_score]
+
         try:
             offset = max(0, int(request.args.get('offset', 0)))
         except (TypeError, ValueError):
             offset = 0
-        page = cached_results[offset:offset + 100]
+        try:
+            limit = int(request.args.get('limit', 100))
+        except (TypeError, ValueError):
+            limit = 100
+        limit = max(1, min(limit, 500))
+        page = results[offset:offset + limit]
+        applied = {k: v for k, v in (('source_ref_prefix', src_pfx),
+                                     ('target_ref_prefix', tgt_pfx),
+                                     ('min_score', min_score)) if v}
         return jsonify({
             'status': 'complete', 'cached': True,
             'source': source_id, 'target': target_id, 'language': language,
-            'count': len(cached_results), 'offset': offset, 'showing': len(page),
+            'count': len(results),            # matches after filters
+            'total': len(cached_results),     # total computed before filters
+            'offset': offset, 'limit': limit, 'showing': len(page),
+            'filters': applied,
             'parallels': [_slim_fusion_result(r) for r in page],
         })
 

--- a/backend/blueprints/mcp_http.py
+++ b/backend/blueprints/mcp_http.py
@@ -24,16 +24,11 @@ logger = logging.getLogger(__name__)
 mcp_http_bp = Blueprint('mcp_http', __name__)
 
 API_BASE = os.environ.get('TESSERAE_API_BASE', 'https://tesserae.caset.buffalo.edu/api').rstrip('/')
-SERVER_INFO = {
-    "name": "tesserae",
-    "title": "Tesserae",
-    "version": "1.0.0",
-    "websiteUrl": "https://tesserae.caset.buffalo.edu",
-    # MCP-native icon hint (clients that render serverInfo icons show the Tesserae
-    # mosaic mark instead of falling back to the parent domain's favicon).
-    "icons": [{"src": "https://tesserae.caset.buffalo.edu/tesserae-icon.jpg",
-               "mimeType": "image/jpeg", "sizes": "90x89"}],
-}
+# Keep this minimal and spec-exact for the negotiated protocolVersion. Adding
+# non-standard Implementation fields (title/websiteUrl/icons from a later draft)
+# caused Claude's connector to reject the initialize response ("Tesserae returned
+# an error when connecting"), 2026-08-14. The Tesserae icon comes from /favicon.ico.
+SERVER_INFO = {"name": "tesserae", "version": "1.0.0"}
 DEFAULT_PROTOCOL = "2025-06-18"
 _TIMEOUT = 90
 _FUSION_POLL_TIMEOUT = 330   # HTTP request timeout for a fresh fusion run

--- a/backend/blueprints/mcp_http.py
+++ b/backend/blueprints/mcp_http.py
@@ -162,6 +162,22 @@ def _fusion_params(a):
             p['offset'] = off
     except (TypeError, ValueError):
         pass
+    try:
+        lim = int(a.get('limit') or 0)
+        if lim > 0:
+            p['limit'] = lim
+    except (TypeError, ValueError):
+        pass
+    # Server-side filters applied over the full result set before the display cap.
+    for k in ('source_ref_prefix', 'target_ref_prefix'):
+        v = (a.get(k) or '').strip()
+        if v:
+            p[k] = v
+    try:
+        if a.get('min_score') is not None and str(a.get('min_score')).strip() != '':
+            p['min_score'] = float(a.get('min_score'))
+    except (TypeError, ValueError):
+        pass
     return p
 
 
@@ -300,10 +316,20 @@ TOOLS = [
                      "required": ["source", "target", "language"]},
      "fn": _t_compare_texts},
     {"name": "fusion_search",
-     "description": "Ranked fusion parallels for two texts across ten similarity signals — the passages most likely to be genuine parallels, strongest first. Returns a 100-result page; pass offset (100, 200, ...) to page deeper, since real parallels also appear below the top. Use compare_texts for a first look; use this to go deeper on the ranking. First run takes a few minutes (cached after); returns status 'running' until ready — call again shortly.",
+     "description": ("Ranked fusion parallels for two texts across ten similarity signals — the passages "
+                     "most likely to be genuine parallels, strongest first. Returns a page (default 100, "
+                     "up to 500 via limit); pass offset (100, 200, ...) to page deeper, since real "
+                     "parallels also appear below the top. To answer a question about ONE section/poem, "
+                     "use source_ref_prefix / target_ref_prefix — these filter the FULL result set (not "
+                     "just the page) by ref, so nothing is lost to the cap; a trailing dot pins a number "
+                     "(e.g. source_ref_prefix=\"ecl. 1.\" matches book/poem 1 but not 10). min_score drops "
+                     "weak matches. Response gives count (after filters) and total (before). First run "
+                     "takes a few minutes (cached after); returns status 'running' until ready."),
      "inputSchema": {"type": "object",
                      "properties": {"source": _STR, "target": _STR, "language": _STR,
-                                    "offset": {"type": "integer"}},
+                                    "offset": {"type": "integer"}, "limit": {"type": "integer"},
+                                    "source_ref_prefix": _STR, "target_ref_prefix": _STR,
+                                    "min_score": {"type": "number"}},
                      "required": ["source", "target", "language"]},
      "fn": _t_fusion_search},
     {"name": "cross_language",


### PR DESCRIPTION
## Why (from a live MCP research session)
Asking 'parallels between Eclogue 1 and Georgics 1' on a whole-work fusion (count 5000, but only the top 100 returned) forced client-side filtering of the top 100 by source ref — only 16 of 100 had an Eclogue-1 source, and pairs ranked 101–5000 were invisible. Any per-section question filtered from the top-N is biased that way. `offset` paging (shipped earlier today) helps but still means walking 50 pages.

## Fix — filter the FULL result set before the cap
On `GET /api/fusion-search` (cached-complete return), applied over all `max_results` before slicing:
- **source_ref_prefix / target_ref_prefix** — match anywhere in the (author-abbreviated) ref; a trailing dot pins the number, e.g. `source_ref_prefix="ecl. 1."` matches `verg. ecl. 1.x` but not `...10.x`. Answers single-poem/section questions natively and cheaply.
- **min_score** — drop weak matches.
- **limit** — page size (default 100, capped at 500).

Response now returns `count` (after filters) and `total` (before). All four exposed on the MCP `fusion_search` tool schema + description.

Compute path is untouched — filtering is pure Python on the already-cached, pre-sorted results. Unit-tested the match semantics (case-insensitivity + trailing-dot precision). Will verify live on a cached pair post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)