### PR TITLE
Line-search dedup: also collapse suffixed .part.N.<name>.tess parts

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1976,7 +1976,7 @@ def line_search():
             import re as _re_dl
 
             def _base_tid(tid):
-                return _re_dl.sub(r'\.part\.\d+\.tess$', '.tess', tid) if tid else tid
+                return _re_dl.sub(r'\.part\.\d+.*\.tess$', '.tess', tid) if tid else tid
 
             _pos = {}
             _deduped = []

--- a/backend/blueprints/hapax.py
+++ b/backend/blueprints/hapax.py
@@ -1959,8 +1959,8 @@ def _compute_rare_words(source_id, target_id, language, source_language, target_
                    if 1 <= doc_freqs.get(l, 0) <= max_occ}
 
     import re
-    source_base = re.sub(r'\.part\.\d+\.tess$', '.tess', source_id)
-    target_base = re.sub(r'\.part\.\d+\.tess$', '.tess', target_id)
+    source_base = re.sub(r'\.part\.\d+.*\.tess$', '.tess', source_id)
+    target_base = re.sub(r'\.part\.\d+.*\.tess$', '.tess', target_id)
     source_is_full = '.part.' not in source_id
     target_is_full = '.part.' not in target_id
 
@@ -1969,7 +1969,7 @@ def _compute_rare_words(source_id, target_id, language, source_language, target_
             return True
         if '.part.' in source_id and loc_id == source_base:
             return True
-        if source_is_full and re.sub(r'\.part\.\d+\.tess$', '.tess', loc_id) == source_id:
+        if source_is_full and re.sub(r'\.part\.\d+.*\.tess$', '.tess', loc_id) == source_id:
             return True
         return False
 
@@ -1978,7 +1978,7 @@ def _compute_rare_words(source_id, target_id, language, source_language, target_
             return True
         if '.part.' in target_id and loc_id == target_base:
             return True
-        if target_is_full and re.sub(r'\.part\.\d+\.tess$', '.tess', loc_id) == target_id:
+        if target_is_full and re.sub(r'\.part\.\d+.*\.tess$', '.tess', loc_id) == target_id:
             return True
         return False
 


### PR DESCRIPTION
Discovered while verifying the arma-virum results after the part ingestion: the whole/part dedup regex `\.part\.\d+\.tess$` required `.tess` right after the part number, so it **missed 145 part files across 15 works** whose parts carry a range/name after the number — Livy, Pliny NH, Gellius, Cicero *Epistulae*, Ovid *Heroides*, Historia Augusta, Seneca epistulae, Augustine, `jerome.vulgate`, etc. (e.g. `seneca.ad_lucilium_epistulae_morales.part.12.111-120.tess`). Those still **double-counted** in line-search uniqueness — visible in arma-virum, where Seneca 113.25 appeared as both the whole and its part.

**Fix:** broaden to `\.part\.\d+.*\.tess$` at all 5 sites (app.py line-search dedup; hapax whole-source location matcher). This matches the SQL doc-freq base expression (`instr(fn,'.part.')`), which already collapsed these correctly — so **rarity/doc-freq was never affected**; only the Python line-search dedup and hapax whole-source matcher had the gap.

Verified: regex unit cases pass. Post-deploy I'll confirm arma-virum Seneca collapses to one row and the reference authors remain present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)