### PR TITLE
line_search: fix single-word misrouting + add corpus_version stamp

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1632,7 +1632,7 @@ def line_search():
     Uses inverted index for fast lookups when available.
     """
     try:
-        from backend.inverted_index import is_index_available, find_co_occurring_lemmas, has_lines_data, get_lines_batch
+        from backend.inverted_index import is_index_available, find_co_occurring_lemmas, has_lines_data, get_lines_batch, get_corpus_version
         from backend.distance_filter import passes_distance_filter, is_prose_text as is_prose_text_unified
         
         # Accept both POST JSON bodies and GET query-string params, so any
@@ -1718,15 +1718,25 @@ def line_search():
             content_lemmas = query_lemmas - stopwords
             filtered_query_lemmas = content_lemmas
             if len(filtered_query_lemmas) < 2:
-                filtered_query_lemmas = query_lemmas  # fallback if too few remain
+                # Restore the common words so the co-occurrence search can still
+                # run — a two-word query whose second word is too common to index
+                # on its own is still a PAIR query, not a single-word one.
+                filtered_query_lemmas = query_lemmas
 
-            # Single-word count_only: line-search finds lines where 2+ words
-            # CO-OCCUR, so a one-content-word query would silently return 0 —
-            # which reads as "vanishingly rare" when it just means "not enough
-            # words to co-occur." Answer the real question instead: how common
-            # the word is across the corpus, via its document frequency (number
-            # of works containing it), from the fast precomputed table.
-            if count_only and len(content_lemmas) < 2:
+            # Words dropped as too-common, named in the response so a reduced
+            # multi-word query is not silently answered as a different question.
+            filtered_common_words = sorted(query_lemmas - content_lemmas)
+            n_query_words = len([w for w in query.split() if w.strip()])
+
+            # Single-word count_only: route here ONLY when the query LITERALLY has
+            # one word. A multi-word query that common-word filtering reduces to a
+            # single content word is still a co-occurrence (pair) query and must
+            # run the pair search with the common word restored — reclassifying it
+            # as single-word silently turned countable pairings like "bis nostra"
+            # (22 places) into a work-count for "bis" (368 works). A one-word query
+            # can't co-occur with anything, so answer how common the word is across
+            # the corpus (document frequency) instead of a silent zero.
+            if count_only and n_query_words <= 1:
                 from backend.blueprints.hapax import get_document_frequencies_batch
                 if content_lemmas:
                     dfs = get_document_frequencies_batch(content_lemmas, language)
@@ -1737,11 +1747,13 @@ def line_search():
                         'unit': 'works',
                         'corpus_document_frequency': df,
                         'total': df,
+                        'corpus_version': get_corpus_version(language),
                         'note': ('single-word query: count is the number of works that contain '
                                  'this word, not co-occurring word pairs'),
                     })
                 return jsonify({
                     'query': query, 'single_word': True, 'total': None, 'unquantified': True,
+                    'corpus_version': get_corpus_version(language),
                     'note': 'query has no content words to count (all stopwords)',
                 })
 
@@ -2071,10 +2083,16 @@ def line_search():
                 'query': query,
                 'search_time': search_time,
                 'capped': capped,
+                'corpus_version': get_corpus_version(language),
             }
             if capped:
                 # `total`/`distinct_loci` are a lower bound under the cap.
                 payload['total_at_least'] = distinct_loci
+            if filtered_common_words:
+                # A common word in the query was too frequent to index on its own;
+                # it WAS still used for co-occurrence. Naming it lets the caller say
+                # the pairing leans on the other word rather than mis-report rarity.
+                payload['filtered_common_words'] = filtered_common_words
             if not count_only:
                 payload['results'] = results
             return jsonify(payload)

--- a/backend/blueprints/mcp_http.py
+++ b/backend/blueprints/mcp_http.py
@@ -90,7 +90,8 @@ def _t_line_search(a):
                                'search_type': a.get('search_type', 'lemma'),
                                'count_only': count_only})
     out = {'query': a.get('query'), 'total': d.get('total'),
-           'distinct_loci': d.get('distinct_loci'), 'capped': d.get('capped')}
+           'distinct_loci': d.get('distinct_loci'), 'capped': d.get('capped'),
+           'corpus_version': d.get('corpus_version')}
     # Single-word query: `total` is a corpus document frequency (number of works
     # containing the word), NOT co-occurring loci. Surface that so it isn't read
     # as a loci count; a null total means all-stopword (unquantified).
@@ -100,6 +101,10 @@ def _t_line_search(a):
         if d.get('unquantified'):
             out['unquantified'] = True
         out['note'] = d.get('note')
+    # A common word in the query was too frequent to index alone but WAS used for
+    # co-occurrence: name it so the pairing isn't mis-reported (the count is real).
+    if d.get('filtered_common_words'):
+        out['filtered_common_words'] = d.get('filtered_common_words')
     # When the corpus scan hit the cap, `total` is a floor — report "N+".
     if d.get('capped'):
         out['total_at_least'] = d.get('total_at_least', d.get('total'))
@@ -346,6 +351,9 @@ def _t_compare_texts(a):
         "it. If line_search reports capped:true the count is a floor: render it as 'at least N places', "
         "never 'N+'. When a rare-phrase/rare-word rarity metric and the line_search corpus check "
         "disagree, TRUST the line_search check — it is the direct corpus evidence. "
+        "These corpus counts shift slightly as the corpus is cleaned, so when the user is recording a "
+        "number for use elsewhere (a paper, a note), quote the corpus_version stamp the response carries "
+        "alongside it ('8 places, corpus version 2026-08-16') so the figure names the state it came from. "
         "NEVER describe results you have not fetched. Do not claim the tail is 'all function words' or "
         "otherwise empty from a few visible entries or from memory of another run — genuine parallels "
         "keep appearing deep into the ranking, into the thousands. The ranking concentrates real "
@@ -421,7 +429,7 @@ TOOLS = [
                      "required": ["language"]},
      "fn": _t_list_texts},
     {"name": "line_search",
-     "description": "Find corpus lines sharing words with a phrase (corpus-wide). The uniqueness check: few results (total) means distinctive wording. Counts collapse whole-work vs per-book/poem duplicates of the same line, AND same-passage duplicates that differ only by author/work spelling (e.g. cyprian vs cyprian_saint), so total is a true distinct-loci count. Set count_only:true to get just the counts (total, distinct_loci, capped) with no results payload — use this to quantify a commonplace cheaply; fetch full results only when the count is small enough to characterize. `capped` is true when the scan hit the result cap (default 500): then `total` is a floor (`total_at_least`) — treat it as 'at least N', not exact. SINGLE-WORD queries: line-search needs 2+ words to CO-OCCUR, so a one-content-word count_only query does NOT return 0 — it returns `single_word:true` with `total` = the number of works that contain the word (a corpus document frequency, `unit:\"works\"`); an all-stopword query returns `unquantified:true` (total null). Report single-word counts as 'appears in N works', not as co-occurring places. search_type: 'lemma' (default) matches lines that share 2+ of the query's LEMMAS anywhere on the line — use this for words that co-occur but are NOT adjacent (e.g. 'Scythiam arces', 'lolium avenae'); 'exact' matches the query as an ADJACENT whole-word phrase (stopwords included literally, so 'ad Scythiam' matches only that contiguous phrase; a Latin enclitic on the final word is allowed, so 'arma virum' hits 'arma virumque') — for non-adjacent words use lemma; 'regex'.",
+     "description": "Find corpus lines sharing words with a phrase (corpus-wide). The uniqueness check: few results (total) means distinctive wording. Counts collapse whole-work vs per-book/poem duplicates of the same line, AND same-passage duplicates that differ only by author/work spelling (e.g. cyprian vs cyprian_saint), so total is a true distinct-loci count. Set count_only:true to get just the counts (total, distinct_loci, capped) with no results payload — use this to quantify a commonplace cheaply; fetch full results only when the count is small enough to characterize. `capped` is true when the scan hit the result cap (default 500): then `total` is a floor (`total_at_least`) — treat it as 'at least N', not exact. SINGLE-WORD queries: a query that LITERALLY has one word can't co-occur with anything, so count_only returns `single_word:true` with `total` = the number of works that contain the word (a corpus document frequency, `unit:\"works\"`) — report as 'appears in N works', not co-occurring places; an all-stopword single word returns `unquantified:true` (total null). A MULTI-word query is always a co-occurrence count even if one word is too common to index alone: it returns the normal pair count plus `filtered_common_words` naming the common word(s) that were down-weighted — the count is real; say the pairing leans on the other word. Every response carries `corpus_version` (a date stamp of the corpus state); when the user is recording a count for use elsewhere, quote it with the number (e.g. '8 places, corpus version 2026-08-16'). search_type: 'lemma' (default) matches lines that share 2+ of the query's LEMMAS anywhere on the line — use this for words that co-occur but are NOT adjacent (e.g. 'Scythiam arces', 'lolium avenae'); 'exact' matches the query as an ADJACENT whole-word phrase (stopwords included literally, so 'ad Scythiam' matches only that contiguous phrase; a Latin enclitic on the final word is allowed, so 'arma virum' hits 'arma virumque') — for non-adjacent words use lemma; 'regex'.",
      "inputSchema": {"type": "object",
                      "properties": {"query": _STR, "language": _STR, "search_type": _STR,
                                     "count_only": {"type": "boolean"}},

--- a/backend/inverted_index.py
+++ b/backend/inverted_index.py
@@ -52,6 +52,39 @@ def is_index_available(language):
     db_path = os.path.join(INDEX_DIR, f'{language}_index.db')
     return os.path.exists(db_path)
 
+_corpus_version = {}
+
+def get_corpus_version(language):
+    """Return the corpus/index version stamp (a date string) for a language, or
+    None if the index has no `meta` table / corpus_version row.
+
+    The stamp names the exact corpus state a count came from, so a figure that
+    shifts as dedup/ingestion/lemmatization improve can still be cited. Bump the
+    `meta.corpus_version` value whenever the corpus changes. Memoized per process
+    (a re-swapped index is picked up on WSGI reload)."""
+    if language in _corpus_version:
+        return _corpus_version[language]
+    v = None
+    conn = get_connection(language)
+    if conn:
+        try:
+            row = conn.execute("SELECT value FROM meta WHERE key='corpus_version'").fetchone()
+            if row is not None:
+                v = row[0]
+        except Exception:
+            v = None
+    _corpus_version[language] = v
+    return v
+
+def set_corpus_version(conn, version):
+    """Stamp an index DB with a corpus_version (idempotent). Call whenever the
+    corpus changes — a full rebuild, a dedup pass, or a lemmatization change.
+    `conn` is an open sqlite3 connection to the index DB."""
+    conn.execute("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)")
+    conn.execute("INSERT INTO meta (key, value) VALUES ('corpus_version', ?) "
+                 "ON CONFLICT(key) DO UPDATE SET value=excluded.value", (version,))
+    conn.commit()
+
 def lookup_lemmas(lemmas, language, fallback_forms=None):
     """
     Look up multiple lemmas and return matching text locations.

--- a/scripts/build_inverted_index.py
+++ b/scripts/build_inverted_index.py
@@ -408,6 +408,17 @@ def build_index(language, text_processor, verbose=True, resume=True, force=False
     # _base_filename_expr.
     build_lemma_doc_freq(conn, verbose=verbose)
 
+    # Stamp the corpus version (build date) so counts drawn from this index can be
+    # cited against a named corpus state. Bump this on any later dedup/lemma change.
+    from datetime import date
+    version = date.today().isoformat()
+    conn.execute("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)")
+    conn.execute("INSERT INTO meta (key, value) VALUES ('corpus_version', ?) "
+                 "ON CONFLICT(key) DO UPDATE SET value=excluded.value", (version,))
+    conn.commit()
+    if verbose:
+        print(f"  corpus_version stamped: {version}", flush=True)
+
     cursor.execute('SELECT COUNT(DISTINCT lemma) FROM postings')
     unique_lemmas = cursor.fetchone()[0]
 

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -93,3 +93,24 @@ def test_line_search_capped_reports_floor(monkeypatch):
     assert out['capped'] is True
     assert out['total_at_least'] == 467
     assert 'results' not in out
+
+
+def test_line_search_multiword_common_word_reported(monkeypatch):
+    """A two-word query reduced by common-word filtering returns the PAIR count
+    plus filtered_common_words (not a single-word work count)."""
+    monkeypatch.setattr(M, '_post', lambda path, body: {
+        'query': 'bis nostra', 'total': 22, 'distinct_loci': 22, 'capped': False,
+        'filtered_common_words': ['noster'], 'corpus_version': '2026-08-16'})
+    out = M._t_line_search({'query': 'bis nostra', 'language': 'la', 'count_only': True})
+    assert out['total'] == 22
+    assert out.get('single_word') is None
+    assert out['filtered_common_words'] == ['noster']
+    assert out['corpus_version'] == '2026-08-16'
+
+
+def test_line_search_carries_corpus_version(monkeypatch):
+    monkeypatch.setattr(M, '_post', lambda path, body: {
+        'query': 'montibus umbrae', 'total': 8, 'distinct_loci': 8, 'capped': False,
+        'corpus_version': '2026-08-16'})
+    out = M._t_line_search({'query': 'montibus umbrae', 'language': 'la', 'count_only': True})
+    assert out['corpus_version'] == '2026-08-16'


### PR DESCRIPTION
**Item 1 (routing regression, priority).** The single-word count_only path classified queries as single-word by **content**-word count (after common-word filtering), so a genuine two-word query whose second word is common — `bis nostra`, `erit semper` — collapsed to one content word and was answered with a **work-count for the surviving word** (`bis` → 368 works) instead of the **co-occurrence pair count** (22 places). That silently degraded the uniqueness check the whole workflow leans on, and possessives / forms of `sum` are exactly the kind of word that carries an echo ("bis sanguine **nostro**").

Fix: route to the single-word path **only when the query literally has one word**. A multi-word query always runs the pair search with the common word restored, and returns `filtered_common_words` naming the down-weighted word(s) so the agent reports honestly ("the pairing leans on bis") instead of mistaking a routing artifact for a property of the texts. Same class as the old silent-zero.

**Item 2 (corpus-version stamp).** Counts shift as the corpus is cleaned (fagus 29→28, avena 37→34, altis montibus 216→205 this week), and a number that moves day to day can't be cited responsibly without naming its state. Adds a `corpus_version` stamp (a `meta` table in the index) on every line_search response; the build script stamps the build date and `set_corpus_version()` bumps it on any later dedup/lemma change. Connector surfaces it; the presentation note tells the agent to quote it when the user records a number ("8 places, corpus version 2026-08-16"). Doubles as a clean cache-invalidation trigger. Live stamp set to **2026-08-16** on prod+dev.

Tests: connector passthrough for both new fields. arma-virum unaffected (no matcher change). Will verify live that `bis nostra` returns the pair count again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
