### PR TITLE
Precompute per-lemma document frequency (rare-word search 34s → 0.02s)

### DIFF
--- a/backend/blueprints/hapax.py
+++ b/backend/blueprints/hapax.py
@@ -1087,6 +1087,31 @@ def get_document_frequency(lemma, language):
         return 0
 
 
+_lemma_doc_freq_available = {}  # language -> bool (does the index have the precomputed table?)
+
+
+def _has_lemma_doc_freq(conn, language):
+    """Return True when the index DB has the precomputed lemma_doc_freq table.
+
+    Memoized per language. The table maps each stored lemma form to the number
+    of distinct base works containing it (parts collapsed to their whole work,
+    matching _base_filename_expr). When present it replaces the per-lemma
+    COUNT(DISTINCT ...) scan over the full postings table — an indexed seek
+    instead of a 17M-row aggregation.
+    """
+    if language in _lemma_doc_freq_available:
+        return _lemma_doc_freq_available[language]
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='lemma_doc_freq'"
+        ).fetchone()
+        available = row is not None
+    except Exception:
+        available = False
+    _lemma_doc_freq_available[language] = available
+    return available
+
+
 def get_document_frequencies_batch(lemmas, language):
     """Get document frequencies for a batch of lemmas efficiently.
     Returns dict mapping lemma -> number of texts containing it."""
@@ -1097,6 +1122,13 @@ def get_document_frequencies_batch(lemmas, language):
     try:
         cursor = conn.cursor()
         result = {}
+
+        # Fast path: read from the precomputed per-lemma document-frequency
+        # table when the index has it. Falls back to the live COUNT(DISTINCT)
+        # aggregation for indexes built before the table existed (grc/en/cop
+        # until rebuilt), so results are identical either way.
+        use_precomputed = _has_lemma_doc_freq(conn, language)
+        base_expr = _base_filename_expr('t')
 
         # Process in batches to avoid huge SQL queries
         lemma_list = list(lemmas)
@@ -1116,15 +1148,22 @@ def get_document_frequencies_batch(lemmas, language):
 
             all_variants = list(expanded_map.keys())
             placeholders = ','.join(['?' for _ in all_variants])
-            base_expr = _base_filename_expr('t')
-            cursor.execute(
-                f'SELECT p.lemma, COUNT(DISTINCT {base_expr}) '  # nosec B608
-                f'FROM postings p JOIN texts t ON p.text_id = t.text_id '
-                f'WHERE p.lemma IN ({placeholders}) GROUP BY p.lemma',
-                all_variants
-            )
+            if use_precomputed:
+                cursor.execute(
+                    f'SELECT lemma, df FROM lemma_doc_freq '  # nosec B608
+                    f'WHERE lemma IN ({placeholders})',
+                    all_variants
+                )
+            else:
+                cursor.execute(
+                    f'SELECT p.lemma, COUNT(DISTINCT {base_expr}) '  # nosec B608
+                    f'FROM postings p JOIN texts t ON p.text_id = t.text_id '
+                    f'WHERE p.lemma IN ({placeholders}) GROUP BY p.lemma',
+                    all_variants
+                )
 
-            # Aggregate counts back to original lemma
+            # Aggregate counts back to original lemma (sums u/v variant forms,
+            # matching the pre-existing behavior for both paths)
             for row_lemma, count in cursor.fetchall():
                 original = expanded_map.get(row_lemma, row_lemma)
                 result[original] = result.get(original, 0) + count

--- a/scripts/build_inverted_index.py
+++ b/scripts/build_inverted_index.py
@@ -142,6 +142,36 @@ def get_text_files(language):
         return []
     return [f for f in os.listdir(lang_dir) if f.endswith('.tess')]
 
+def build_lemma_doc_freq(conn, verbose=True):
+    """(Re)build the lemma_doc_freq table: lemma -> number of distinct base
+    works containing it.
+
+    Part files (e.g. homer.iliad.part.1.tess) collapse to their base work
+    (homer.iliad.tess) so a word in one partitioned work counts once, matching
+    the runtime _base_filename_expr in backend/blueprints/hapax.py. Read by
+    get_document_frequencies_batch(); safe to regenerate at any time.
+    """
+    base = ("CASE WHEN instr(t.filename,'.part.')>0 "
+            "THEN substr(t.filename,1,instr(t.filename,'.part.')-1)||'.tess' "
+            "ELSE t.filename END")
+    cur = conn.cursor()
+    if verbose:
+        print("  Building lemma_doc_freq (per-lemma document frequency)...", flush=True)
+    t0 = time.time()
+    cur.execute('DROP TABLE IF EXISTS lemma_doc_freq')
+    cur.execute('CREATE TABLE lemma_doc_freq (lemma TEXT PRIMARY KEY, df INTEGER)')
+    cur.execute(
+        f'INSERT INTO lemma_doc_freq (lemma, df) '  # nosec B608
+        f'SELECT p.lemma, COUNT(DISTINCT {base}) '
+        f'FROM postings p JOIN texts t ON p.text_id = t.text_id '
+        f'GROUP BY p.lemma'
+    )
+    conn.commit()
+    if verbose:
+        n = cur.execute('SELECT COUNT(*) FROM lemma_doc_freq').fetchone()[0]
+        print(f"  lemma_doc_freq: {n} lemmas in {time.time()-t0:.1f}s", flush=True)
+
+
 def build_index(language, text_processor, verbose=True, resume=True, force=False,
                 use_syntax_db=False, fast_mode=False):
     """Build inverted index for a language.
@@ -370,10 +400,17 @@ def build_index(language, text_processor, verbose=True, resume=True, force=False
             print(f"  [{i+1}/{remaining}] {filename} — {file_lines} lines, {file_postings} postings ({file_elapsed:.1f}s) | Total: {total_lines} lines, {total_elapsed:.0f}s elapsed", flush=True)
     
     conn.commit()
-    
+
+    # Precompute per-lemma document frequency so rare-word / rarity lookups
+    # (backend/blueprints/hapax.py get_document_frequencies_batch) become an
+    # indexed seek instead of a COUNT(DISTINCT) scan over the whole postings
+    # table. df collapses part files to their base work, matching the runtime
+    # _base_filename_expr.
+    build_lemma_doc_freq(conn, verbose=verbose)
+
     cursor.execute('SELECT COUNT(DISTINCT lemma) FROM postings')
     unique_lemmas = cursor.fetchone()[0]
-    
+
     conn.close()
     
     file_size = os.path.getsize(db_path) / (1024 * 1024)

--- a/tests/test_doc_freq_fast_path.py
+++ b/tests/test_doc_freq_fast_path.py
@@ -1,0 +1,64 @@
+"""The precomputed lemma_doc_freq fast path must return exactly what the live
+COUNT(DISTINCT) fallback returns — including part->base-work collapse and u/v
+variant summing."""
+import sqlite3
+import pytest
+import backend.blueprints.hapax as hx
+
+
+def _make_index():
+    """Tiny in-memory index: an Aeneid (whole + one part), Bellum Civile, Metamorphoses."""
+    conn = sqlite3.connect(':memory:')
+    conn.executescript(
+        """
+        CREATE TABLE texts (text_id INTEGER PRIMARY KEY, filename TEXT UNIQUE);
+        CREATE TABLE postings (lemma TEXT, text_id INTEGER, ref TEXT, positions TEXT);
+        INSERT INTO texts VALUES
+            (1,'vergil.aeneid.tess'),
+            (2,'vergil.aeneid.part.1.tess'),
+            (3,'lucan.bellum_civile.tess'),
+            (4,'ovid.metamorphoses.tess');
+        -- 'arma' in Aeneid (whole+part, collapses to 1 work) and Bellum Civile -> df 2
+        INSERT INTO postings VALUES ('arma',1,'1.1','[]'),('arma',2,'1.1','[]'),('arma',3,'1.1','[]');
+        -- 'rara' only in Metamorphoses -> df 1
+        INSERT INTO postings VALUES ('rara',4,'1.1','[]');
+        -- 'uirtus' (u-form, as index stores it) in Aeneid and Metamorphoses -> df 2
+        INSERT INTO postings VALUES ('uirtus',1,'1.1','[]'),('uirtus',4,'1.1','[]');
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def _add_precomputed(conn):
+    base = ("CASE WHEN instr(t.filename,'.part.')>0 "
+            "THEN substr(t.filename,1,instr(t.filename,'.part.')-1)||'.tess' "
+            "ELSE t.filename END")
+    conn.execute('CREATE TABLE lemma_doc_freq (lemma TEXT PRIMARY KEY, df INTEGER)')
+    conn.execute(
+        f'INSERT INTO lemma_doc_freq (lemma, df) '
+        f'SELECT p.lemma, COUNT(DISTINCT {base}) '
+        f'FROM postings p JOIN texts t ON p.text_id=t.text_id GROUP BY p.lemma')
+    conn.commit()
+
+
+def _run(monkeypatch, conn):
+    monkeypatch.setattr(hx, 'get_connection', lambda language: conn)
+    hx._lemma_doc_freq_available = {}  # reset memoization
+    # query 'virtus' too: v-variant of stored 'uirtus', must sum to the same df
+    return hx.get_document_frequencies_batch({'arma', 'rara', 'virtus'}, 'la')
+
+
+def test_fallback_values(monkeypatch):
+    conn = _make_index()  # no lemma_doc_freq table -> fallback path
+    out = _run(monkeypatch, conn)
+    assert out == {'arma': 2, 'rara': 1, 'virtus': 2}
+
+
+def test_fast_path_matches_fallback(monkeypatch):
+    conn = _make_index()
+    _add_precomputed(conn)  # now the fast path is used
+    hx._lemma_doc_freq_available = {}  # fresh check (new process/connection would too)
+    assert hx._has_lemma_doc_freq(conn, 'la') is True
+    out = _run(monkeypatch, conn)
+    assert out == {'arma': 2, 'rara': 1, 'virtus': 2}


### PR DESCRIPTION
**Follow-up to #234.** After routing rare-word/rare-pair searches through the cached lemma loader, profiling showed the remaining time was **not** lemmatization or the location scan (2s) — it was `get_document_frequencies_batch`: **34s**.

**Why:** it ran `COUNT(DISTINCT CASE WHEN instr(filename,'.part.')...)` per shared lemma over the 17.3M-row postings table. That computed expression can't use an index, so every rare-word search (and fusion's cold-cache rarity scoring, which reuses this function) paid a full-table aggregation.

**Fix:** a precomputed `lemma_doc_freq` table (lemma → distinct base-work count, parts collapsed to their whole work exactly like the runtime `_base_filename_expr`). The batch function does an **indexed IN-seek** when the table is present and **falls back** to the live `COUNT(DISTINCT)` when absent — so grc/en/cop indexes (and any pre-table index) keep working with identical results until rebuilt. `build_inverted_index.py` now regenerates the table on every build.

**Proof:** for the 3,110 shared lemmas of Aeneid × Bellum Civile, the fast path returns **byte-identical** doc frequencies (0 mismatches) in **0.021s vs 34.5s — 1,621×**. New unit test covers fast-path == fallback, part→base collapse, and u/v summing. arma-virum regression unchanged.

The prod Latin index already has the table built (verified); this PR is the code that reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)