### PR TITLE
Exact line-search: whole-word matching (fix 'quot annis' matching 'aliquot')

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -65,7 +65,7 @@ from backend.matcher import Matcher
 from backend.scorer import Scorer
 from backend.utils import (
     get_text_metadata, build_text_hierarchy, clean_cts_reference, resolve_text_path,
-    apply_text_list_filters
+    apply_text_list_filters, exact_phrase_pattern
 )
 from backend.cache import (
     get_cached_results, save_cached_results, 
@@ -1816,6 +1816,8 @@ def line_search():
             
             else:
                 # SLOW PATH: Fallback to file scanning (for exact/regex search)
+                # Compile the exact-phrase pattern once (whole-word-start matching).
+                exact_pattern = exact_phrase_pattern(query) if search_type == 'exact' else None
                 text_files = [f for f in os.listdir(lang_dir) if f.endswith('.tess')]
                 
                 for filename in text_files:
@@ -1861,7 +1863,9 @@ def line_search():
                             
                             match_found = False
                             if search_type == 'exact':
-                                if query.lower() in text.lower():
+                                # Whole-word-start match (see _exact_phrase_pattern):
+                                # excludes substring hits like "quot" inside "aliquot".
+                                if exact_pattern and exact_pattern.search(text):
                                     match_found = True
                             elif search_type == 'regex':
                                 try:
@@ -1894,6 +1898,16 @@ def line_search():
                                         if shared_lemmas:
                                             matched_words.append(word)
                                             matched_lemmas.update(shared_lemmas)
+                                elif search_type == 'exact':
+                                    # Highlight query words present as whole-word starts
+                                    # (consistent with the match test above).
+                                    for word in query.split():
+                                        wl = word.lower()
+                                        if wl in stopwords:
+                                            continue
+                                        if re.search(r'\b' + re.escape(word), text, re.IGNORECASE):
+                                            matched_words.append(wl)
+                                            matched_lemmas.add(wl)
                                 else:
                                     for word in query.lower().split():
                                         if word in text.lower() and word not in stopwords:

--- a/backend/blueprints/mcp_http.py
+++ b/backend/blueprints/mcp_http.py
@@ -137,9 +137,15 @@ def _fusion_poll(params, budget):
         d = _get('/fusion-search', params)
         status = d.get('status')
         if status == 'complete':
-            return {'status': 'complete', 'count': d.get('count'),
-                    'showing': d.get('showing'), 'offset': d.get('offset', 0),
-                    'parallels': d.get('parallels')}
+            out = {'status': 'complete', 'count': d.get('count'),
+                   'showing': d.get('showing'), 'offset': d.get('offset', 0),
+                   'parallels': d.get('parallels')}
+            # Surface filter context when present (count is after filters; total is
+            # the full result set before them).
+            for k in ('total', 'limit', 'filters'):
+                if d.get(k) is not None and d.get(k) != {}:
+                    out[k] = d.get(k)
+            return out
         if status == 'error':
             return {'status': 'error', 'error': d.get('error')}
         # Return before starting a sleep that would push us past the budget, so

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -9,6 +9,24 @@ import unicodedata
 
 logger = logging.getLogger(__name__)
 
+
+def exact_phrase_pattern(query):
+    """Compile the regex for an *exact* line-search phrase.
+
+    Each query word must START at a word boundary, so a query word is not matched
+    inside a longer word: "quot annis" no longer matches "ali-quot annis". Words
+    are joined by whitespace. There is deliberately NO trailing boundary, so a
+    final word may carry a Latin enclitic — "arma virum" still matches "arma
+    virum-que cano" (the canonical arma-virum reference match). Unicode-aware
+    (\\b/\\w cover Greek and Coptic). Returns a compiled case-insensitive pattern,
+    or None for an empty query.
+    """
+    words = (query or '').split()
+    if not words:
+        return None
+    return re.compile(r'\s+'.join(r'\b' + re.escape(w) for w in words), re.IGNORECASE)
+
+
 OVERRIDES_PATH = os.path.join(os.path.dirname(__file__), 'text_metadata_overrides.json')
 PROVENANCE_PATH = os.path.join(os.path.dirname(__file__), 'text_provenance.json')
 

--- a/tests/test_exact_phrase.py
+++ b/tests/test_exact_phrase.py
@@ -1,0 +1,37 @@
+"""Exact-phrase line-search matching (backend.utils.exact_phrase_pattern).
+
+Guards the whole-word-START semantics: a query word must begin at a word
+boundary (so it is not matched inside a longer word), but a trailing enclitic is
+allowed (so "arma virum" still matches "arma virumque", the canonical arma-virum
+reference match). Pure-regex; no app import.
+"""
+from backend.utils import exact_phrase_pattern
+
+
+def _matches(query, text):
+    p = exact_phrase_pattern(query)
+    return bool(p and p.search(text))
+
+
+def test_enclitic_is_kept_arma_virumque():
+    # Reference test depends on this: exact "arma virum" must hit "arma virumque cano".
+    assert _matches("arma virum", "arma virumque cano Troiae qui primus ab oris")
+    assert _matches("arma virum", "arma virum tabulaeque et Troia gaza per undas")
+
+
+def test_substring_inside_longer_word_is_excluded_aliquot():
+    # The reported bug: "quot annis" must NOT match "aliquot annis".
+    assert not _matches("quot annis", "his aliquot annis continuis fuit")
+    # ...but the genuine phrase is kept.
+    assert _matches("quot annis", "belloque superbum quot annis populum")
+
+
+def test_leading_boundary_blocks_midword_and_run_together():
+    assert not _matches("arma virum", "clamarma virumbus")   # mid-word junk
+    assert not _matches("quot annis", "quotannis frumentum")  # run-together = different word
+
+
+def test_case_insensitive_and_empty():
+    assert _matches("arma virum", "ARMA VIRUMQUE")
+    assert exact_phrase_pattern("") is None
+    assert exact_phrase_pattern("   ") is None


### PR DESCRIPTION
## Why (from the live MCP session)
Exact line-search matched the query as a raw **substring**, so `quot annis` matched inside `ali-quot annis` — Cicero (10) and Livy (8) prose flooded 43 results, most false. The agent workflow leans on this corpus-uniqueness count for every rarity claim, so it was silently overcounting.

## Fix — whole-word-START matching
`exact_phrase_pattern(query)` (new, in `backend/utils.py`): each query word must **start** at a word boundary, joined by whitespace. Deliberately **no trailing boundary**, so a final word may carry a Latin enclitic — `arma virum` still matches `arma virumque cano`.

This is the crucial subtlety: pure whole-word-on-both-sides would have **broken the canonical arma-virum reference test** (which must match `arma virumque`, virum + -que). Leading-boundary-only excludes `aliquot` while preserving `virumque`.

Also fixes the matched-word highlight extraction the same way. **Regex mode is unchanged.**

## Tests
- `tests/test_exact_phrase.py` (CI, pure-regex, no app import): aliquot excluded, virumque kept, mid-word/run-together excluded, case-insensitive.
- Will run the live arma-virum reference test (must return Ovid/Quintilian/Seneca/Vergil-incl-virumque) + confirm `quot annis` drops the aliquot false positives, post-deploy.

## Also
Issue-1 polish: MCP `_fusion_poll` passes through `total`/`limit`/`filters` so the agent sees before-filter total alongside after-filter count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)