### PR TITLE
Connector: corpus-context-on-every-entry contract + line_search count_only / cap / author-dedup

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1598,6 +1598,33 @@ def add_text():
 # These routes enable searching for words/phrases across the entire corpus
 # using the pre-built inverted index for fast lookups.
 
+def _dedup_same_passage(results):
+    """Collapse the SAME passage duplicated across text_ids that vary only by
+    author/work naming — e.g. cyprian.ad_demetrianum vs cyprian_saint.ad_demetrianum
+    (both locus 23), or arnobius.adversus_nationes vs
+    arnobius_of_sicca.adversus_nationes_libri_vii (both 2.59). The whole/part
+    text_id dedup misses these because the ids differ.
+
+    Key on (locus, normalized line text): two rows sharing BOTH the exact locus
+    label and the exact line are the same passage under a variant spelling.
+    Conservative by construction — a repeated refrain has one text but different
+    loci (kept), and edition spelling variants differ in text (kept), so this only
+    removes genuine duplicate-text inflation, never distinct loci. Rows with empty
+    text are always kept (can't confirm they are duplicates). Order preserved.
+    """
+    seen = set()
+    out = []
+    for r in results:
+        nt = ' '.join((r.get('text') or '').lower().split())
+        key = (r.get('locus'), nt)
+        if nt and key in seen:
+            continue
+        if nt:
+            seen.add(key)
+        out.append(r)
+    return out
+
+
 @api_route('/line-search', methods=['GET', 'POST'])
 def line_search():
     """
@@ -1627,6 +1654,14 @@ def line_search():
             max_results = 500
         if max_results <= 0:
             max_results = 500
+
+        # count_only: return just the deduped corpus counts (total / distinct_loci
+        # / capped) and skip the results payload. Quantifying a "commonplace" for
+        # the per-entry corpus-context rule then costs a tiny response instead of
+        # hundreds of passages. Accept truthy strings on GET.
+        count_only = data.get('count_only', False)
+        if isinstance(count_only, str):
+            count_only = count_only.strip().lower() in ('1', 'true', 'yes', 'on')
 
         # Source exclusion - don't include the source line in results
         exclude_text_id = data.get('exclude_text_id', '')
@@ -1966,6 +2001,13 @@ def line_search():
             ))
             
             search_time = round(time_module.time() - search_start_time, 3)
+
+            # Whether the corpus scan hit the result cap. When it did, `total`
+            # is a floor, not an exact count — callers should report "N+" rather
+            # than a false precise number. (The build loop breaks as soon as
+            # len(results) reaches max_results.)
+            capped = len(results) >= max_results
+
             # Collapse the corpus's whole-work vs .part.N duplication: e.g.
             # vergil.eclogues.tess and vergil.eclogues.part.1.tess both report
             # Eclogues 1.43, so an undeduped list double-counts the same line and
@@ -1991,14 +2033,25 @@ def line_search():
                     if '.part.' in (_deduped[idx].get('text_id') or '') and '.part.' not in (r.get('text_id') or ''):
                         _deduped[idx] = r
             results = _deduped
+
+            # Second pass: collapse the SAME passage duplicated across text_ids
+            # that vary only by author/work naming (see _dedup_same_passage).
+            results = _dedup_same_passage(results)
+
             distinct_loci = len(results)
-            return jsonify({
-                'results': results,
-                'total': len(results),
+            payload = {
+                'total': distinct_loci,
                 'distinct_loci': distinct_loci,
                 'query': query,
-                'search_time': search_time
-            })
+                'search_time': search_time,
+                'capped': capped,
+            }
+            if capped:
+                # `total`/`distinct_loci` are a lower bound under the cap.
+                payload['total_at_least'] = distinct_loci
+            if not count_only:
+                payload['results'] = results
+            return jsonify(payload)
         
         elif line_text or data.get('source_text_id'):
             pass

--- a/backend/blueprints/mcp_http.py
+++ b/backend/blueprints/mcp_http.py
@@ -84,14 +84,22 @@ def _t_list_texts(a):
 
 
 def _t_line_search(a):
+    count_only = bool(a.get('count_only'))
     d = _post('/line-search', {'query': a.get('query', ''),
                                'language': a.get('language', 'la'),
-                               'search_type': a.get('search_type', 'lemma')})
-    return {'query': a.get('query'), 'total': d.get('total'),
-            'results': [{'locus': r.get('locus'), 'author': r.get('author'),
-                         'work': r.get('work'), 'text': r.get('text'),
-                         'matched_words': r.get('matched_words')}
-                        for r in (d.get('results') or [])[:40]]}
+                               'search_type': a.get('search_type', 'lemma'),
+                               'count_only': count_only})
+    out = {'query': a.get('query'), 'total': d.get('total'),
+           'distinct_loci': d.get('distinct_loci'), 'capped': d.get('capped')}
+    # When the corpus scan hit the cap, `total` is a floor — report "N+".
+    if d.get('capped'):
+        out['total_at_least'] = d.get('total_at_least', d.get('total'))
+    if not count_only:
+        out['results'] = [{'locus': r.get('locus'), 'author': r.get('author'),
+                           'work': r.get('work'), 'text': r.get('text'),
+                           'matched_words': r.get('matched_words')}
+                          for r in (d.get('results') or [])[:40]]
+    return out
 
 
 def _t_string_search(a):
@@ -301,12 +309,19 @@ def _t_compare_texts(a):
         "same passage pair, say so and rank it HIGHER (a fusion parallel carries an also_found_by field "
         "when it coincides with a rare hit; otherwise match by ref) — convergence of independent methods "
         "is itself evidence. "
-        "Fold each parallel's corpus context INLINE with its entry, not in a separate methods section: "
-        "run line_search on its shared words for how distinctive it is corpus-wide (use distinct_loci / "
-        "deduped counts) with a one-line characterization; do this for at least the top handful and any "
-        "entry resting on a rarity claim, before presenting. When a rare-phrase/rare-word rarity metric "
-        "and the line_search corpus check disagree, TRUST the line_search check — it is the direct "
-        "corpus evidence (the percentile can overstate distinctiveness). "
+        "Fold each parallel's corpus context INLINE with its entry, not in a separate methods section. "
+        "EVERY presented entry carries its corpus-wide context inline, in two proportionate tiers. "
+        "(a) Every entry states the corpus count for its shared material: line_search on the shared "
+        "lemmas (use count_only:true — it returns just the deduped count cheaply), or the rare-word "
+        "corpus_count where that is the entry's basis. (b) When that count is small enough to mean "
+        "something (roughly under 40), also characterize the distribution in one line — who else, which "
+        "era, verbatim quotation vs independent use — fetching the full line_search results (dedup "
+        "applied) for that entry. Above ~40 the number plus the word 'commonplace' suffices, and the "
+        "entry's interest then rests on placement or theme, so say so. If a count cannot be retrieved, "
+        "the entry says 'unquantified' rather than silently omitting it. If line_search reports "
+        "capped:true, report the count as 'N+' (it is a floor, not exact). When a rare-phrase/rare-word "
+        "rarity metric and the line_search corpus check disagree, TRUST the line_search check — it is "
+        "the direct corpus evidence (the percentile can overstate distinctiveness). "
         "Present ~25 entries, then ASK whether to continue, re-sort (fusion score / rarity / order in "
         "either text / channel_count), filter (a ref range via source_ref_prefix), or search other "
         "lines. Small sets (<10) need no batching. "
@@ -372,9 +387,10 @@ TOOLS = [
                      "required": ["language"]},
      "fn": _t_list_texts},
     {"name": "line_search",
-     "description": "Find corpus lines sharing words with a phrase (corpus-wide). The uniqueness check: few results (total) means distinctive wording. Counts collapse whole-work vs per-book/poem duplicates of the same line, so total is a true distinct-loci count. search_type: 'lemma' (default) matches lines that share 2+ of the query's LEMMAS anywhere on the line — use this for words that co-occur but are NOT adjacent (e.g. 'Scythiam arces', 'lolium avenae'); 'exact' matches the query as an ADJACENT whole-word phrase (stopwords included literally, so 'ad Scythiam' matches only that contiguous phrase; a Latin enclitic on the final word is allowed, so 'arma virum' hits 'arma virumque') — for non-adjacent words use lemma; 'regex'.",
+     "description": "Find corpus lines sharing words with a phrase (corpus-wide). The uniqueness check: few results (total) means distinctive wording. Counts collapse whole-work vs per-book/poem duplicates of the same line, AND same-passage duplicates that differ only by author/work spelling (e.g. cyprian vs cyprian_saint), so total is a true distinct-loci count. Set count_only:true to get just the counts (total, distinct_loci, capped) with no results payload — use this to quantify a commonplace cheaply; fetch full results only when the count is small enough to characterize. `capped` is true when the scan hit the result cap (default 500): then `total` is a floor and `total_at_least` is returned — report it as \"N+\", not a precise count. search_type: 'lemma' (default) matches lines that share 2+ of the query's LEMMAS anywhere on the line — use this for words that co-occur but are NOT adjacent (e.g. 'Scythiam arces', 'lolium avenae'); 'exact' matches the query as an ADJACENT whole-word phrase (stopwords included literally, so 'ad Scythiam' matches only that contiguous phrase; a Latin enclitic on the final word is allowed, so 'arma virum' hits 'arma virumque') — for non-adjacent words use lemma; 'regex'.",
      "inputSchema": {"type": "object",
-                     "properties": {"query": _STR, "language": _STR, "search_type": _STR},
+                     "properties": {"query": _STR, "language": _STR, "search_type": _STR,
+                                    "count_only": {"type": "boolean"}},
                      "required": ["query", "language"]},
      "fn": _t_line_search},
     {"name": "string_search",

--- a/tests/test_line_search_dedup.py
+++ b/tests/test_line_search_dedup.py
@@ -1,0 +1,66 @@
+"""_dedup_same_passage collapses the same passage duplicated across text_ids
+that differ only by author/work spelling, without touching distinct loci."""
+import os
+# Importing backend.app has DB/secret side effects — configure a throwaway env
+# before import, mirroring tests/test_app.py.
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("TESSERAE_DIRECT_SERVER", "1")
+os.environ.setdefault("SESSION_SECRET", "test-secret-key")
+
+from backend.app import _dedup_same_passage  # noqa: E402
+
+
+def test_collapses_author_variant_duplicate():
+    # cyprian vs cyprian_saint at the same locus with the same line = one passage.
+    rows = [
+        {'author': 'Vergil', 'text_id': 'vergil.georgics.tess', 'locus': '1.154',
+         'text': 'infelix lolium et steriles dominantur avenae'},
+        {'author': 'Cyprian Saint', 'text_id': 'cyprian_saint.ad_demetrianum.tess',
+         'locus': '23', 'text': 'lolium et avena'},
+        {'author': 'Cyprian', 'text_id': 'cyprian.ad_demetrianum.tess',
+         'locus': '23', 'text': 'lolium et avena'},
+        {'author': 'Arnobius Of Sicca',
+         'text_id': 'arnobius_of_sicca.adversus_nationes_libri_vii.tess',
+         'locus': '2.59', 'text': 'inter lolium et avenam'},
+        {'author': 'Arnobius', 'text_id': 'arnobius.adversus_nationes.tess',
+         'locus': '2.59', 'text': 'inter lolium et avenam'},
+    ]
+    out = _dedup_same_passage(rows)
+    assert len(out) == 3  # Vergil + one Cyprian + one Arnobius
+    # the first occurrence is kept as representative
+    assert out[1]['author'] == 'Cyprian Saint'
+    assert out[2]['author'] == 'Arnobius Of Sicca'
+
+
+def test_keeps_same_text_at_different_loci():
+    # A repeated refrain: identical text, different loci -> both kept.
+    rows = [
+        {'text_id': 'x.tess', 'locus': '1.1', 'text': 'io triumphe'},
+        {'text_id': 'x.tess', 'locus': '5.9', 'text': 'io triumphe'},
+    ]
+    assert len(_dedup_same_passage(rows)) == 2
+
+
+def test_keeps_same_locus_different_text():
+    # Same locus label in different works but different lines -> both kept.
+    rows = [
+        {'text_id': 'a.tess', 'locus': '1.1', 'text': 'arma virumque cano'},
+        {'text_id': 'b.tess', 'locus': '1.1', 'text': 'in nova fert animus'},
+    ]
+    assert len(_dedup_same_passage(rows)) == 2
+
+
+def test_empty_text_rows_always_kept():
+    rows = [
+        {'text_id': 'a.tess', 'locus': '1', 'text': ''},
+        {'text_id': 'b.tess', 'locus': '1', 'text': ''},
+    ]
+    assert len(_dedup_same_passage(rows)) == 2
+
+
+def test_whitespace_and_case_normalized():
+    rows = [
+        {'text_id': 'a.tess', 'locus': '3', 'text': 'Lolium  et   avena'},
+        {'text_id': 'b.tess', 'locus': '3', 'text': 'lolium et avena'},
+    ]
+    assert len(_dedup_same_passage(rows)) == 1

--- a/tests/test_line_search_dedup.py
+++ b/tests/test_line_search_dedup.py
@@ -1,11 +1,14 @@
 """_dedup_same_passage collapses the same passage duplicated across text_ids
 that differ only by author/work spelling, without touching distinct loci."""
 import os
-# Importing backend.app has DB/secret side effects — configure a throwaway env
-# before import, mirroring tests/test_app.py.
+# Importing backend.app has DB/secret side effects and captures DEPLOYMENT_ENV
+# into a module global at import time. Set the same env other suites expect
+# BEFORE importing, so whichever test module imports app first leaves it in the
+# non-dev state test_security_headers.py relies on (HSTS is gated on this global).
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("TESSERAE_DIRECT_SERVER", "1")
 os.environ.setdefault("SESSION_SECRET", "test-secret-key")
+os.environ.setdefault("DEPLOYMENT_ENV", "test")
 
 from backend.app import _dedup_same_passage  # noqa: E402
 


### PR DESCRIPTION
**Restores the owner's original presentation requirement** (the prior note softened it to 'at least the top handful', so an agent following the note presented most entries without corpus context).

### 1. Contract amendment (the note the connector hands the agent)
EVERY presented entry carries its corpus-wide context inline, in two proportionate tiers:
- **(a)** every entry states the **corpus count** for its shared material (line_search on shared lemmas via `count_only`, or rare-word `corpus_count`);
- **(b)** when that count is small enough to matter (**~under 40**) the entry also **characterizes the distribution** in one line (who else, which era, verbatim quotation vs independent use, dedup applied);
- above ~40 the number + **'commonplace'** suffices and the entry says its interest rests on placement/theme.
- A count that can't be retrieved → **'unquantified'** (never silently omitted). A capped count → **'N+'**.

### 2. API support the amended contract needs
- **`count_only` for line_search** — returns just `{total, distinct_loci, capped}`, no results payload. Quantifying a commonplace costs a tiny response instead of hundreds of passages (the toto-orbe check returned ~469 rows to deliver one number). Full results fetched only for the small-count tier.
- **Cap disclosure** — `capped:true` + `total_at_least` when the scan hit the cap (default 500), so agents report **'N+'** not a false exact count (quid+facio returned exactly 500).
- **Author-variant dedup** — `_dedup_same_passage()` collapses the same passage duplicated across text_ids that differ only by author/work spelling (`cyprian` vs `cyprian_saint` @23; `arnobius` vs `arnobius_of_sicca` @2.59), keying on **(locus, normalized line text)**. Conservative: refrains (same text, different loci) and edition variants (different text) are kept. **lolium+avena total 8 → 6.**

Unit-tested the dedup (5 cases). The underlying duplicate **text files** (same work ingested under variant author/work names) are a corpus-audit follow-up; this is the defensive layer.

### Not in this PR
The `cupressum` question: confirmed there is **no ~40 threshold** (connector rare_words uses backend default max_occurrences=50), so its dropout is not an intended cutoff — investigating separately as a possible lemma-grouping shift from the cache restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)